### PR TITLE
Add a how to "contribution guide" in documentation

### DIFF
--- a/docs/Contribution Guide.md
+++ b/docs/Contribution Guide.md
@@ -1,0 +1,63 @@
+# Contribution Guide
+
+The VMS project is always looking for more contributors like you! Before you begin however, you should install and get the project running. Click [here](https://github.com/systers/vms/blob/master/docs/Installation%20Guide.md#installation-guide) for the installation guide. Always make sure that you are working with the latest version of the project, as your concerns may have already been addressed. Remember that coding is not the only method of contributing. You can help with documentation, QA, user interface, and much more!
+
+## Reporting bugs
+
+In order to report bugs, you should create a [new issue](https://github.com/systers/vms/issues/new) on GitHub, and include as many of the following as you can:
+
+* Detailed description of bug
+
+* Expected results versus actual results
+
+* Reproduction steps
+
+* Screenshots
+
+* Any other information that you see fit
+
+
+
+## Reporting issues
+
+In order to report issues, you should create a [new issue](https://github.com/systers/vms/issues/new) on GitHub, and include as many of the following as you can:
+
+* Detailed description of issue
+
+* Suggestions to fix issue
+
+* Location of issue
+
+* Screenshots
+
+* Any other information that you see fit
+
+
+
+## Suggesting features
+
+In order to suggest a feature, you should create a [new issue](https://github.com/systers/vms/issues/new) on GitHub. It may seem strange that feature suggestions go there, but that is just how GitHub is organized! Try to include as many of the following as you can:
+
+* Detailed description of features you want implemented
+
+* How you want the features to be implemented
+
+* Why you feel these changes are worthwhile
+
+* If applicable, sample examples or designs to help visualize
+
+* Any other information that you see fit.
+
+
+
+##Creating pull requests
+
+If you there is a bug/issue/feature in the [issue list](https://github.com/systers/vms/issues) that you want to tackle, just clone the VMS repository and make the necessary changes. If you have a working solution, push your changes to your forked VMS repository, and then make a [pull request](https://github.com/systers/vms/compare). Please try to push ONLY the relevant changes, which also means you will only need to add one new commit. You should also reference the issue you are addressing in the body of the pull request by adding something like "closes #X" where X is the number of the issue. This will auto close the issue if your code gets merged.
+
+For more information on push and pull requests [click here](http://blog.scottlowe.org/2015/01/27/using-fork-branch-git-workflow/)
+
+For more information on how to write a good commit [click here](http://chris.beams.io/posts/git-commit/).
+
+
+
+**Note:** You should only focus on ONE thing in your bug/issue/feature/pull request submission. If you have more things to contribute, fantastic! Just make a new submission for each.


### PR DESCRIPTION
The new documentation added will help guide contributors on what to do if they want to help the VMS project.
Example of the first half of the documentation:
![pls](https://cloud.githubusercontent.com/assets/16299227/12501861/2fd36a50-c090-11e5-8868-d5b9368313fd.png)