### PR TITLE
Added event dates in selector options [Google Code In Task VMS-18]

### DIFF
--- a/vms/job/templates/job/create.html
+++ b/vms/job/templates/job/create.html
@@ -30,7 +30,7 @@
                         <div class="col-md-8">
                             <select class="form-control" name="event_id" id="id" onchange="dates()">
                                 {% for event in event_list %}
-                                    <option value="{{ event.id }}" event="{{ event }}">{{ event.name }}</option>
+                                    <option value="{{ event.id }}" event="{{ event }}">{{ event.name }} &nbsp;&nbsp;&nbsp;&nbsp; [from {{ event.start_date }} to {{ event.end_date }}]</option>
                                 {% endfor %}
                             </select>
                         </div>


### PR DESCRIPTION
The event duration can now be seen in the event selector. The attached screenshot shows what it looks like.

![adding event date](https://cloud.githubusercontent.com/assets/14851667/12007835/925b6812-abdc-11e5-81eb-1a688e34746a.PNG)
