### PR TITLE
Functionality so that a shift cannot be deleted

### DIFF
--- a/vms/shift/services.py
+++ b/vms/shift/services.py
@@ -2,7 +2,10 @@ import datetime
 
 from django.core.exceptions import ObjectDoesNotExist
 
-from organization.services import get_organization_by_name, get_organizations_ordered_by_name
+from organization.services import (
+                            get_organization_by_name,
+                            get_organizations_ordered_by_name
+                            )
 from shift.models import Shift, VolunteerShift
 from volunteer.services import get_volunteer_by_id
 
@@ -73,12 +76,18 @@ def clear_shift_hours(v_id, s_id):
     return result
 
 
-def delete_shift(shift_id):
+def delete_shift(s_id):
+    """
+    Check before deleting:
+    does the shift exist?
+    is a volunteer signed up for the shift?
+    """
 
     result = True
-    shift = get_shift_by_id(shift_id)
+    shift = get_shift_by_id(s_id)
+    num_slots_taken = VolunteerShift.objects.filter(shift_id=s_id).count()
 
-    if shift:
+    if shift and num_slots_taken == 0:
         shift.delete()
     else:
         result = False
@@ -124,9 +133,9 @@ def generate_report(volunteer_shift_list):
         report["logged_start_time"] = volunteer_shift.shift.start_time
         report["logged_end_time"] = volunteer_shift.shift.end_time
         report["duration"] = calculate_duration(
-                                                volunteer_shift.shift.start_time,
-                                                volunteer_shift.shift.end_time
-                                                )
+                        volunteer_shift.shift.start_time,
+                        volunteer_shift.shift.end_time
+                        )
 
         report_list.append(report)
 

--- a/vms/shift/tests.py
+++ b/vms/shift/tests.py
@@ -7,7 +7,24 @@ from django.test import TestCase
 from event.models import Event
 from job.models import Job
 from shift.models import Shift, VolunteerShift
-from shift.services import add_shift_hours, calculate_duration, calculate_total_report_hours, cancel_shift_registration, clear_shift_hours, delete_shift, edit_shift_hours, generate_report, get_administrator_report, get_all_volunteer_shifts_with_hours, get_shift_by_id, get_shifts_by_job_id, get_shifts_ordered_by_date, get_shift_slots_remaining, get_shifts_with_open_slots, get_unlogged_shifts_by_volunteer_id, get_volunteer_report, get_volunteer_shift_by_id, get_volunteer_shifts_with_hours, is_signed_up, register
+from shift.services import (
+            add_shift_hours,
+            calculate_duration,
+            calculate_total_report_hours,
+            cancel_shift_registration,
+            clear_shift_hours, delete_shift,
+            edit_shift_hours, generate_report,
+            get_all_volunteer_shifts_with_hours,
+            get_shift_by_id, get_shifts_by_job_id,
+            get_shifts_ordered_by_date,
+            get_shift_slots_remaining,
+            get_shifts_with_open_slots,
+            get_unlogged_shifts_by_volunteer_id,
+            get_volunteer_shift_by_id,
+            get_volunteer_shifts_with_hours,
+            is_signed_up,
+            register
+            )
 from volunteer.models import Volunteer
 
 
@@ -639,13 +656,25 @@ class ShiftMethodTests(TestCase):
                 job=j1
                 )
 
+        s2 = Shift(
+                date="2011-11-11",
+                start_time="11:00",
+                end_time="12:00",
+                max_volunteers=3,
+                job=j1
+                )
+
         s1.save()
+        s2.save()
 
         self.assertTrue(delete_shift(s1.id))
         self.assertFalse(delete_shift(100))
 
-    def test_edit_shift_hours(self):
+        register(v1.id, s2.id)
+        self.assertFalse(delete_shift(s2.id))
 
+
+    def test_edit_shift_hours(self):
         u1 = User.objects.create_user('Yoshi')
 
         v1 = Volunteer(


### PR DESCRIPTION
Issue https://github.com/systers/vms/issues/65

Add functionality so that a shift cannot be deleted if at least one volunteer is signed up for it or has logged hours for it.

Functions have been supplemented:
- delete_shift in services.py
- test_delete_shift in tests.py