### PR TITLE
Add getting help guide in documentation

### DIFF
--- a/docs/Getting Help.md
+++ b/docs/Getting Help.md
@@ -1,0 +1,26 @@
+# Getting Help
+As you contribute to VMS, there will certainly be times when you will need to ask for help. When you do, it is important to know how to communicate your question effectively. To do this, be sure to follow the five Ws (and one H) of getting help!
+## What to ask
+Before you ask a question, pinpoint what your problem is exactly. Are you confused in general on what to do, or is there just a small part that you do not know how to implement? Highlight this exact issue in your question, and provide as much detail as possible on what you are confused about. The better that the responding party can understand your concern, the better they can help you!
+
+## Who to ask
+Who would your question concern? The question should be asked to the people that are the most suitable to answer. As much as everyone in VMS would love to help, no person is an expert at everything! For example, generic questions about good coding practices can be asked on the general project chat, whilst clarifications on an issue should be redirected to the person who opened the issue.
+
+## When to ask
+This is an interesting thing to consider, but when you ask a question matters. You should ask a question when you actually need the answer. The problem with asking a question too early, is that it might be become irrelevant by the time you can actually utilize the answers you receive, or that you will have other more pressing questions in the mean time that have to be asked first.
+
+## Where to ask
+The where relates to the who. You should consider where to ask your question. There is a chat for the VMS project on the Systers slack page, GitHub issue and pull request pages, personal emails, and other places as well. You want your question to be seen by the relevant audience, so try to post it in the place that fits best. A personal email for example, is probably not a good place to try and do code review, when GitHub offers more people and tools to help with that.
+
+## Why ask
+The why can be interpreted in two ways. First of all, the reason why you should ask questions is because you can! You are not doing an exam; you are working on an open source project. If you feel like you are missing something, go right ahead and ask for help. There is no point in trying to do everything on your own, for VMS is one large group project. You cannot produce the best results if you do not communicate with others. Now as for the why you are asking your question, include that as part of your explanation. Just stating why you need help can tell others a lot about the project, like fixing things that might be confusing, adding more documentation, making the code more accessible and so on. All questions are good as long as there is a purpose behind them.
+
+## How to ask
+Getting help and asking questions is a lot like submitting bugs/issues/features/pull requests. You should try to include as much of the following as you can:
+* Detailed question
+* Why you are asking the question
+* What you wanted to do versus what you experienced
+* Intuitions you might have to help answer your question or clarification
+* Screenshots to help visualize
+* Anything else that you feel is important to mention
+


### PR DESCRIPTION
The getting help guide should help new contributors learn what to include and remember when asking questions.
Sample of the documentation:
![hi](https://cloud.githubusercontent.com/assets/16299227/12528447/968fc1a2-c163-11e5-8d3f-015069923e62.png)
