### PR TITLE
Show event dates for job create and edit

### DIFF
--- a/vms/job/templates/job/create.html
+++ b/vms/job/templates/job/create.html
@@ -1,5 +1,7 @@
 {% extends "administrator/settings.html" %}
 
+{% load staticfiles %}
+
 {% block setting_content %}
 <br>
 {% if messages %}
@@ -28,21 +30,24 @@
                             Event:
                         </label>
                         <div class="col-md-8">
-                            <select class="form-control" name="event_id" id="id" onchange="dates()">
+                            <select class="form-control" name="event_id" id="events" onchange="update_event_dates()">
                                 {% for event in event_list %}
-                                    <option value="{{ event.id }}" event="{{ event }}">{{ event.name }}</option>
+                                    <option value="{{ event.id }}" start_date="{{ event.start_date }}" end_date="{{ event.end_date }}">{{ event.name }}</option>
                                 {% endfor %}
                             </select>
                         </div>
                     </div>
-                    <p id="d"></p>
-                    <script type="text/javascript" src="{{ STATIC_URL }}js/jquery-1.8.3.min.js">
-                       function dates(){
-                            var event_id=document.getElementById("id");
-                            event=event_id.getAttribute("event");
-                            document.getElementById("d").innerHTML="Event starts by {{ event.start_date }} and ends by {{ event.end_date }}";
-                    </script>
-
+					<div class="form-group">
+						<label class="col-md-2 control-label">Event Start Date</label>
+						<div class="col-md-10">
+							<p class="form-control-static" id="start_date_here">start_date</p>
+						</div>
+						<label class="col-md-2 control-label">Event End Date</label>
+						<div class="col-md-10">
+							<p class="form-control-static" id="end_date_here">end_date</p>
+						</div>
+					</div>
+                    <script src="{% static "vms/js/update-event-dates.js" %}"></script>
                     {% if form.name.errors %}
                         <div class="form-group has-error">
                             <label class="col-md-2 control-label">Job Name</label>

--- a/vms/job/templates/job/edit.html
+++ b/vms/job/templates/job/edit.html
@@ -1,5 +1,7 @@
 {% extends "administrator/settings.html" %}
 
+{% load staticfiles %}
+
 {% block setting_content %}
     <div class="spacer"></div>
     {% if event_list %}
@@ -13,17 +15,28 @@
                             Event:
                         </label>
                         <div class="col-md-8">
-                            <select class="form-control" name="event_id">
+                            <select class="form-control" name="event_id" id="events" onchange="update_event_dates()">
                                 {% for event in event_list %}
                                     {% if event.name == job.event.name %}
-                                        <option selected value="{{ event.id }}">{{ event.name }}</option>
+                                        <option selected value="{{ event.id }}" start_date="{{ event.start_date }}" end_date="{{ event.end_date }}">{{ event.name }}</option>
                                     {% else %}
-                                        <option value="{{ event.id }}">{{ event.name }}</option>
+                                        <option value="{{ event.id }}" start_date="{{ event.start_date }}" end_date="{{ event.end_date }}">{{ event.name }}</option>
                                     {% endif %}
                                 {% endfor %}
                             </select>
                         </div>
                     </div>
+					<div class="form-group">
+						<label class="col-md-2 control-label">Event Start Date</label>
+						<div class="col-md-10">
+							<p class="form-control-static" id="start_date_here">start_date</p>
+						</div>
+						<label class="col-md-2 control-label">Event End Date</label>
+						<div class="col-md-10">
+							<p class="form-control-static" id="end_date_here">end_date</p>
+						</div>
+					</div>
+					<script src="{% static "vms/js/update-event-dates.js" %}"></script>
                     {% if form.name.errors %}
                         <div class="form-group has-error">
                             <label class="col-md-2 control-label">Job Name</label>

--- a/vms/vms/static/vms/js/update-event-dates.js
+++ b/vms/vms/static/vms/js/update-event-dates.js
@@ -1,0 +1,9 @@
+function update_event_dates(){
+	var event_list = document.getElementById("events");
+	var selected_event = event_list.options[event_list.selectedIndex];
+	var start_date = selected_event.getAttribute("start_date");
+	var end_date = selected_event.getAttribute("end_date");
+	document.getElementById("start_date_here").innerHTML = start_date;
+	document.getElementById("end_date_here").innerHTML = end_date;
+}
+update_event_dates();


### PR DESCRIPTION
The event dates are now shown in both job creation and editing as separate fields, and will change based on what event is chosen.

job creation example:
![vid1](https://cloud.githubusercontent.com/assets/16299227/12075786/49996fd8-b15a-11e5-9f24-e5ae0680eac8.gif)
job editing example:
![vid2](https://cloud.githubusercontent.com/assets/16299227/12075788/4f66cc3a-b15a-11e5-990f-3fa32c0cda32.gif)
