### PR TITLE
Fixes validity errors while editing shifts and indentation errors in the file

### DIFF
--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -239,13 +239,18 @@ def create(request, job_id):
                         start_date_job=job.start_date
                         end_date_job=job.end_date
                         shift_date=form.cleaned_data['date']
-                        if( shift_date >= start_date_job and shift_date <= end_date_job ):
+                        shift_start_time=form.cleaned_data['start_time']
+                        shift_end_time=form.cleaned_data['end_time']
+                        if( shift_date >= start_date_job and shift_date <= end_date_job and shift_end_time > shift_start_time):
                             shift = form.save(commit=False)
                             shift.job = job
                             shift.save()
                             return HttpResponseRedirect(reverse('shift:list_shifts', args=(job_id,)))
                         else:
-                            messages.add_message(request, messages.INFO, 'Shift date should lie within Job dates')
+                            if (shift_date < start_date_job or shift_date > end_date_job):
+                                messages.add_message(request, messages.INFO, 'Shift date should lie within Job dates')
+                            if shift_end_time <= shift_start_time:
+                                messages.add_message(request, messages.INFO, 'Shift end time should be greater than start time')
                             return render(
                             request,
                             'shift/create.html',

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -326,58 +326,44 @@ def edit(request, shift_id):
         shift = None
         if shift_id:
             shift = get_shift_by_id(shift_id)
+            job=shift.job
 
         if request.method == 'POST':
-            form = ShiftForm(request.POST, instance=shift)
-            if form.is_valid():
-                shift_to_edit = form.save(commit=False)
-                
-		job=shift.job
-		if job:
-                    shift_to_edit.job = job
-                else:
-                    raise Http404
-		
-		start_date_job=job.start_date
-		end_date_job=job.end_date
-                shift_date=form.cleaned_data['date']
+            if job:
+                form = ShiftForm(request.POST, instance=shift)
+                if form.is_valid():
 
-		shift_start_time=form.cleaned_data['start_time']
-		shift_end_time=form.cleaned_data['end_time']
-		if( shift_date >= start_date_job and shift_date <= end_date_job ):
-			if(shift_end_time>shift_start_time):
-                            shift = form.save(commit=False)
-                            shift.job = job
-                            shift.save()
-                            return HttpResponseRedirect(reverse('shift:list_shifts', args=(shift.job.id,)))
+                    start_date_job = job.start_date
+                    end_date_job = job.end_date
+                    shift_date=form.cleaned_data['date']
+                    shift_start_time=form.cleaned_data['start_time']
+                    shift_end_time=form.cleaned_data['end_time']
 
-			else:
-			    messages.add_message(request, messages.INFO, 'Shift end time should be greater than start time')
-                            return render(
-                            request,
-                            'shift/edit.html',
-                            {'form': form, 'shift': shift, 'job': shift.job }
-                            )
-
-                else:
+                    #save when all conditions satisfied
+                    if( shift_date >= start_date_job and shift_date <= end_date_job and shift_end_time > shift_start_time):
+                        shift_to_edit = form.save(commit=False)
+                        shift_to_edit.job = job
+                        shift_to_edit.save()
+                        return HttpResponseRedirect(reverse('shift:list_shifts', args=(shift.job.id,)))
+                    else:
+                        if (shift_date < start_date_job or shift_date > end_date_job):
                             messages.add_message(request, messages.INFO, 'Shift date should lie within Job dates')
-                            return render(
-                    	    request,
+                        if shift_end_time <= shift_start_time:
+                            messages.add_message(request, messages.INFO, 'Shift end time should be greater than start time')
+                        return render(
+                            request,
                             'shift/edit.html',
                             {'form': form, 'shift': shift, 'job': shift.job}
                             )
-
-		shift_to_edit.save()
-                return HttpResponseRedirect(reverse(
-                    'shift:list_shifts',
-                    args=(shift.job.id, )
-                    ))
+                else:
+                    return render(
+                        request,
+                        'shift/edit.html',
+                        {'form': form, 'shift': shift, 'job': shift.job}
+                        )
             else:
-                return render(
-                    request,
-                    'shift/edit.html',
-                    {'form': form, 'shift': shift, 'job': shift.job}
-                    )
+                raise Http404
+
         else:
             form = ShiftForm(instance=shift)
             return render(

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -23,24 +23,21 @@ def add_hours(request, shift_id, volunteer_id):
                     start_time = form.cleaned_data['start_time']
                     end_time = form.cleaned_data['end_time']
                     try:
-			if(end_time>start_time):
-                        	 add_shift_hours(
-                           	 volunteer_id,
-                           	 shift_id,
-                           	 start_time,
-                           	 end_time
-                            	 )
-                        	 return HttpResponseRedirect(reverse(
-                                	'shift:view_hours',
-                                	args=(volunteer_id,)
-                                	))
-			else:
-				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
-				return render(
-                        	request,
-                        	'shift/add_hours.html',
-                        	{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                        	)
+                        if(end_time>start_time):
+                            add_shift_hours(
+                                volunteer_id,
+                                shift_id,
+                                start_time,
+                                end_time
+                                )
+                            return HttpResponseRedirect(reverse('shift:view_hours',args=(volunteer_id,)))
+                        else:
+                            messages.add_message(request, messages.INFO, 'End time should be greater than start time')
+                            return render(
+                                request,
+                                'shift/add_hours.html',
+                                {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
+                                )
                     except:
                         raise Http404
                 else:
@@ -82,23 +79,23 @@ def add_hours_manager(request, shift_id, volunteer_id):
                 end_time = form.cleaned_data['end_time']
                 try:
                     if(end_time>start_time):
-                        	 add_shift_hours(
-                           	 volunteer_id,
-                           	 shift_id,
-                           	 start_time,
-                           	 end_time
-                            	 )
-                        	 return HttpResponseRedirect(reverse(
-                        	 'shift:manage_volunteer_shifts',
-                        	 args=(volunteer_id, )
-                        	 ))
-		    else:
-				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
-				return render(
-                    		request,
-                    		'shift/add_hours_manager.html',
-                    		{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                    		)
+                        add_shift_hours(
+                            volunteer_id,
+                            shift_id,
+                            start_time,
+                            end_time
+                            )
+                        return HttpResponseRedirect(reverse(
+                            'shift:manage_volunteer_shifts',
+                            args=(volunteer_id, )
+                            ))
+                    else:
+                        messages.add_message(request, messages.INFO, 'End time should be greater than start time')
+                        return render(
+                            request,
+                            'shift/add_hours_manager.html',
+                            {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
+                            )
                 except:
                     raise Http404
             else:
@@ -387,22 +384,21 @@ def edit_hours(request, shift_id, volunteer_id):
                         start_time = form.cleaned_data['start_time']
                         end_time = form.cleaned_data['end_time']
                         try:
-			    if(end_time>start_time):
-                        	edit_shift_hours(
-                                volunteer_id,
-                                shift_id,
-                                start_time,
-                                end_time
-                                )
-                            	return HttpResponseRedirect(reverse('shift:view_hours', args=(volunteer_id,)))
-			    else:
-				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
-				return render(
-                        	request,
-                            	'shift/edit_hours.html',
-                            	{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                            	)
-                            
+                            if(end_time>start_time):
+                                edit_shift_hours(
+                                    volunteer_id,
+                                    shift_id,
+                                    start_time,
+                                    end_time
+                                    )
+                                return HttpResponseRedirect(reverse('shift:view_hours', args=(volunteer_id,)))
+                            else:
+                                messages.add_message(request, messages.INFO, 'End time should be greater than start time')
+                                return render(
+                                    request,
+                                    'shift/edit_hours.html',
+                                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
+                                    )                            
                         except:
                             raise Http404
                     else:
@@ -448,17 +444,16 @@ def edit_hours_manager(request, shift_id, volunteer_id):
                         start_time = form.cleaned_data['start_time']
                         end_time = form.cleaned_data['end_time']
                         try:
-			    if(end_time>start_time):
-                        	edit_shift_hours(volunteer_id, shift_id, start_time, end_time)
+                            if(end_time>start_time):
+                                edit_shift_hours(volunteer_id, shift_id, start_time, end_time)
                                 return HttpResponseRedirect(reverse('shift:manage_volunteer_shifts', args=(volunteer_id,)))
-			    else:
-				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
-				return render(
-                        	request,
-                            	'shift/edit_hours_manager.html',
-                            	{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                            	)
-                            
+                            else:
+                                messages.add_message(request, messages.INFO, 'End time should be greater than start time')
+                                return render(
+                                    request,
+                                    'shift/edit_hours_manager.html',
+                                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
+                                    )                            
                         except:
                             raise Http404
                     else:


### PR DESCRIPTION
Fixes #228 and #236 

The previous code after a recent merge seemed to have some indentation issues and duplicated code :worried: .due to which the above error were faced

After these changes:
1. It is checked that the shift dates lie between the job dates while editing
2. The concerns in #195 for logging hours are addressed
3. Merged with latest change to check time for edit shifts
4. Added time check for create shifts

Please do crosscheck and suggest changes