### PR TITLE
Show all shifts except signed up

### DIFF
--- a/vms/shift/services.py
+++ b/vms/shift/services.py
@@ -324,6 +324,28 @@ def get_shifts_with_open_slots(j_id):
     return shift_list
 
 
+def get_shifts_with_open_slots_for_volunteer(j_id, v_id):
+    """
+    Returns shifts with open slots
+    all except those for which the volunteer has signed up.
+    """
+    shift_list_by_date = get_shifts_ordered_by_date(j_id)
+    shift_list = []
+
+    for shift in shift_list_by_date:
+        slots_remaining = get_shift_slots_remaining(shift.id)
+        if slots_remaining > 0 and not is_signed_up(v_id, shift.id):
+            shift_map = {}
+            shift_map["id"] = shift.id
+            shift_map["date"] = shift.date
+            shift_map["start_time"] = shift.start_time
+            shift_map["end_time"] = shift.end_time
+            shift_map["slots_remaining"] = slots_remaining
+            shift_list.append(shift_map)
+
+    return shift_list
+
+
 def get_unlogged_shifts_by_volunteer_id(v_id):
 
     # get shifts that the volunteer signed up for and

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -467,7 +467,7 @@ def list_shifts_sign_up(request, job_id, volunteer_id):
     if job_id:
         job = get_job_by_id(job_id)
         if job:
-            shift_list = get_shifts_with_open_slots(job_id)
+            shift_list = get_shifts_with_open_slots_for_volunteer(job_id, volunteer_id)
             return render(
                 request,
                 'shift/list_shifts_sign_up.html',


### PR DESCRIPTION
Closes https://github.com/systers/vms/issues/112

After these changes, in the list /shift/list_shifts_sign_up/ a volunteer can see all shifts except those for which she/he has signed up. And she/he will not receive any error messages.