### PR TITLE
Fixed edit job date validity

### DIFF
--- a/vms/job/templates/job/edit.html
+++ b/vms/job/templates/job/edit.html
@@ -3,6 +3,21 @@
 {% load staticfiles %}
 
 {% block setting_content %}
+
+<br>
+{% if messages %}
+
+<div class="alert alert-dismissible alert-danger">
+  <button type="button" class="close" data-dismiss="alert"></button>
+  <ul class="messages">
+    {% for message in messages %}
+    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+    {% endfor %}
+</ul>
+</div>
+
+{% endif %}
+
     <div class="spacer"></div>
     {% if event_list %}
         <div class="well">

--- a/vms/job/views.py
+++ b/vms/job/views.py
@@ -127,7 +127,28 @@ def edit(request, job_id):
                 else:
                     raise Http404
                 job_to_edit.save()
-                return HttpResponseRedirect(reverse('job:list'))
+                
+		start_date_event=event.start_date
+                end_date_event=event.end_date
+                start_date_job=form.cleaned_data.get('start_date')
+                end_date_job=form.cleaned_data.get('end_date')
+                if(start_date_job>=start_date_event and end_date_job<=end_date_event):
+                    job = form.save(commit=False)
+                    if event:
+                        job.event = event
+                    else:
+                        raise Http404
+                    job.save()
+                    return HttpResponseRedirect(reverse('job:list'))
+                else:
+                    messages.add_message(request, messages.INFO, 'Job dates should lie within Event dates')
+                    return render(
+                    request,
+                    'job/edit.html',
+                    {'form': form, 'event_list': event_list , 'job': job}
+                    )
+		return HttpResponseRedirect(reverse('job:list'))
+
             else:
                 return render(
                     request,


### PR DESCRIPTION
Before:
 When a job was created,it didn't allow start date and end date to be outside event dates.
 But when the job was edited,it showed no error for dates outside that of event dates.

Now : 
 It shows error message as in create job page for edit page if dates selected were not valid.

Please review and suggest changes.