### PR TITLE
Simplify editing of the shift

### DIFF
--- a/vms/shift/templates/shift/edit.html
+++ b/vms/shift/templates/shift/edit.html
@@ -11,6 +11,18 @@
             {% csrf_token %}
             <fieldset>
                 <legend>Edit Shift</legend>
+				<label class="col-md-2 control-label">Job Name</label>
+                <div class="col-md-10">
+                    <p class="form-control-static">{{ job.name }}</p>
+                </div>
+                <label class="col-md-2 control-label">Job Start Date</label>
+                <div class="col-md-10">
+                    <p class="form-control-static">{{ job.start_date }}</p>
+                </div>
+                <label class="col-md-2 control-label">Job End Date</label>
+                <div class="col-md-10">
+                    <p class="form-control-static">{{ job.end_date }}</p>
+                </div>
                 {% if form.date.errors %}
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">Date</label>

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -323,14 +323,14 @@ def edit(request, shift_id):
                 return render(
                     request,
                     'shift/edit.html',
-                    {'form': form, 'shift': shift}
+                    {'form': form, 'shift': shift, 'job': shift.job}
                     )
         else:
             form = ShiftForm(instance=shift)
             return render(
                 request,
                 'shift/edit.html',
-                {'form': form, 'shift': shift}
+                {'form': form, 'shift': shift, 'job': shift.job}
                 )
 
 


### PR DESCRIPTION
Extends #132 
job names and dates now show up in shift editing as well to match the creation.
![edit](https://cloud.githubusercontent.com/assets/16299227/11914393/2ea7a2c4-a64e-11e5-9a81-a3a1197ed23a.png)
