### PR TITLE
Fixed editing issues for events and jobs

### DIFF
--- a/vms/event/services.py
+++ b/vms/event/services.py
@@ -32,9 +32,11 @@ def get_event_by_shift_id(shift_id):
 
     return result
 
-# need to check that this event is not accociated with any jobs,
-# otherwise the jobs that it is associated with will be cascade deleted
+
 def delete_event(event_id):
+    """ 
+    Deletes an event if no jobs are associated with it
+    """
 
     result = True
     event = get_event_by_id(event_id)
@@ -52,6 +54,31 @@ def delete_event(event_id):
         result = False
 
     return result
+
+def check_edit_event(event_id, new_start_date, new_end_date):
+    """ 
+    Checks if an event can be edited without resulting in invalid job or shift dates 
+    """
+    result = True
+    invalid_count = 0
+    invalid_jobs = []
+    event = get_event_by_id(event_id)
+
+    if event_not_empty(event_id) and event:
+        
+        jobs_in_event = event.job_set.all()
+        # check if there are currently any jobs associated with this event
+        if jobs_in_event:        
+            for job in jobs_in_event:
+                if( job.start_date < new_start_date or job.end_date > new_end_date):
+                    result = False
+                    invalid_count += 1
+                    invalid_jobs.append(job.name)
+
+    else:
+        result = False
+
+    return {'result' : result, 'invalid_count': invalid_count, 'invalid_jobs': invalid_jobs}
 
 
 def get_event_by_id(event_id):

--- a/vms/event/templates/event/edit_error.html
+++ b/vms/event/templates/event/edit_error.html
@@ -1,0 +1,17 @@
+{% extends "administrator/settings.html" %}
+
+{% block setting_content %}
+    <div class="spacer"></div>
+    <div class="alert alert-danger">
+        <h4>Error</h4>
+        <p>You cannot edit this event as the following associated job{{ count|pluralize }} no longer lie{{ count|pluralize:"s," }} within the new date range :</p>
+        <br>
+        <ul>
+            {% for job in jobs %}
+                <li>{{ job }}</li>
+                <br>
+            {% endfor %}
+        </ul>
+        <a href="{% url 'event:list' %}" class="btn btn-default">Return to Event List</a>
+    </div>
+{% endblock %}

--- a/vms/event/tests.py
+++ b/vms/event/tests.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
+import datetime
+from datetime import date
 
 from event.models import Event
 from job.models import Job
