### PR TITLE
Validation of phone numbers based on country

### DIFF
--- a/vms/registration/phone_validate.py
+++ b/vms/registration/phone_validate.py
@@ -2,9 +2,13 @@ from cities_light.models import Country
 import phonenumbers
 
 def validate_phone(my_country, my_phone):
-	entry = Country.objects.get(name__iexact=my_country)
-	country_code = entry.code2
-	print country_code
+	try:
+		entry = Country.objects.get(name__iexact=my_country)
+		country_code = entry.code2
+	except:
+		print ('No matching country in database')
+		return "missing"
+	print (country_code)
 	parsed_number = phonenumbers.parse( my_phone, country_code)
 	return (phonenumbers.is_valid_number(parsed_number) and phonenumbers.is_possible_number(parsed_number))
 	

--- a/vms/registration/phone_validate.py
+++ b/vms/registration/phone_validate.py
@@ -1,0 +1,10 @@
+from cities_light.models import Country
+import phonenumbers
+
+def validate_phone(my_country, my_phone):
+	entry = Country.objects.get(name__iexact=my_country)
+	country_code = entry.code2
+	print country_code
+	parsed_number = phonenumbers.parse( my_phone, country_code)
+	return (phonenumbers.is_valid_number(parsed_number) and phonenumbers.is_possible_number(parsed_number))
+	

--- a/vms/registration/templates/registration/signup_administrator.html
+++ b/vms/registration/templates/registration/signup_administrator.html
@@ -258,6 +258,20 @@
                     </p>
                 </div>
             </div>
+        {% elif phone_error %}
+            <div id="div_id_phone_number" class="form-group has-error">
+                <label class="control-label requiredField" for="id_phone_number">
+                    Phone Number<span class="asteriskField">*</span>
+                </label>
+                <div class="controls">
+                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="Phone Number" name="admin-phone_number" value="{{ administrator_form.phone_number.value }}">
+                    <p class="help-block">
+                        <strong>
+                            This phone number isn't valid for the selected country
+                        </strong>
+                    </p>
+                </div>
+            </div>
         {% else %}
             <div id="div_id_phone_number" class="form-group">
                 <label class="control-label requiredField" for="id_phone_number">

--- a/vms/registration/templates/registration/signup_volunteer.html
+++ b/vms/registration/templates/registration/signup_volunteer.html
@@ -274,12 +274,26 @@
                     {% trans "Phone Number" %}<span class="asteriskField">*</span>
                 </label>
                 <div class="controls">
-                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="+999999999" name="vol-phone_number" value="{{ volunteer_form.phone_number.value }}">
+                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="Phone Number" name="vol-phone_number" value="{{ volunteer_form.phone_number.value }}">
                     <p class="help-block">
                         <strong>
                             {% for error in volunteer_form.phone_number.errors %}
                                 {{ error }}
                             {% endfor %}
+                        </strong>
+                    </p>
+                </div>
+            </div>
+        {% elif phone_error %}
+            <div id="div_id_phone_number" class="form-group has-error">
+                <label class="control-label requiredField" for="id_phone_number">
+                    Phone Number<span class="asteriskField">*</span>
+                </label>
+                <div class="controls">
+                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="Phone Number" name="vol-phone_number" value="{{ volunteer_form.phone_number.value }}">
+                    <p class="help-block">
+                        <strong>
+                            This phone number isn't valid for the selected country
                         </strong>
                     </p>
                 </div>
@@ -290,7 +304,7 @@
                     {% trans "Phone Number" %}<span class="asteriskField">*</span>
                 </label>
                 <div class="controls">
-                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="+999999999" name="vol-phone_number" value="{% if volunteer_form.phone_number.value %}{{ volunteer_form.phone_number.value }}{% endif %}">
+                    <input id="id_phone_number" class="textinput textInput form-control" type="text" placeholder="Phone Number" name="vol-phone_number" value="{% if volunteer_form.phone_number.value %}{{ volunteer_form.phone_number.value }}{% endif %}">
                 </div>
             </div>
         {% endif %}

