### PR TITLE
Add coverage config file for local development testing

### DIFF
--- a/vms/.coveragerc
+++ b/vms/.coveragerc
@@ -1,0 +1,10 @@
+# Configuration file for coverage.py
+[run]
+branch = True
+source = vms
+
+[report]
+ignore_errors = True
+
+[html]
+directory = coverage_html_report


### PR DESCRIPTION
The `.coveragerc` file is added for the convenience of developers running coverage locally during development. Relates to #11 