### PR TITLE
Simplify the creating of the shift 

### DIFF
--- a/vms/shift/templates/shift/create.html
+++ b/vms/shift/templates/shift/create.html
@@ -12,6 +12,27 @@
             {% csrf_token %}
             <fieldset>
                 <legend>Create Shift</legend>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job Name</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.name }}" disabled>
+					</div>
+				</div>
+				<div>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job Start Date</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.start_date }}" disabled>
+					</div>
+				</div>
+				<div>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job End Date</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.end_date }}" disabled>
+					</div>
+				</div>
+				<div>
                 {% if form.date.errors %}
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">Date</label>

--- a/vms/shift/templates/shift/edit.html
+++ b/vms/shift/templates/shift/edit.html
@@ -11,6 +11,27 @@
             {% csrf_token %}
             <fieldset>
                 <legend>Edit Shift</legend>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job Name</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.name }}" disabled>
+					</div>
+				</div>
+				<div>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job Start Date</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.start_date }}" disabled>
+					</div>
+				</div>
+				<div>
+				<div class="form-group">
+					<label class="col-md-2 control-label">Job End Date</label>
+					<div class="col-md-8">
+						<input class="form-control" type="text" value="{{ job.end_date }}" disabled>
+					</div>
+				</div>
+				<div>
                 {% if form.date.errors %}
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">Date</label>

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -245,7 +245,7 @@ def create(request, job_id):
                 return render(
                     request,
                     'shift/create.html',
-                    {'form': form, 'job_id': job_id, 'country': country, 'state': state, 'city': city, 'address': address, 'venue': venue}
+                    {'form': form, 'job_id': job_id, 'country': country, 'state': state, 'city': city, 'address': address, 'venue': venue, 'job': job}
                     )
         else:
             raise Http404
@@ -311,14 +311,14 @@ def edit(request, shift_id):
                 return render(
                     request,
                     'shift/edit.html',
-                    {'form': form, 'shift': shift}
+                    {'form': form, 'shift': shift, 'job': shift.job}
                     )
         else:
             form = ShiftForm(instance=shift)
             return render(
                 request,
                 'shift/edit.html',
-                {'form': form, 'shift': shift}
+                {'form': form, 'shift': shift, 'job': shift.job}
                 )
 
 


### PR DESCRIPTION
closes #132.

I made changes to the following files:
shift/templates/shift/create.html
shift/templates/shift/edit.html
shift/views.py

I made the job names and dates disabled inputs.
![create](https://cloud.githubusercontent.com/assets/16299227/11859335/db0be4f8-a437-11e5-98ae-a728438ac1fa.png)

![edit](https://cloud.githubusercontent.com/assets/16299227/11859351/00b0abc6-a438-11e5-9635-c0235655135b.png)


I closed my other pull as it had a lot of issues, so I redid it.