### PR TITLE
SHIFT SIGN UP list enchancement: show only not empty events and jobs

### DIFF
--- a/docs/Installation Guide.md
+++ b/docs/Installation Guide.md
@@ -27,7 +27,7 @@ If you don't already have git, you can download it [here](http://git-scm.com/dow
 
 Clone the project from GitHub by running the following command:
 
-    git clone project_url_here
+    git clone https://github.com/systers/vms
 
 For my project, this would correspond to:
 

--- a/vms/event/services.py
+++ b/vms/event/services.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from event.models import Event
 from job.models import Job
 from shift.models import Shift
-
+from job.services import get_jobs_by_event_id, remove_empty_jobs
 
 def event_not_empty(event_id):
     """ Checks if the event exists and is not empty """
@@ -89,3 +89,15 @@ def get_events_by_date(start_date, end_date):
 def get_events_ordered_by_name():
     event_list = Event.objects.all().order_by('name')
     return event_list
+
+
+def remove_empty_events(event_list, volunteer_id):
+    """ Removes all events from an event list without jobs, or events
+        that have jobs but not shifts"""
+    new_event_list = []
+    for event in event_list:
+        job_list = get_jobs_by_event_id(event.id)
+        job_list = remove_empty_jobs(job_list, volunteer_id)
+        if job_list:
+            new_event_list.append(event)
+    return new_event_list

--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -100,7 +100,7 @@ def list_sign_up(request, volunteer_id):
             end_date = form.cleaned_data['end_date']
             
             event_list = get_events_by_date(start_date, end_date)
-            
+            event_list = remove_empty_events(event_list, volunteer_id)
             return render(
                 request,
                 'event/list_sign_up.html',
@@ -108,6 +108,7 @@ def list_sign_up(request, volunteer_id):
                 )
         else:
             event_list = get_events_ordered_by_name()
+            event_list = remove_empty_events(event_list, volunteer_id)
             return render(
                 request,
                 'event/list_sign_up.html',
@@ -115,6 +116,7 @@ def list_sign_up(request, volunteer_id):
                 )
     else:
         event_list = get_events_ordered_by_name()
