### PR TITLE
Fixed editing issues for events and jobs

### DIFF
--- a/vms/event/services.py
+++ b/vms/event/services.py
@@ -32,9 +32,10 @@ def get_event_by_shift_id(shift_id):
 
     return result
 
-# need to check that this event is not accociated with any jobs,
-# otherwise the jobs that it is associated with will be cascade deleted
 def delete_event(event_id):
+    """ 
+    Deletes an event if no jobs are associated with it
+    """
 
     result = True
     event = get_event_by_id(event_id)

--- a/vms/event/services.py
+++ b/vms/event/services.py
@@ -53,6 +53,31 @@ def delete_event(event_id):
 
     return result
 
+def check_edit_event(event_id, new_start_date, new_end_date):
+    """
+    Checks if an event can be edited without resulting in invalid job or shift dates
+    """
+    result = True
+    invalid_count = 0
+    invalid_jobs = []
+    event = get_event_by_id(event_id)
+
+    if event_not_empty(event_id) and event:
+
+        jobs_in_event = event.job_set.all()
+        # check if there are currently any jobs associated with this event
+        if jobs_in_event:
+            for job in jobs_in_event:
+                if( job.start_date < new_start_date or job.end_date > new_end_date):
+                    result = False
+                    invalid_count += 1
+                    invalid_jobs.append(job.name)
+
+    else:
+        result = False
+
+    return {'result' : result, 'invalid_count': invalid_count, 'invalid_jobs': invalid_jobs}
+
 
 def get_event_by_id(event_id):
 

--- a/vms/event/templates/event/edit_error.html
+++ b/vms/event/templates/event/edit_error.html
@@ -1,0 +1,17 @@
+{% extends "administrator/settings.html" %}
+
+{% block setting_content %}
+    <div class="spacer"></div>
+    <div class="alert alert-danger">
+        <h4>Error</h4>
+        <p>You cannot edit this event as the following associated job{{ count|pluralize }} no longer lie{{ count|pluralize:"s," }} within the new date range :</p>
+        <br>
+        <ul>
+            {% for job in jobs %}
+                <li>{{ job }}</li>
+                <br>
+            {% endfor %}
+        </ul>
+        <a href="{% url 'event:list' %}" class="btn btn-default">Return to Event List</a>
+    </div>
+{% endblock %}

--- a/vms/event/tests.py
+++ b/vms/event/tests.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
+import datetime
+from datetime import date
 
 from event.models import Event
 from job.models import Job