--- a/vms/registration/views.py
+++ b/vms/registration/views.py
@@ -9,6 +9,7 @@ from organization.services import (get_organizations_ordered_by_name,
 from volunteer.forms import VolunteerForm
 from volunteer.validation import validate_file
 from registration.forms import UserForm
+from registration.phone_validate import validate_phone
 
 
 def signup_administrator(request):
@@ -21,6 +22,7 @@ def signup_administrator(request):
     """
     registered = False
     organization_list = get_organizations_ordered_by_name()
+    phone_error = False
 
     if organization_list:
         if request.method == 'POST':
@@ -29,6 +31,22 @@ def signup_administrator(request):
                                                    prefix="admin")
 
             if user_form.is_valid() and administrator_form.is_valid():
+
+                ad_country = request.POST.get('admin-country')
+                ad_phone = request.POST.get('admin-phone_number')
+
+                if (ad_country and ad_phone):
+                    if not validate_phone(ad_country, ad_phone):
+                        phone_error = True
+                        return render(request,
+                                      'registration/signup_administrator.html',
+                                      {'user_form': user_form,
+                                       'administrator_form': administrator_form,
+                                       'registered': registered,
+                                       'phone_error': phone_error,
+                                       'organization_list': organization_list,
+                                       })
+
                 user = user_form.save()
                 user.set_password(user.password)
                 user.save()
@@ -55,7 +73,9 @@ def signup_administrator(request):
                               {'user_form': user_form,
                                'administrator_form': administrator_form,
                                'registered': registered,
-                               'organization_list': organization_list, })
+                               'phone_error': phone_error,
+                               'organization_list': organization_list,
+                               })
         else:
             user_form = UserForm(prefix="usr")
             administrator_form = AdministratorForm(prefix="admin")
@@ -65,6 +85,7 @@ def signup_administrator(request):
                       {'user_form': user_form,
                        'administrator_form': administrator_form,
                        'registered': registered,
+                       'phone_error': phone_error,
                        'organization_list': organization_list, })
 
     else:
@@ -75,6 +96,7 @@ def signup_volunteer(request):
 
     registered = False
     organization_list = get_organizations_ordered_by_name()
+    phone_error = False
 
     if organization_list:
         if request.method == 'POST':
@@ -87,6 +109,21 @@ def signup_volunteer(request):
 
             if user_form.is_valid() and volunteer_form.is_valid():
 
+                vol_country = request.POST.get('vol-country')
+                vol_phone = request.POST.get('vol-phone_number')
+                if (vol_country and vol_phone):
+                    if not validate_phone(vol_country, vol_phone):
+                        phone_error = True
+                        return render(request,
+                            'registration/signup_volunteer.html',
+                            {'user_form': user_form,
+                            'volunteer_form': volunteer_form,
+                            'registered': registered,
+                            'phone_error': phone_error,
+                            'organization_list': organization_list,
+                            })
+                        
+
                 if 'resume_file' in request.FILES:
                     my_file = volunteer_form.cleaned_data['resume_file']
                     if not validate_file(my_file):
@@ -95,6 +132,7 @@ def signup_volunteer(request):
                                       {'user_form': user_form,
                                        'volunteer_form': volunteer_form,
                                        'registered': registered,
+                                       'phone_error': phone_error,
                                        'organization_list': organization_list,
                                        })
 
@@ -126,6 +164,7 @@ def signup_volunteer(request):
                               {'user_form': user_form,
                                'volunteer_form': volunteer_form,
                                'registered': registered,
+                               'phone_error': phone_error,
                                'organization_list': organization_list, })
         else:
             user_form = UserForm(prefix="usr")
@@ -135,6 +174,7 @@ def signup_volunteer(request):
                       {'user_form': user_form,
                        'volunteer_form': volunteer_form,
                        'registered': registered,
+                       'phone_error': phone_error,
                        'organization_list': organization_list, })
 
     else:

--- a/vms/vms/settings.py
+++ b/vms/vms/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = (
     'shift',
     'vms',
     'volunteer',
+    'cities_light',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/vms/volunteer/models.py
+++ b/vms/volunteer/models.py
@@ -62,8 +62,8 @@ class Volunteer(models.Model):
         max_length=20,
         validators=[
             RegexValidator(
-                r'^\+?1?\d{9,15}$',
-                message="Phone number must be entered in the format: '+999999999'. Up to 15 digits allowed.",
+                r'^\s*(?:\+?(\d{1,3}))?([-. (]*(\d{3})[-. )]*)?((\d{3})[-. ]*(\d{2,4})(?:[-.x ]*(\d+))?)\s*$',
+                message="Please enter a valid phone number",
             ),
         ],
     )


### PR DESCRIPTION
Earlier, there was no validation for phone numbers with respect to the country. This PR attempts to do that with the help of [python-phonenumbers](https://github.com/daviddrysdale/python-phonenumbers) package. I tested this change successfully for a few phone numbers (mostly India based) and verified it with [javascript](https://rawgit.com/googlei18n/libphonenumber/master/javascript/i18n/phonenumbers/demo-compiled.html) / [java](http://libphonenumber.appspot.com/) demo. Country codes available at [geonames](http://www.geonames.org/countries/)

There are two dependencies required - django-cities-light and phonenumbers.

For cities-light installation - [here](https://github.com/yourlabs/django-cities-light)
`pip install django-cities-light`
Adding to settings (already done)
`python manage.py migrate`  - cities light supports version of django 1.7 and above
`python manage.py cities_light`- populating database, this can take time

For phonenumbers `pip install phonenumbers` should work

django-cities-light has been used to get the country code based on entered country and then later the phone number is validated for that region. I have kept the phone validation script in the registration app, as it was called during both volunteer and admin registration.

This PR assumes that validation of countries and cities is done (I already saw a PR for this) and that a valid country is selected.

Fixes #129

Please review and let me know if something is wrong. I searched and narrowed down to this package as it seems to solve the problem with proper validation. However, if there is a better alternative, please suggest changes