@@ -9,6 +11,7 @@ from volunteer.models import Volunteer
 from event.services import (
         event_not_empty,
         delete_event,
+        check_edit_event,
         get_event_by_id,
         get_events_ordered_by_name,
         get_events_by_date,
@@ -139,6 +142,77 @@ class EventMethodTests(TestCase):
         self.assertFalse(delete_event(200))
         self.assertFalse(delete_event(300))
 
+
+    def test_check_edit_event(self):
+        
+        e1 = Event(
+                name="Open Source Event",
+                start_date="2012-10-3",
+                end_date="2012-10-24"
+                )
+
+        e2 = Event(
+                name="Python Event",
+                start_date="2013-11-3",
+                end_date="2013-11-15"
+                )
+
+        e1.save()
+        e2.save()
+
+        j1 = Job(
+                name="Software Developer",
+                start_date="2012-10-22",
+                end_date="2012-10-23",
+                description="A software job",
+                event=e1
+                )
+
+        j2 = Job(
+                name="Systems Administrator",
+                start_date="2012-10-8",
+                end_date="2012-10-16",
+                description="A systems administrator job",
+                event=e1
+                )
+
+        j1.save()
+        j2.save()
+
+        # test typical cases
+
+        start_date1 = datetime.date(2012, 10, 8)
+        start_date2 = datetime.date(2012, 10, 7)
+        start_date3 = datetime.date(2012, 10, 15)
+        start_date4 = datetime.date(2013, 10, 8)
+        start_date5 = datetime.date(2015, 11, 4)
+        start_date6 = datetime.date(2013, 11, 1)
+        start_date7 = datetime.date(2012, 10, 7)
+        stop_date1 = datetime.date(2012, 10, 23)
+        stop_date2 = datetime.date(2012, 10, 22)
+        stop_date3 = datetime.date(2012, 10, 26)
+        stop_date4 = datetime.date(2013, 10, 23)
+        stop_date5 = datetime.date(2015, 11, 6)
+        stop_date6 = datetime.date(2013, 11, 7)
+        stop_date7 = datetime.date(2013, 10, 22)
+        
+        out1 = check_edit_event(e1.id, start_date1, stop_date1)
+        out2 = check_edit_event(e1.id, start_date2, stop_date2)
+        out3 = check_edit_event(e1.id, start_date3, stop_date3)
+        out4 = check_edit_event(e1.id, start_date4, stop_date4)
+        out5 = check_edit_event(e2.id, start_date5, stop_date5)
+        out6 = check_edit_event(100, start_date6, stop_date6)
+        out7 = check_edit_event(e1.id, start_date7, stop_date7)
+
+        self.assertTrue(out1['result'])
+        self.assertFalse(out2['result'])
+        self.assertFalse(out3['result'])
+        self.assertFalse(out4['result'])
+        self.assertTrue(out5['result'])
+        self.assertFalse(out6['result'])
+        self.assertTrue(out7['result'])
+
+
     def test_get_event_by_id(self):
         """ Test get_event_by_id(event_id) """
 
@@ -235,6 +309,8 @@ class EventMethodTests(TestCase):
         self.assertEqual(event_list[0], e3)
         self.assertEqual(event_list[1], e5)
         self.assertEqual(event_list[2], e4)
+
+
 
     def test_get_events_ordered_by_name(self):
         """ Test get_events_ordered_by_name() """

--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -74,6 +74,15 @@ def edit(request, event_id):
         if request.method == 'POST':
             form = EventForm(request.POST, instance=event)
             if form.is_valid():
+                start_date_event = form.cleaned_data['start_date']
+                end_date_event = form.cleaned_data['end_date']
+                event_edit = check_edit_event(event_id, start_date_event, end_date_event)
+                if not event_edit['result']:
+                    return render(
+                        request, 
+                        'event/edit_error.html', 
+                        {'count': event_edit['invalid_count'], 'jobs': event_edit['invalid_jobs']}
+                        )
                 form.save()
                 return HttpResponseRedirect(reverse('event:list'))
             else:

--- a/vms/job/services.py
+++ b/vms/job/services.py
@@ -13,9 +13,13 @@ def job_not_empty(job_id):
 
 
 def delete_job(job_id):
+    """ 
+    Deletes a job if no shifts are associated with it
+    """
 
     result = True
     job = get_job_by_id(job_id)
+
 
     if job_not_empty(job_id):
         shifts_in_job = job.shift_set.all()
@@ -26,6 +30,30 @@ def delete_job(job_id):
         result = False
 
     return result
+
+def check_edit_job(job_id, new_start_date, new_end_date):
+    """ 
+    Checks if a job can be edited without resulting in invalid shift date
+    """
+
+    result = True
+    invalid_count = 0
+    job = get_job_by_id(job_id)
+
+    if job_not_empty(job_id) and job:
+        
+        shifts_in_job = job.shift_set.all()
+        # check if there are currently any shifts associated with this job
+        if shifts_in_job:        
+            for shift in shifts_in_job:
+                if( shift.date < new_start_date or shift.date > new_end_date):
+                    result = False
+                    invalid_count += 1
+
+    else:
+        result = False
+
+    return {'result' : result, 'invalid_count': invalid_count}
 
 
 def get_job_by_id(job_id):

--- a/vms/job/templates/job/edit_error.html
+++ b/vms/job/templates/job/edit_error.html
@@ -1,0 +1,11 @@
+{% extends "administrator/settings.html" %}
+
+{% block setting_content %}
+    <div class="spacer"></div>
+    <div class="alert alert-danger">
+        <h4>Error</h4>
+        <p>You cannot edit this job as {{count}} associated shift{{ count|pluralize }} no longer lie{{ count|pluralize:"s," }} within the new date range</p>
+        <br>
+        <a href="{% url 'job:list' %}" class="btn btn-default">Return to Job List</a>
+    </div>
+{% endblock %}

--- a/vms/job/tests.py
+++ b/vms/job/tests.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
+import datetime
+from datetime import date
 
 from event.models import Event
 from job.models import Job
@@ -8,6 +10,7 @@ from shift.models import Shift
 from volunteer.models import Volunteer
 from job.services import (
                             delete_job,
+                            check_edit_job,
                             get_job_by_id,
                             get_jobs_by_event_id,
                             get_jobs_ordered_by_title,
@@ -63,6 +66,85 @@ class JobMethodTests(TestCase):
         self.assertFalse(delete_job(100))
         self.assertFalse(delete_job(200))
         self.assertFalse(delete_job(300))
+
+
+    def test_check_edit_job(self):
+        
+        e1 = Event(
+                name="Open Source Event",
+                start_date="2012-10-3",
+                end_date="2012-10-24"
+                )
+
+        e1.save()
+
+        j1 = Job(
+                name="Software Developer",
+                start_date="2012-10-22",
+                end_date="2012-10-23",
+                description="A software job",
+                event=e1
+                )
+
+        j2 = Job(
+                name="Systems Administrator",
+                start_date="2012-10-8",
+                end_date="2012-10-16",
+                description="A systems administrator job",
+                event=e1
+                )
+
+        j1.save()
+        j2.save()
+
+        s1 = Shift(
+                date="2012-10-23",
+                start_time="1:00",
+                end_time="3:00",
+                max_volunteers=5,
+                job=j1
+                )
+
+        s2 = Shift(
+                date="2012-10-25",
+                start_time="2:00",
+                end_time="4:00",
+                max_volunteers=5,
+                job=j1
+                )
+
+        s1.save()
+        s2.save()
+
+        # test typical cases
+
+        start_date1 = datetime.date(2012, 10, 23)
+        start_date2 = datetime.date(2012, 10, 25)
+        start_date3 = datetime.date(2012, 10, 2)
+        start_date4 = datetime.date(2013, 10, 8)
+        start_date5 = datetime.date(2015, 11, 4)
+        start_date6 = datetime.date(2013, 11, 1)
+        stop_date1 = datetime.date(2012, 10, 28)
+        stop_date2 = datetime.date(2012, 10, 29)
+        stop_date3 = datetime.date(2012, 10, 24)
+        stop_date4 = datetime.date(2013, 10, 20)
+        stop_date5 = datetime.date(2015, 11, 6)
+        stop_date6 = datetime.date(2013, 11, 7)
+        
+        out1 = check_edit_job(j1.id, start_date1, stop_date1)
+        out2 = check_edit_job(j1.id, start_date2, stop_date2)
+        out3 = check_edit_job(j1.id, start_date3, stop_date3)
+        out4 = check_edit_job(j1.id, start_date4, stop_date4)
+        out5 = check_edit_job(j2.id, start_date5, stop_date5)
+        out6 = check_edit_job(100, start_date6, stop_date6)
+
+        self.assertTrue(out1['result'])
+        self.assertFalse(out2['result'])
+        self.assertFalse(out3['result'])
+        self.assertFalse(out4['result'])
+        self.assertTrue(out5['result'])
+        self.assertFalse(out6['result'])
+
 
     def test_get_job_by_id(self):
 

--- a/vms/job/views.py
+++ b/vms/job/views.py
@@ -119,6 +119,15 @@ def edit(request, job_id):
         if request.method == 'POST':
             form = JobForm(request.POST, instance=job)
             if form.is_valid():
+                start_date_job = form.cleaned_data['start_date']
+                end_date_job = form.cleaned_data['end_date']
+                job_edit = check_edit_job(job_id, start_date_job, end_date_job)
+                if not job_edit['result']:
+                    return render(
+                        request, 
+                        'job/edit_error.html', 
+                        {'count': job_edit['invalid_count']}
+                        )
                 job_to_edit = form.save(commit=False)
                 event_id = request.POST.get('event_id')
                 event = get_event_by_id(event_id)


### PR DESCRIPTION
Earlier:
The dates of an event could be changed anytime after its creation. However, there was no check for its jobs to see if it still falls within the new date range. A similar situation existed for jobs and shifts. 

This PR attempts to allow editing of event/job in two possible situations:
1. There are no associated jobs/shifts
2. If dates are changed for event/job and they don't result in discrepancies for associated jobs/shifts

In remaining cases, editing is not allowed and an appropriate error message is displayed as shown below:

![editing_fix](https://cloud.githubusercontent.com/assets/13931206/12666462/24c87c9a-c667-11e5-80a9-c1a55655aaf2.png)

Since I have added some functions in services.py, I have added tests for them.

Fixes #210 

Please review changes and suggest any possible improvements