### PR TITLE
Change the default username and password in settings file

### DIFF
--- a/vms/vms/settings.py
+++ b/vms/vms/settings.py
@@ -61,8 +61,8 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'vms',
-        'USER': 'myuser',
-        'PASSWORD': 'mypassword',
+        'USER': 'vmsadmin',
+        'PASSWORD': '0xdeadbeef',
         'HOST': 'localhost',
     }
 }


### PR DESCRIPTION
This fixes the error **password authentication failed for user "myuser"**. 

It was also pointed by a GCI participant, [here](http://gci-maydha.blogspot.in/2015/12/installing-volunteer-management-system.html).