@@ -9,6 +11,7 @@ from volunteer.models import Volunteer
 from event.services import (
         event_not_empty,
         delete_event,
+        check_edit_event,
         get_event_by_id,
         get_events_ordered_by_name,
         get_events_by_date,
@@ -138,6 +141,77 @@ class EventMethodTests(TestCase):
         self.assertFalse(delete_event(100))
         self.assertFalse(delete_event(200))
         self.assertFalse(delete_event(300))
+
+
+    def test_check_edit_event(self):
+
+        e1 = Event(
+                name="Open Source Event",
+                start_date="2012-10-3",
+                end_date="2012-10-24"
+                )
+
+        e2 = Event(
+                name="Python Event",
+                start_date="2013-11-3",
+                end_date="2013-11-15"
+                )
+
+        e1.save()
+        e2.save()
+
+        j1 = Job(
+                name="Software Developer",
+                start_date="2012-10-22",
+                end_date="2012-10-23",
+                description="A software job",
+                event=e1
+                )
+
+        j2 = Job(
+                name="Systems Administrator",
+                start_date="2012-10-8",
+                end_date="2012-10-16",
+                description="A systems administrator job",
+                event=e1
+                )
+
+        j1.save()
+        j2.save()
+
+        # test typical cases
+
+        start_date1 = datetime.date(2012, 10, 8)
+        start_date2 = datetime.date(2012, 10, 7)
+        start_date3 = datetime.date(2012, 10, 15)
+        start_date4 = datetime.date(2013, 10, 8)
+        start_date5 = datetime.date(2015, 11, 4)
+        start_date6 = datetime.date(2013, 11, 1)
+        start_date7 = datetime.date(2012, 10, 7)
+        stop_date1 = datetime.date(2012, 10, 23)
+        stop_date2 = datetime.date(2012, 10, 22)
+        stop_date3 = datetime.date(2012, 10, 26)
+        stop_date4 = datetime.date(2013, 10, 23)
+        stop_date5 = datetime.date(2015, 11, 6)
+        stop_date6 = datetime.date(2013, 11, 7)
+        stop_date7 = datetime.date(2013, 10, 22)
+
+        out1 = check_edit_event(e1.id, start_date1, stop_date1)
+        out2 = check_edit_event(e1.id, start_date2, stop_date2)
+        out3 = check_edit_event(e1.id, start_date3, stop_date3)
+        out4 = check_edit_event(e1.id, start_date4, stop_date4)
+        out5 = check_edit_event(e2.id, start_date5, stop_date5)
+        out6 = check_edit_event(100, start_date6, stop_date6)
+        out7 = check_edit_event(e1.id, start_date7, stop_date7)
+
+        self.assertTrue(out1['result'])
+        self.assertFalse(out2['result'])
+        self.assertFalse(out3['result'])
+        self.assertFalse(out4['result'])
+        self.assertTrue(out5['result'])
+        self.assertFalse(out6['result'])
+        self.assertTrue(out7['result'])
+
 
     def test_get_event_by_id(self):
         """ Test get_event_by_id(event_id) """

--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -74,6 +74,15 @@ def edit(request, event_id):
         if request.method == 'POST':
             form = EventForm(request.POST, instance=event)
             if form.is_valid():
+                start_date_event = form.cleaned_data['start_date']
+                end_date_event = form.cleaned_data['end_date']
+                event_edit = check_edit_event(event_id, start_date_event, end_date_event)
+                if not event_edit['result']:
+                    return render(
+                        request,
+                        'event/edit_error.html',
+                        {'count': event_edit['invalid_count'], 'jobs': event_edit['invalid_jobs']}
+                        )
                 form.save()
                 return HttpResponseRedirect(reverse('event:list'))
             else:

--- a/vms/job/services.py
+++ b/vms/job/services.py
@@ -13,7 +13,9 @@ def job_not_empty(job_id):
 
 
 def delete_job(job_id):
-
+    """
+    Deletes a job if no shifts are associated with it
+    """
     result = True
     job = get_job_by_id(job_id)
 
@@ -26,6 +28,31 @@ def delete_job(job_id):
         result = False
 
     return result
+
+
+def check_edit_job(job_id, new_start_date, new_end_date):
+    """
+    Checks if a job can be edited without resulting in invalid shift date
+    """
+
+    result = True
+    invalid_count = 0
+    job = get_job_by_id(job_id)
+
+    if job_not_empty(job_id) and job:
+
+        shifts_in_job = job.shift_set.all()
+        # check if there are currently any shifts associated with this job
+        if shifts_in_job:
+            for shift in shifts_in_job:
+                if( shift.date < new_start_date or shift.date > new_end_date):
+                    result = False
+                    invalid_count += 1
+
+    else:
+        result = False
+
+    return {'result' : result, 'invalid_count': invalid_count}
 
 
 def get_job_by_id(job_id):

--- a/vms/job/templates/job/edit_error.html
+++ b/vms/job/templates/job/edit_error.html
@@ -1,0 +1,11 @@
+{% extends "administrator/settings.html" %}
+
+{% block setting_content %}
+    <div class="spacer"></div>
+    <div class="alert alert-danger">
+        <h4>Error</h4>
+        <p>You cannot edit this job as {{count}} associated shift{{ count|pluralize }} no longer lie{{ count|pluralize:"s," }} within the new date range</p>
+        <br>
+        <a href="{% url 'job:list' %}" class="btn btn-default">Return to Job List</a>
+    </div>
+{% endblock %}

--- a/vms/job/views.py
+++ b/vms/job/views.py
@@ -118,7 +118,7 @@ def edit(request, job_id):
 
         if request.method == 'POST':
             form = JobForm(request.POST, instance=job)
-            
+
             if form.is_valid():
 
                 event_id = request.POST.get('event_id')
@@ -127,6 +127,14 @@ def edit(request, job_id):
                 end_date_event=event.end_date
                 start_date_job=form.cleaned_data.get('start_date')
                 end_date_job=form.cleaned_data.get('end_date')
+
+                job_edit = check_edit_job(job_id, start_date_job, end_date_job)
+                if not job_edit['result']:
+                    return render(
+                        request,
+                        'job/edit_error.html',
+                        {'count': job_edit['invalid_count']}
+                        )
 
                 if(start_date_job>=start_date_event and end_date_job<=end_date_event):
                     job_to_edit = form.save(commit=False)

--- a/vms/job/views.py
+++ b/vms/job/views.py
@@ -118,27 +118,23 @@ def edit(request, job_id):
 
         if request.method == 'POST':
             form = JobForm(request.POST, instance=job)
+            
             if form.is_valid():
-                job_to_edit = form.save(commit=False)
+
                 event_id = request.POST.get('event_id')
                 event = get_event_by_id(event_id)
-                if event:
-                    job_to_edit.event = event
-                else:
-                    raise Http404
-                job_to_edit.save()
-                
-		start_date_event=event.start_date
+                start_date_event=event.start_date
                 end_date_event=event.end_date
                 start_date_job=form.cleaned_data.get('start_date')
                 end_date_job=form.cleaned_data.get('end_date')
+
                 if(start_date_job>=start_date_event and end_date_job<=end_date_event):
-                    job = form.save(commit=False)
+                    job_to_edit = form.save(commit=False)
                     if event:
-                        job.event = event
+                        job_to_edit.event = event
                     else:
                         raise Http404
-                    job.save()
+                    job_to_edit.save()
                     return HttpResponseRedirect(reverse('job:list'))
                 else:
                     messages.add_message(request, messages.INFO, 'Job dates should lie within Event dates')
@@ -147,7 +143,6 @@ def edit(request, job_id):
                     'job/edit.html',
                     {'form': form, 'event_list': event_list , 'job': job}
                     )
-		return HttpResponseRedirect(reverse('job:list'))
 
             else:
                 return render(


### PR DESCRIPTION
This PR attempts to allow editing of event/job in two possible situations:
1. There are no associated jobs/shifts
2. If dates are changed for event/job and they don't result in discrepancies for associated jobs/shifts

In remaining cases, editing is not allowed and an appropriate error message is displayed as shown below:

![editing_fix](https://cloud.githubusercontent.com/assets/13931206/12666462/24c87c9a-c667-11e5-80a9-c1a55655aaf2.png)

Since I have added some functions in services.py, I have added tests for them.

I have broken down the commits in a previous PR ( #212) and made a new request. In addition, while editing jobs/views.py I came across some other errors which occur in the jobs view ( Please see #229 ). I have tried to resolve these. 

![correct](https://cloud.githubusercontent.com/assets/13931206/13171847/fbc2543c-d71a-11e5-94d1-509ce1270a78.gif)

So now additionally,

1. While editing jobs, job dates are checked to see if they lie in the valid range.
2. While editing shifts, shift dates are checked to see if they lie in valid range.

Fixes #210
Also fixes #229  or  #192

Please review changes and suggest any possible improvements