### PR TITLE
Show only not empty events and jobs

### DIFF
--- a/vms/event/services.py
+++ b/vms/event/services.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from event.models import Event
 from job.models import Job
 from shift.models import Shift
-
+from job.services import get_jobs_by_event_id, remove_empty_jobs_for_volunteer
 
 def event_not_empty(event_id):
     """ Checks if the event exists and is not empty """
@@ -89,3 +89,14 @@ def get_events_by_date(start_date, end_date):
 def get_events_ordered_by_name():
     event_list = Event.objects.all().order_by('name')
     return event_list
+
+
+def remove_empty_events_for_volunteer(event_list, volunteer_id):
+    """ Removes all events from an event list without jobs or shifts """
+    new_event_list = []
+    for event in event_list:
+        job_list = get_jobs_by_event_id(event.id)
+        job_list = remove_empty_jobs_for_volunteer(job_list, volunteer_id)
+        if job_list:
+            new_event_list.append(event)
+    return new_event_list

--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -100,6 +100,7 @@ def list_sign_up(request, volunteer_id):
             end_date = form.cleaned_data['end_date']
             
             event_list = get_events_by_date(start_date, end_date)
+            event_list = remove_empty_events_for_volunteer(event_list, volunteer_id)
             
             return render(
                 request,
@@ -108,6 +109,7 @@ def list_sign_up(request, volunteer_id):
                 )
         else:
             event_list = get_events_ordered_by_name()
+            event_list = remove_empty_events_for_volunteer(event_list, volunteer_id)
             return render(
                 request,
                 'event/list_sign_up.html',
@@ -115,6 +117,7 @@ def list_sign_up(request, volunteer_id):
                 )
     else:
         event_list = get_events_ordered_by_name()
+        event_list = remove_empty_events_for_volunteer(event_list, volunteer_id)
         return render(
             request,
             'event/list_sign_up.html',

--- a/vms/job/services.py
+++ b/vms/job/services.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 
 from job.models import Job
-
+from shift.services import get_shifts_with_open_slots_for_volunteer
 
 def job_not_empty(job_id):
     """ Check if the job exists and is not empty """
@@ -52,3 +52,13 @@ def get_jobs_by_event_id(e_id):
 def get_jobs_ordered_by_title():
     job_list = Job.objects.all().order_by('name')
     return job_list
+
+
+def remove_empty_jobs_for_volunteer(job_list, volunteer_id):
+    """ Removes all jobs from a job list without shifts """
+    new_job_list = []
+    for job in job_list:
+        shift_list = get_shifts_with_open_slots_for_volunteer(job.id, volunteer_id)
+        if shift_list:
+            new_job_list.append(job)
+    return new_job_list

--- a/vms/job/views.py
+++ b/vms/job/views.py
@@ -154,6 +154,7 @@ def list_sign_up(request, event_id, volunteer_id):
         event = get_event_by_id(event_id)
         if event:
             job_list = get_jobs_by_event_id(event_id)
+            job_list = remove_empty_jobs_for_volunteer(job_list, volunteer_id)
             return render(request, 'job/list_sign_up.html', {'event': event, 'job_list': job_list, 'volunteer_id': volunteer_id})
         else:
             raise Http404


### PR DESCRIPTION
closes #175 
Volunteers will only be able to see events with jobs (at least 1 job must have a shift), and jobs with shifts.

What admin sees:
![admin](https://cloud.githubusercontent.com/assets/16299227/11914812/d9d90fda-a657-11e5-83be-7d53a163180f.png)

What volunteer sees:
![user](https://cloud.githubusercontent.com/assets/16299227/11914815/e36cc6d6-a657-11e5-8d1e-80b8422baa0b.png)
