### PR TITLE
Updated the link to run vms on local machine

### DIFF
--- a/docs/Installation Guide.md
+++ b/docs/Installation Guide.md
@@ -275,7 +275,7 @@ Start the development server by running the command (this runs the development s
 
     python manage.py runserver [::]:8000
 
-You can now try out the project by going to [http://localhost:8000/home](http://localhost:8000/home) on a browser on your local machine.
+You can now try out the project by going to [http://localhost:8001/home](http://localhost:8001/home) on a browser on your local machine.
 
 ## Run Unit Tests
 


### PR DESCRIPTION
As mentioned previously in installation guide, after following all the steps as required 
When we go to the link http://localhost:8000/home/ there is a connection error.
![screenshot 29](https://cloud.githubusercontent.com/assets/9394028/11712342/6c4d325e-9f52-11e5-94f5-12c1d8a769b6.png)

Actually the link is supposed to be http://localhost:8001/home/ for which we get the vms
![screenshot 30](https://cloud.githubusercontent.com/assets/9394028/11712354/8500bcbc-9f52-11e5-96d8-281e42a76553.png)

So, the link needs to be updated.
