### PR TITLE
Phone number registration and menu item name

### DIFF
--- a/vms/administrator/models.py
+++ b/vms/administrator/models.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User
 from django.core.validators import RegexValidator
 from django.db import models
+
 from organization.models import Organization
 
 
@@ -57,7 +58,8 @@ class Administrator(models.Model):
         max_length=20,
         validators=[
             RegexValidator(
-                r'^[0-9]+$',
+                r'^\+?1?\d{9,15}$',
+                message="Phone number must be entered in the format: '+999999999'. Up to 15 digits allowed.",
             ),
         ],
     )

--- a/vms/registration/templates/registration/signup_administrator.html
+++ b/vms/registration/templates/registration/signup_administrator.html
@@ -246,7 +246,7 @@
                     Phone Number<span class="asteriskField">*</span>
                 </label>
                 <div class="controls">
-                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="Phone Number" name="admin-phone_number" value="{{ administrator_form.phone_number.value }}">
+                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="+999999999" name="admin-phone_number" value="{{ administrator_form.phone_number.value }}">
                     <p class="help-block">
                         <strong>
                             {% for error in administrator_form.phone_number.errors %}
@@ -262,7 +262,7 @@
                     Phone Number<span class="asteriskField">*</span>
                 </label>
                 <div class="controls">
-                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="Phone Number" name="admin-phone_number" value="{% if administrator_form.phone_number.value %}{{ administrator_form.phone_number.value }}{% endif %}">
+                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="+999999999" name="admin-phone_number" value="{% if administrator_form.phone_number.value %}{{ administrator_form.phone_number.value }}{% endif %}">
                 </div>
             </div>
         {% endif %}

--- a/vms/registration/templates/registration/signup_volunteer.html
+++ b/vms/registration/templates/registration/signup_volunteer.html
@@ -273,7 +273,7 @@
                     Phone Number<span class="asteriskField">*</span>
                 </label>
                 <div class="controls">
-                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="Phone Number" name="vol-phone_number" value="{{ volunteer_form.phone_number.value }}">
+                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="+999999999" name="vol-phone_number" value="{{ volunteer_form.phone_number.value }}">
                     <p class="help-block">
                         <strong>
                             {% for error in volunteer_form.phone_number.errors %}
@@ -289,7 +289,7 @@
                     Phone Number<span class="asteriskField">*</span>
                 </label>
                 <div class="controls">
-                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="Phone Number" name="vol-phone_number" value="{% if volunteer_form.phone_number.value %}{{ volunteer_form.phone_number.value }}{% endif %}">
+                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="+999999999" name="vol-phone_number" value="{% if volunteer_form.phone_number.value %}{{ volunteer_form.phone_number.value }}{% endif %}">
                 </div>
             </div>
         {% endif %}

--- a/vms/vms/templates/vms/base.html
+++ b/vms/vms/templates/vms/base.html
@@ -40,7 +40,7 @@
                             <li><a href="{% url 'volunteer:search' %}">Volunteer Search</a></li>
                             <li><a href="{% url 'shift:volunteer_search' %}">Manage Volunteer Shifts</a></li>
                             <li><a href="{% url 'administrator:report' %}">Report</a></li>
-                            <li><a href="{% url 'administrator:settings' %}">Settings</a></li>
+                            <li><a href="{% url 'administrator:settings' %}">Events</a></li>
                             <li><a href="{% url 'registration:signup_administrator' %}">Create Admin Account</a></li>
                         {% endif %}
                         {% if user.volunteer %} 

--- a/vms/volunteer/models.py
+++ b/vms/volunteer/models.py
@@ -62,7 +62,8 @@ class Volunteer(models.Model):
         max_length=20,
         validators=[
             RegexValidator(
-                r'^[0-9]+$',
+                r'^\+?1?\d{9,15}$',
+                message="Phone number must be entered in the format: '+999999999'. Up to 15 digits allowed.",
             ),
         ],
     )


### PR DESCRIPTION
Closes https://github.com/systers/vms/issues/94.
Related also to https://github.com/systers/vms/issues/97.

Before typing you can see a prompt:

![image](https://cloud.githubusercontent.com/assets/7673323/9294938/11591282-445d-11e5-9107-5197fbd7d29a.png)

Error message is more helpful now:

![image](https://cloud.githubusercontent.com/assets/7673323/9294934/fc109738-445c-11e5-8113-579448cffe0c.png)
