### PR TITLE
Fixed edit shift date validity

### DIFF
--- a/vms/shift/templates/shift/edit.html
+++ b/vms/shift/templates/shift/edit.html
@@ -2,6 +2,20 @@
 
 {% block setting_content %}
 
+<br>
+{% if messages %}
+
+<div class="alert alert-dismissible alert-danger">
+  <button type="button" class="close" data-dismiss="alert"></button>
+  <ul class="messages">
+    {% for message in messages %}
+    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+    {% endfor %}
+</ul>
+</div>
+
+{% endif %}
+
 {% load static %}
 
 <script type="text/javascript" src="{% static 'vms/js/timepicker.js' %}"></script>


### PR DESCRIPTION
Before:
When a shift was created,it didn't allow start date and end date to be outside job dates.
But when the shift was edited,it showed no error for dates outside that of job dates.

Now :
It shows error message as in create shift page for edit page if dates selected were not valid.
Fixed #193 

Please review and suggest changes.