### PR TITLE
Enhance UI for creating shifts

### DIFF
--- a/vms/event/services.py
+++ b/vms/event/services.py
@@ -1,16 +1,36 @@
 from django.core.exceptions import ObjectDoesNotExist
 
 from event.models import Event
+from job.models import Job
+from shift.models import Shift
 
 
 def event_not_empty(event_id):
-    """ Check if the event exists and is not empty """
+    """ Checks if the event exists and is not empty """
     result = True
     event = get_event_by_id(event_id)
     if not event:
         result = False
     return result
 
+
+def get_event_by_shift_id(shift_id):
+    """
+    Returns an event for the shift. Can be helpful for finding an event
+    """
+    is_valid = True
+    result = None
+
+    try:
+        shift = Shift.objects.get(pk=shift_id)
+        event = shift.job.event
+    except ObjectDoesNotExist:
+        is_valid = False
+
+    if is_valid:
+        result = event
+
+    return result
 
 # need to check that this event is not accociated with any jobs,
 # otherwise the jobs that it is associated with will be cascade deleted

--- a/vms/event/templates/event/edit.html
+++ b/vms/event/templates/event/edit.html
@@ -33,7 +33,7 @@
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">Start Date</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="MM/DD/YYYY" type="text" name="start_date" value="{% if form.start_date.value %}{{ form.start_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
+                            <input class="form-control" type="text" name="start_date" id="from" name="from" value="{% if form.start_date.value %}{{ form.start_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
                             <p class="help-block">
                                 <strong>
                                     {% for error in form.start_date.errors %}
@@ -47,7 +47,7 @@
                     <div class="form-group">
                         <label class="col-md-2 control-label">Start Date</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="MM/DD/YYYY" type="text" name="start_date" value="{% if form.start_date.value %}{{ form.start_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
+                            <input class="form-control" type="text" name="start_date" id="from" name="from" value="{% if form.start_date.value %}{{ form.start_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
                         </div>
                     </div>
                 {% endif %}
@@ -55,7 +55,7 @@
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">End Date</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="MM/DD/YYYY" type="text" name="end_date" value="{% if form.end_date.value %}{{ form.end_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
+                            <input class="form-control" type="text" name="end_date" id="to" name="to" value="{% if form.end_date.value %}{{ form.end_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
                             <p class="help-block">
                                 <strong>
                                     {% for error in form.end_date.errors %}
@@ -69,7 +69,7 @@
                     <div class="form-group">
                         <label class="col-md-2 control-label">End Date</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="MM/DD/YYYY" type="text" name="end_date" value="{% if form.end_date.value %}{{ form.end_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
+                            <input class="form-control" type="text" name="end_date" id="to" name="to" value="{% if form.end_date.value %}{{ form.end_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
                         </div>
                     </div>
                 {% endif %}

--- a/vms/event/tests.py
+++ b/vms/event/tests.py
@@ -1,12 +1,15 @@
 from django.test import TestCase
 
 from event.models import Event
+from job.models import Job
+from shift.models import Shift
 from event.services import (
         event_not_empty,
         delete_event,
         get_event_by_id,
         get_events_ordered_by_name,
-        get_events_by_date
+        get_events_by_date,
+        get_event_by_shift_id
         )
 
 
@@ -40,6 +43,67 @@ class EventMethodTests(TestCase):
         self.assertFalse(event_not_empty(100))
         self.assertFalse(event_not_empty(200))
         self.assertFalse(event_not_empty(300))
+
+    def test_get_event_by_shift_id(self):
+        e1 = Event(
+                name="Open Source Event",
+                start_date="2012-10-22",
+                end_date="2012-10-23"
+                )
+
+        e1.save()
+
+        j1 = Job(
+                name="Software Developer",
+                start_date="2012-10-22",
+                end_date="2012-10-23",
+                description="A software job",
+                event=e1
+                )
+
+        j2 = Job(
+                name="Systems Administrator",
+                start_date="2012-9-1",
+                end_date="2012-10-26",
+                description="A systems administrator job",
+                event=e1
+                )
+
+        j1.save()
+        j2.save()
+
+        s1 = Shift(
+                date="2012-10-23",
+                start_time="9:00",
+                end_time="3:00",
+                max_volunteers=1,
+                job=j1
+                )
+
+        s2 = Shift(
+                date="2012-10-23",
+                start_time="10:00",
+                end_time="4:00",
+                max_volunteers=2,
+                job=j1
+                )
+
+        s3 = Shift(
+                date="2012-10-23",
+                start_time="12:00",
+                end_time="6:00",
+                max_volunteers=4,
+                job=j2
+                )
+
+        s1.save()
+        s2.save()
+        s3.save()
+        
+        self.assertIsNotNone(get_event_by_shift_id(s1.id))
+        self.assertIsNotNone(get_event_by_shift_id(s2.id))
+        self.assertIsNotNone(get_event_by_shift_id(s3.id))
+
 
     def test_delete_event(self):
         """ Test delete_event(event_id) """

--- a/vms/job/templates/job/edit.html
+++ b/vms/job/templates/job/edit.html
@@ -72,7 +72,7 @@
                         <div class="form-group has-error">
                             <label class="col-md-2 control-label">Start Date</label>
                             <div class="col-md-8">
-                                <input class="form-control" placeholder="MM/DD/YYYY" type="text" name="start_date" value="{% if form.start_date.value %}{{ form.start_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
+							<input class="form-control" type="text" name="start_date" id="from" name="from" value="{% if form.start_date.value %}{{ form.start_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
                                 <p class="help-block">
                                     <strong>
                                         {% for error in form.start_date.errors %}
@@ -86,7 +86,7 @@
                         <div class="form-group">
                             <label class="col-md-2 control-label">Start Date</label>
                             <div class="col-md-8">
-                                <input class="form-control" placeholder="MM/DD/YYYY" type="text" name="start_date" value="{% if form.start_date.value %}{{ form.start_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
+							<input class="form-control" type="text" name="start_date" id="from" name="from" value="{% if form.start_date.value %}{{ form.start_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
                             </div>
                         </div>
                     {% endif %}
@@ -94,7 +94,7 @@
                         <div class="form-group has-error">
                             <label class="col-md-2 control-label">End Date</label>
                             <div class="col-md-8">
-                                <input class="form-control" placeholder="MM/DD/YYYY" type="text" name="end_date" value="{% if form.end_date.value %}{{ form.end_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
+                                <input class="form-control" type="text" name="end_date" id="to" name="to" value="{% if form.end_date.value %}{{ form.end_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
                                 <p class="help-block">
                                     <strong>
                                         {% for error in form.end_date.errors %}
@@ -108,7 +108,7 @@
                         <div class="form-group">
                             <label class="col-md-2 control-label">End Date</label>
                             <div class="col-md-8">
-                                <input class="form-control" placeholder="MM/DD/YYYY" type="text" name="end_date" value="{% if form.end_date.value %}{{ form.end_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
+                                <input class="form-control" type="text" name="end_date" id="to" name="to" value="{% if form.end_date.value %}{{ form.end_date.value|date:"SHORT_DATE_FORMAT" }}{% endif %}">
                             </div>
                         </div>
                     {% endif %}

--- a/vms/shift/models.py
+++ b/vms/shift/models.py
@@ -6,6 +6,7 @@ from django.core.validators import (
 from django.db import models
 
 from job.models import Job
+from event.models import Event
 from volunteer.models import Volunteer
 
 

--- a/vms/shift/templates/shift/create.html
+++ b/vms/shift/templates/shift/create.html
@@ -99,7 +99,7 @@
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">Country</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="Shift Country" type="text" name="country" value="{% if form.country.value %}{{ form.country.value }}{% endif %}">
+                            <input class="form-control" placeholder="Shift Country" type="text" name="country" value="{% if form.country.value %}{{ form.country.value }}{% elif country %}{{ country }}{% endif %}">
                             <p class="help-block">
                                 <strong>
                                     {% for error in form.country.errors %}
@@ -113,7 +113,7 @@
                     <div class="form-group">
                         <label class="col-md-2 control-label">Country</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="Shift Country" type="text" name="country" value="{% if form.country.value %}{{ form.country.value }}{% endif %}">
+                            <input class="form-control" placeholder="Shift Country" type="text" name="country" value="{% if form.country.value %}{{ form.country.value }}{% elif country %}{{ country }}{% endif %}">
                         </div>
                     </div>
                 {% endif %}
@@ -121,7 +121,7 @@
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">State</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="Shift State" type="text" name="state" value="{% if form.state.value %}{{ form.state.value }}{% endif %}">
+                            <input class="form-control" placeholder="Shift State" type="text" name="state" value="{% if form.state.value %}{{ form.state.value }}{% elif state %}{{ state }}{% endif %}">
                             <p class="help-block">
                                 <strong>
                                     {% for error in form.state.errors %}
@@ -135,7 +135,7 @@
                     <div class="form-group">
                         <label class="col-md-2 control-label">State</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="Shift State" type="text" name="state" value="{% if form.state.value %}{{ form.state.value }}{% endif %}">
+                            <input class="form-control" placeholder="Shift State" type="text" name="state" value="{% if form.state.value %}{{ form.state.value }}{% elif state %}{{ state }}{% endif %}">
                         </div>
                     </div>
                 {% endif %}
@@ -144,7 +144,7 @@
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">City</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="Shift City" type="text" name="city" value="{% if form.city.value %}{{ form.city.value }}{% endif %}">
+                            <input class="form-control" placeholder="Shift City" type="text" name="city" value="{% if form.city.value %}{{ form.city.value }}{% elif city %}{{ city }}{% endif %}">
                             <p class="help-block">
                                 <strong>
                                     {% for error in form.city.errors %}
@@ -158,7 +158,7 @@
                     <div class="form-group">
                         <label class="col-md-2 control-label">City</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="Shift City" type="text" name="city" value="{% if form.city.value %}{{ form.city.value }}{% endif %}">
+                            <input class="form-control" placeholder="Shift City" type="text" name="city" value="{% if form.city.value %}{{ form.city.value }}{% elif city %}{{ city }}{% endif %}">
                         </div>
                     </div>
                 {% endif %}
@@ -167,7 +167,7 @@
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">Address</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="Shift Address" type="text" name="address" value="{% if form.address.value %}{{ form.address.value }}{% endif %}">
+                            <input class="form-control" placeholder="Shift Address" type="text" name="address" value="{% if form.address.value %}{{ form.address.value }}{% elif address %}{{ address }}{% endif %}">
                             <p class="help-block">
                                 <strong>
                                     {% for error in form.address.errors %}
@@ -181,7 +181,7 @@
                     <div class="form-group">
                         <label class="col-md-2 control-label">Address</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="Shift Address" type="text" name="address" value="{% if form.address.value %}{{ form.address.value }}{% endif %}">
+                            <input class="form-control" placeholder="Shift Address" type="text" name="address" value="{% if form.address.value %}{{ form.address.value }}{% elif address %}{{ address }}{% endif %}">
                         </div>
                     </div>
                 {% endif %}
@@ -190,7 +190,7 @@
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">Venue</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="Shift Venue" type="text" name="venue" value="{% if form.venue.value %}{{ form.venue.value }}{% endif %}">
+                            <input class="form-control" placeholder="Shift Venue" type="text" name="venue" value="{% if form.venue.value %}{{ form.venue.value }}{% elif venue %}{{ venue }}{% endif %}">
                             <p class="help-block">
                                 <strong>
                                     {% for error in form.venue.errors %}
@@ -204,7 +204,7 @@
                     <div class="form-group">
                         <label class="col-md-2 control-label">Venue</label>
                         <div class="col-md-8">
-                            <input class="form-control" placeholder="Shift Venue" type="text" name="venue" value="{% if form.venue.value %}{{ form.venue.value }}{% endif %}">
+                            <input class="form-control" placeholder="Shift Venue" type="text" name="venue" value="{% if form.venue.value %}{{ form.venue.value }}{% elif venue %}{{ venue }}{% endif %}">
                         </div>
                     </div>
                 {% endif %}

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -217,8 +217,9 @@ def create(request, job_id):
         return render(request, 'vms/no_admin_rights.html')
     else:
         if job_id:
+            job = get_job_by_id(job_id)
+            event = job.event
             if request.method == 'POST':
-                job = get_job_by_id(job_id)
                 if job:
                     form = ShiftForm(request.POST)
                     if form.is_valid():
@@ -236,10 +237,15 @@ def create(request, job_id):
                     raise Http404
             else:
                 form = ShiftForm()
+                country = event.country
+                state = event.state
+                city = event.city
+                address = event.address
+                venue = event.venue
                 return render(
                     request,
                     'shift/create.html',
-                    {'form': form, 'job_id': job_id, }
+                    {'form': form, 'job_id': job_id, 'country': country, 'state': state, 'city': city, 'address': address, 'venue': venue}
                     )
         else:
             raise Http404
@@ -330,7 +336,12 @@ def edit_hours(request, shift_id, volunteer_id):
                         start_time = form.cleaned_data['start_time']
                         end_time = form.cleaned_data['end_time']
                         try:
-                            edit_shift_hours(volunteer_id, shift_id, start_time, end_time)
+                            edit_shift_hours(
+                                volunteer_id,
+                                shift_id,
+                                start_time,
+                                end_time
+                                )
                             return HttpResponseRedirect(reverse('shift:view_hours', args=(volunteer_id,)))
                         except:
                             raise Http404
@@ -489,7 +500,11 @@ def manage_volunteer_shifts(request, volunteer_id):
                 # (since it doesn't make sense be able to cancel shifts that have already been logged)
                 shift_list = get_unlogged_shifts_by_volunteer_id(volunteer_id)
                 shift_list_with_hours = get_volunteer_shifts_with_hours(volunteer_id)
-                return render(request, 'shift/manage_volunteer_shifts.html', {'shift_list': shift_list,'shift_list_with_hours': shift_list_with_hours, 'volunteer_id': volunteer_id})
+                return render(
+                    request,
+                    'shift/manage_volunteer_shifts.html',
+                    {'shift_list': shift_list,'shift_list_with_hours': shift_list_with_hours, 'volunteer_id': volunteer_id}
+                    )
             else:
                 raise Http404
         else:
@@ -649,5 +664,5 @@ def volunteer_search(request):
         return render(
             request,
             'shift/volunteer_search.html',
-            {'form': form, 'has_searched' : False, 'volunteer_list' : volunteer_list}
+            {'form': form, 'has_searched': False, 'volunteer_list': volunteer_list}
             )


### PR DESCRIPTION
Inspired by @willingc. Closes https://github.com/systers/vms/issues/100

This PR adds a pre-populate feature for creating shifts. 

The shift-fields are filled with database information already know about the event (country, state, city, address, venue) to minimize typing by admin. The admin is able to override the pre-populated information.