+        event_list = remove_empty_events(event_list, volunteer_id)
         return render(
             request,
             'event/list_sign_up.html',

--- a/vms/job/services.py
+++ b/vms/job/services.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 
 from job.models import Job
-
+from shift.services import get_shifts_with_open_slots_for_volunteer
 
 def job_not_empty(job_id):
     """ Check if the job exists and is not empty """
@@ -52,3 +52,13 @@ def get_jobs_by_event_id(e_id):
 def get_jobs_ordered_by_title():
     job_list = Job.objects.all().order_by('name')
     return job_list
+
+
+def remove_empty_jobs(job_list, volunteer_id):
+    """ Removes all jobs from a job list without shifts """
+    new_job_list = []
+    for job in job_list:
+        shift_list = get_shifts_with_open_slots_for_volunteer(job.id, volunteer_id)
+        if shift_list:
+            new_job_list.append(job)
+    return new_job_list

--- a/vms/job/templates/job/create.html
+++ b/vms/job/templates/job/create.html
@@ -15,7 +15,7 @@
                         <div class="col-md-8">
                             <select class="form-control" name="event_id">
                                 {% for event in event_list %}
-                                    <option value="{{ event.id }}">{{ event.name }}</option>
+                                    <option value="{{ event.id }} ">{{ event.name }} ({{event.start_date}} - {{event.end_date}})</option>
                                 {% endfor %}
                             </select>
                         </div>

--- a/vms/job/templates/job/edit.html
+++ b/vms/job/templates/job/edit.html
@@ -16,9 +16,9 @@
                             <select class="form-control" name="event_id">
                                 {% for event in event_list %}
                                     {% if event.name == job.event.name %}
-                                        <option selected value="{{ event.id }}">{{ event.name }}</option>
+                                        <option selected value="{{ event.id }} ">{{ event.name }} ({{event.start_date}} - {{event.end_date}})</option>
                                     {% else %}
-                                        <option value="{{ event.id }}">{{ event.name }}</option>
+                                        <option value="{{ event.id }} ">{{ event.name }} ({{event.start_date}} - {{event.end_date}})</option>
                                     {% endif %}
                                 {% endfor %}
                             </select>

--- a/vms/job/views.py
+++ b/vms/job/views.py
@@ -136,6 +136,7 @@ def list_sign_up(request, event_id, volunteer_id):
         event = get_event_by_id(event_id)
         if event:
             job_list = get_jobs_by_event_id(event_id)
+            job_list = remove_empty_jobs(job_list, volunteer_id)
             return render(request, 'job/list_sign_up.html', {'event': event, 'job_list': job_list, 'volunteer_id': volunteer_id})
         else:
             raise Http404

--- a/vms/shift/services.py
+++ b/vms/shift/services.py
@@ -326,15 +326,15 @@ def get_shifts_with_open_slots(j_id):
 
 def get_shifts_with_open_slots_for_volunteer(j_id, v_id):
     """
-    Returns shifts with open slots
+    Returns shifts with open slots that start today or later only
     all except those for which the volunteer has signed up.
     """
     shift_list_by_date = get_shifts_ordered_by_date(j_id)
     shift_list = []
-
+    current_date = date.today()
     for shift in shift_list_by_date:
         slots_remaining = get_shift_slots_remaining(shift.id)
-        if slots_remaining > 0 and not is_signed_up(v_id, shift.id):
+        if slots_remaining > 0 and not is_signed_up(v_id, shift.id) and shift.date >= current_date:
             shift_map = {}
             shift_map["id"] = shift.id
             shift_map["date"] = shift.date

--- a/vms/shift/templates/shift/create.html
+++ b/vms/shift/templates/shift/create.html
@@ -12,6 +12,27 @@
             {% csrf_token %}
             <fieldset>
                 <legend>Create Shift</legend>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job Name</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.name }}" disabled>
+					</div>
+				</div>
+				<div>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job Start Date</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.start_date }}" disabled>
+					</div>
+				</div>
+				<div>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job End Date</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.end_date }}" disabled>
+					</div>
+				</div>
+				<div>
                 {% if form.date.errors %}
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">Date</label>

--- a/vms/shift/templates/shift/edit.html
+++ b/vms/shift/templates/shift/edit.html
@@ -11,6 +11,27 @@
             {% csrf_token %}
             <fieldset>
                 <legend>Edit Shift</legend>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job Name</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.name }}" disabled>
+					</div>
+				</div>
+				<div>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job Start Date</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.start_date }}" disabled>
+					</div>
+				</div>
+				<div>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job End Date</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.end_date }}" disabled>
+					</div>
+				</div>
+				<div>
                 {% if form.date.errors %}
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">Date</label>

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -245,7 +245,7 @@ def create(request, job_id):
                 return render(
                     request,
                     'shift/create.html',
-                    {'form': form, 'job_id': job_id, 'country': country, 'state': state, 'city': city, 'address': address, 'venue': venue}
+                    {'form': form, 'job_id': job_id, 'country': country, 'state': state, 'city': city, 'address': address, 'venue': venue, 'job': job}
                     )
         else:
             raise Http404
@@ -311,14 +311,14 @@ def edit(request, shift_id):
                 return render(
                     request,
                     'shift/edit.html',
-                    {'form': form, 'shift': shift}
+                    {'form': form, 'shift': shift, 'job': shift.job}
                     )
         else:
             form = ShiftForm(instance=shift)
             return render(
                 request,
                 'shift/edit.html',
-                {'form': form, 'shift': shift}
+                {'form': form, 'shift': shift, 'job': shift.job}
                 )
 
 


### PR DESCRIPTION
EDIT: look at pull #185 instead
closes #175 
I made changes to:
/event/services.py
/event/views.py
/job/services.py
/job/views.py

The shift sign up will no longer show events with no jobs, or events with jobs but no shifts, or jobs with no shifts.