### PR TITLE
Add editorconfig settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,rst,ini}]
+indent_style = space
+indent_size = 4
+
+[*.py]
+line_length=120
+known_first_party=vms
+multi_line_output=3
+default_section=THIRDPARTY
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This PR adds a config file for EditorConfig.  The settings are based on the settings suggested by Danny Greenfeld, author of 2 scoops of django.

Closes #115