### PR TITLE
Fixed shifts save error and appropriate return to job shifts after save operation

### DIFF
--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -356,7 +356,7 @@ def edit(request, shift_id):
                     )
                 return HttpResponseRedirect(reverse(
                     'shift:list_shifts',
-                    args=(shift.job.id,)
+                    args=(job.id,)
                 ))
             else:
                 return render(

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -12,6 +12,7 @@ from volunteer.forms import SearchVolunteerForm
 from volunteer.services import get_all_volunteers, search_volunteers
 from django.contrib import messages
 
+
 @login_required
 def add_hours(request, shift_id, volunteer_id):
     if shift_id and volunteer_id:
@@ -23,24 +24,24 @@ def add_hours(request, shift_id, volunteer_id):
                     start_time = form.cleaned_data['start_time']
                     end_time = form.cleaned_data['end_time']
                     try:
-			if(end_time>start_time):
-                        	 add_shift_hours(
-                           	 volunteer_id,
-                           	 shift_id,
-                           	 start_time,
-                           	 end_time
-                            	 )
-                        	 return HttpResponseRedirect(reverse(
-                                	'shift:view_hours',
-                                	args=(volunteer_id,)
-                                	))
-			else:
-				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
-				return render(
-                        	request,
-                        	'shift/add_hours.html',
-                        	{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                        	)
+                        if (end_time > start_time):
+                            add_shift_hours(
+                                volunteer_id,
+                                shift_id,
+                                start_time,
+                                end_time
+                            )
+                            return HttpResponseRedirect(reverse(
+                                'shift:view_hours',
+                                args=(volunteer_id,)
+                            ))
+                        else:
+                            messages.add_message(request, messages.INFO, 'End time should be greater than start time')
+                            return render(
+                                request,
+                                'shift/add_hours.html',
+                                {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
+                            )
                     except:
                         raise Http404
                 else:
@@ -48,14 +49,14 @@ def add_hours(request, shift_id, volunteer_id):
                         request,
                         'shift/add_hours.html',
                         {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                        )
+                    )
             else:
                 form = HoursForm()
                 return render(
                     request,
                     'shift/add_hours.html',
                     {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                    )
+                )
         else:
             return HttpResponse(status=403)
     else:
@@ -81,24 +82,24 @@ def add_hours_manager(request, shift_id, volunteer_id):
                 start_time = form.cleaned_data['start_time']
                 end_time = form.cleaned_data['end_time']
                 try:
-                    if(end_time>start_time):
-                        	 add_shift_hours(
-                           	 volunteer_id,
-                           	 shift_id,
-                           	 start_time,
-                           	 end_time
-                            	 )
-                        	 return HttpResponseRedirect(reverse(
-                        	 'shift:manage_volunteer_shifts',
-                        	 args=(volunteer_id, )
-                        	 ))
-		    else:
-				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
-				return render(
-                    		request,
-                    		'shift/add_hours_manager.html',
-                    		{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                    		)
+                    if (end_time > start_time):
+                        add_shift_hours(
+                            volunteer_id,
+                            shift_id,
+                            start_time,
+                            end_time
+                        )
+                        return HttpResponseRedirect(reverse(
+                            'shift:manage_volunteer_shifts',
+                            args=(volunteer_id,)
+                        ))
+                    else:
+                        messages.add_message(request, messages.INFO, 'End time should be greater than start time')
+                        return render(
+                            request,
+                            'shift/add_hours_manager.html',
+                            {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
+                        )
                 except:
                     raise Http404
             else:
@@ -106,19 +107,18 @@ def add_hours_manager(request, shift_id, volunteer_id):
                     request,
                     'shift/add_hours_manager.html',
                     {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                    )
+                )
         else:
             form = HoursForm()
             return render(
                 request,
                 'shift/add_hours_manager.html',
                 {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                )
+            )
 
 
 @login_required
 def cancel(request, shift_id, volunteer_id):
-
     if shift_id and volunteer_id:
 
         user = request.user
@@ -149,13 +149,13 @@ def cancel(request, shift_id, volunteer_id):
                 if admin:
                     return HttpResponseRedirect(reverse(
                         'shift:manage_volunteer_shifts',
-                        args=(volunteer_id, )
-                        ))
+                        args=(volunteer_id,)
+                    ))
                 elif volunteer:
                     return HttpResponseRedirect(reverse(
                         'shift:view_volunteer_shifts',
-                        args=(volunteer_id, )
-                        ))
+                        args=(volunteer_id,)
+                    ))
                 else:
                     raise Http404
             except:
@@ -165,22 +165,21 @@ def cancel(request, shift_id, volunteer_id):
                 request,
                 'shift/cancel_shift.html',
                 {'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                )
+            )
     else:
         raise Http404
 
 
 @login_required
 def clear_hours(request, shift_id, volunteer_id):
-
     if shift_id and volunteer_id:
         if request.method == 'POST':
             result = clear_shift_hours(volunteer_id, shift_id)
             if result:
                 return HttpResponseRedirect(reverse(
                     'shift:view_hours',
-                    args=(volunteer_id, )
-                    ))
+                    args=(volunteer_id,)
+                ))
             else:
                 raise Http404
         else:
@@ -208,8 +207,8 @@ def clear_hours_manager(request, shift_id, volunteer_id):
                 if result:
                     return HttpResponseRedirect(reverse(
                         'shift:manage_volunteer_shifts',
-                        args=(volunteer_id, )
-                        ))
+                        args=(volunteer_id,)
+                    ))
                 else:
                     raise Http404
             else:
@@ -239,10 +238,10 @@ def create(request, job_id):
                 if job:
                     form = ShiftForm(request.POST)
                     if form.is_valid():
-                        start_date_job=job.start_date
-                        end_date_job=job.end_date
-                        shift_date=form.cleaned_data['date']
-                        if( shift_date >= start_date_job and shift_date <= end_date_job ):
+                        start_date_job = job.start_date
+                        end_date_job = job.end_date
+                        shift_date = form.cleaned_data['date']
+                        if (shift_date >= start_date_job and shift_date <= end_date_job):
                             shift = form.save(commit=False)
                             shift.job = job
                             shift.save()
@@ -250,17 +249,17 @@ def create(request, job_id):
                         else:
                             messages.add_message(request, messages.INFO, 'Shift date should lie within Job dates')
                             return render(
-                            request,
-                            'shift/create.html',
-                            {'form': form, 'job_id': job_id, 'job': job }
+                                request,
+                                'shift/create.html',
+                                {'form': form, 'job_id': job_id, 'job': job}
                             )
 
                     else:
                         return render(
                             request,
                             'shift/create.html',
-                            {'form': form, 'job_id': job_id, 'job': job }
-                            )
+                            {'form': form, 'job_id': job_id, 'job': job}
+                        )
                 else:
                     raise Http404
             else:
@@ -273,8 +272,9 @@ def create(request, job_id):
                 return render(
                     request,
                     'shift/create.html',
-                    {'form': form, 'job_id': job_id, 'country': country, 'state': state, 'city': city, 'address': address, 'venue': venue, 'job': job}
-                    )
+                    {'form': form, 'job_id': job_id, 'country': country, 'state': state, 'city': city,
+                     'address': address, 'venue': venue, 'job': job}
+                )
         else:
             raise Http404
 
@@ -304,7 +304,7 @@ def delete(request, shift_id):
                 request,
                 'shift/delete.html',
                 {'shift_id': shift_id}
-                )
+            )
         else:
             raise Http404
 
@@ -331,51 +331,50 @@ def edit(request, shift_id):
             form = ShiftForm(request.POST, instance=shift)
             if form.is_valid():
                 shift_to_edit = form.save(commit=False)
-                
-		job=shift.job
-		if job:
+
+                job = shift.job
+                if job:
                     shift_to_edit.job = job
                 else:
                     raise Http404
                 shift_to_edit.save()
-		
-		start_date_job=job.start_date
-		end_date_job=job.end_date
-                shift_date=form.cleaned_data['date']
-		if( shift_date >= start_date_job and shift_date <= end_date_job ):
-                            shift = form.save(commit=False)
-                            shift.job = job
-                            shift.save()
-                            return HttpResponseRedirect(reverse('shift:list_shifts', args=(shift_id,)))
+
+                start_date_job = job.start_date
+                end_date_job = job.end_date
+                shift_date = form.cleaned_data['date']
+                if (shift_date >= start_date_job and shift_date <= end_date_job):
+                    shift = form.save(commit=False)
+                    shift.job = job
+                    shift.save()
+                    return HttpResponseRedirect(reverse('shift:list_shifts', args=(job.id,)))
                 else:
-                            messages.add_message(request, messages.INFO, 'Shift date should lie within Job dates')
-                            return render(
-                    	    request,
-                            'shift/edit.html',
-                            {'form': form, 'shift': shift, 'job': shift.job}
-                            )
+                    messages.add_message(request, messages.INFO, 'Shift date should lie within Job dates')
+                    return render(
+                        request,
+                        'shift/edit.html',
+                        {'form': form, 'shift': shift, 'job': shift.job}
+                    )
                 return HttpResponseRedirect(reverse(
                     'shift:list_shifts',
-                    args=(shift.job.id, )
-                    ))
+                    args=(shift.job.id,)
+                ))
             else:
                 return render(
                     request,
                     'shift/edit.html',
                     {'form': form, 'shift': shift, 'job': shift.job}
-                    )
+                )
         else:
             form = ShiftForm(instance=shift)
             return render(
                 request,
                 'shift/edit.html',
                 {'form': form, 'shift': shift, 'job': shift.job}
-                )
+            )
 
 
 @login_required
 def edit_hours(request, shift_id, volunteer_id):
-
     if shift_id and volunteer_id:
         volunteer_shift = get_volunteer_shift_by_id(volunteer_id, shift_id)
         user = request.user
@@ -387,22 +386,23 @@ def edit_hours(request, shift_id, volunteer_id):
                         start_time = form.cleaned_data['start_time']
                         end_time = form.cleaned_data['end_time']
                         try:
-			    if(end_time>start_time):
-                        	edit_shift_hours(
-                                volunteer_id,
-                                shift_id,
-                                start_time,
-                                end_time
+                            if (end_time > start_time):
+                                edit_shift_hours(
+                                    volunteer_id,
+                                    shift_id,
+                                    start_time,
+                                    end_time
                                 )
-                            	return HttpResponseRedirect(reverse('shift:view_hours', args=(volunteer_id,)))
-			    else:
-				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
-				return render(
-                        	request,
-                            	'shift/edit_hours.html',
-                            	{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                            	)
-                            
+                                return HttpResponseRedirect(reverse('shift:view_hours', args=(volunteer_id,)))
+                            else:
+                                messages.add_message(request, messages.INFO,
+                                                     'End time should be greater than start time')
+                                return render(
+                                    request,
+                                    'shift/edit_hours.html',
+                                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
+                                )
+
                         except:
                             raise Http404
                     else:
@@ -410,14 +410,15 @@ def edit_hours(request, shift_id, volunteer_id):
                             request,
                             'shift/edit_hours.html',
                             {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                            )
+                        )
                 else:
-                    form = HoursForm(initial={'start_time': volunteer_shift.start_time, 'end_time': volunteer_shift.end_time})
+                    form = HoursForm(
+                        initial={'start_time': volunteer_shift.start_time, 'end_time': volunteer_shift.end_time})
                     return render(
                         request,
                         'shift/edit_hours.html',
                         {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                        )
+                    )
             else:
                 raise Http404
         else:
@@ -448,17 +449,19 @@ def edit_hours_manager(request, shift_id, volunteer_id):
                         start_time = form.cleaned_data['start_time']
                         end_time = form.cleaned_data['end_time']
                         try:
-			    if(end_time>start_time):
-                        	edit_shift_hours(volunteer_id, shift_id, start_time, end_time)
-                                return HttpResponseRedirect(reverse('shift:manage_volunteer_shifts', args=(volunteer_id,)))
-			    else:
-				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
-				return render(
-                        	request,
-                            	'shift/edit_hours_manager.html',
-                            	{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                            	)
-                            
+                            if (end_time > start_time):
+                                edit_shift_hours(volunteer_id, shift_id, start_time, end_time)
+                                return HttpResponseRedirect(
+                                    reverse('shift:manage_volunteer_shifts', args=(volunteer_id,)))
+                            else:
+                                messages.add_message(request, messages.INFO,
+                                                     'End time should be greater than start time')
+                                return render(
+                                    request,
+                                    'shift/edit_hours_manager.html',
+                                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
+                                )
+
                         except:
                             raise Http404
                     else:
@@ -466,14 +469,15 @@ def edit_hours_manager(request, shift_id, volunteer_id):
                             request,
                             'shift/edit_hours_manager.html',
                             {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                            )
+                        )
                 else:
-                    form = HoursForm(initial={'start_time': volunteer_shift.start_time, 'end_time': volunteer_shift.end_time})
+                    form = HoursForm(
+                        initial={'start_time': volunteer_shift.start_time, 'end_time': volunteer_shift.end_time})
                     return render(
                         request,
                         'shift/edit_hours_manager.html',
                         {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                        )
+                    )
             else:
                 raise Http404
         else:
@@ -490,7 +494,7 @@ def list_jobs(request):
     except ObjectDoesNotExist:
         pass
 
-    #check that an admin is logged in
+    # check that an admin is logged in
     if not admin:
         return render(request, 'vms/no_admin_rights.html')
     else:
@@ -498,8 +502,8 @@ def list_jobs(request):
         return render(
             request,
             'shift/list_jobs.html',
-            {'job_list' : job_list}
-            )
+            {'job_list': job_list}
+        )
 
 
 @login_required
@@ -512,7 +516,7 @@ def list_shifts(request, job_id):
     except ObjectDoesNotExist:
         pass
 
-    #check that an admin is logged in
+    # check that an admin is logged in
     if not admin:
         return render(request, 'vms/no_admin_rights.html')
     else:
@@ -524,7 +528,7 @@ def list_shifts(request, job_id):
                     request,
                     'shift/list_shifts.html',
                     {'shift_list': shift_list, 'job_id': job_id}
-                    )
+                )
             else:
                 raise Http404
         else:
@@ -541,7 +545,7 @@ def list_shifts_sign_up(request, job_id, volunteer_id):
                 request,
                 'shift/list_shifts_sign_up.html',
                 {'shift_list': shift_list, 'job': job, 'volunteer_id': volunteer_id}
-                )
+            )
         else:
             raise Http404
     else:
@@ -572,8 +576,9 @@ def manage_volunteer_shifts(request, volunteer_id):
                 return render(
                     request,
                     'shift/manage_volunteer_shifts.html',
-                    {'shift_list': shift_list,'shift_list_with_hours': shift_list_with_hours, 'volunteer_id': volunteer_id}
-                    )
+                    {'shift_list': shift_list, 'shift_list_with_hours': shift_list_with_hours,
+                     'volunteer_id': volunteer_id}
+                )
             else:
                 raise Http404
         else:
@@ -619,7 +624,7 @@ def sign_up(request, shift_id, volunteer_id):
                             request,
                             'shift/sign_up_error.html',
                             {'error_code': result}
-                            )
+                        )
                 except ObjectDoesNotExist:
                     raise Http404
             else:
@@ -627,7 +632,7 @@ def sign_up(request, shift_id, volunteer_id):
                     request,
                     'shift/sign_up.html',
                     {'shift': shift, 'volunteer_id': volunteer_id}
-                    )
+                )
         else:
             raise Http404
     else:
@@ -646,7 +651,7 @@ def view_hours(request, volunteer_id):
                     request,
                     'shift/hours_list.html',
                     {'volunteer_shift_list': volunteer_shift_list, }
-                    )
+                )
             else:
                 return HttpResponse(status=403)
         else:
@@ -677,7 +682,7 @@ def view_volunteer_shifts(request, volunteer_id):
                         request,
                         'shift/volunteer_shifts.html',
                         {'shift_list': shift_list, 'volunteer_id': volunteer_id, }
-                        )
+                    )
                 else:
                     return HttpResponse(status=403)
             else:
@@ -705,7 +710,6 @@ def volunteer_search(request):
         if request.method == 'POST':
             form = SearchVolunteerForm(request.POST)
             if form.is_valid():
-
                 first_name = form.cleaned_data['first_name']
                 last_name = form.cleaned_data['last_name']
                 city = form.cleaned_data['city']
@@ -714,18 +718,18 @@ def volunteer_search(request):
                 organization = form.cleaned_data['organization']
 
                 volunteer_list = search_volunteers(
-                        first_name,
-                        last_name,
-                        city,
-                        state,
-                        country,
-                        organization
-                        )
+                    first_name,
+                    last_name,
+                    city,
+                    state,
+                    country,
+                    organization
+                )
                 return render(
                     request,
                     'shift/volunteer_search.html',
                     {'form': form, 'has_searched': True, 'volunteer_list': volunteer_list}
-                    )
+                )
         else:
             form = SearchVolunteerForm()
             volunteer_list = get_all_volunteers()
@@ -734,4 +738,4 @@ def volunteer_search(request):
             request,
             'shift/volunteer_search.html',
             {'form': form, 'has_searched': False, 'volunteer_list': volunteer_list}
-            )
+        )

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
-
+from datetime import date
 from job.services import *
 from shift.forms import HoursForm, ShiftForm
 from shift.models import Shift
@@ -11,7 +11,6 @@ from shift.services import *
 from volunteer.forms import SearchVolunteerForm
 from volunteer.services import get_all_volunteers, search_volunteers
 from django.contrib import messages
-
 
 @login_required
 def add_hours(request, shift_id, volunteer_id):
@@ -24,24 +23,24 @@ def add_hours(request, shift_id, volunteer_id):
                     start_time = form.cleaned_data['start_time']
                     end_time = form.cleaned_data['end_time']
                     try:
-                        if (end_time > start_time):
-                            add_shift_hours(
-                                volunteer_id,
-                                shift_id,
-                                start_time,
-                                end_time
-                            )
-                            return HttpResponseRedirect(reverse(
-                                'shift:view_hours',
-                                args=(volunteer_id,)
-                            ))
-                        else:
-                            messages.add_message(request, messages.INFO, 'End time should be greater than start time')
-                            return render(
-                                request,
-                                'shift/add_hours.html',
-                                {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                            )
+			if(end_time>start_time):
+                        	 add_shift_hours(
+                           	 volunteer_id,
+                           	 shift_id,
+                           	 start_time,
+                           	 end_time
+                            	 )
+                        	 return HttpResponseRedirect(reverse(
+                                	'shift:view_hours',
+                                	args=(volunteer_id,)
+                                	))
+			else:
+				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
+				return render(
+                        	request,
+                        	'shift/add_hours.html',
+                        	{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
+                        	)
                     except:
                         raise Http404
                 else:
@@ -49,14 +48,14 @@ def add_hours(request, shift_id, volunteer_id):
                         request,
                         'shift/add_hours.html',
                         {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                    )
+                        )
             else:
                 form = HoursForm()
                 return render(
                     request,
                     'shift/add_hours.html',
                     {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                )
+                    )
         else:
             return HttpResponse(status=403)
     else:
@@ -82,24 +81,24 @@ def add_hours_manager(request, shift_id, volunteer_id):
                 start_time = form.cleaned_data['start_time']
                 end_time = form.cleaned_data['end_time']
                 try:
-                    if (end_time > start_time):
-                        add_shift_hours(
-                            volunteer_id,
-                            shift_id,
-                            start_time,
-                            end_time
-                        )
-                        return HttpResponseRedirect(reverse(
-                            'shift:manage_volunteer_shifts',
-                            args=(volunteer_id,)
-                        ))
-                    else:
-                        messages.add_message(request, messages.INFO, 'End time should be greater than start time')
-                        return render(
-                            request,
-                            'shift/add_hours_manager.html',
-                            {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                        )
+                    if(end_time>start_time):
+                        	 add_shift_hours(
+                           	 volunteer_id,
+                           	 shift_id,
+                           	 start_time,
+                           	 end_time
+                            	 )
+                        	 return HttpResponseRedirect(reverse(
+                        	 'shift:manage_volunteer_shifts',
+                        	 args=(volunteer_id, )
+                        	 ))
+		    else:
+				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
+				return render(
+                    		request,
+                    		'shift/add_hours_manager.html',
+                    		{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
+                    		)
                 except:
                     raise Http404
             else:
@@ -107,18 +106,19 @@ def add_hours_manager(request, shift_id, volunteer_id):
                     request,
                     'shift/add_hours_manager.html',
                     {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-                )
+                    )
         else:
             form = HoursForm()
             return render(
                 request,
                 'shift/add_hours_manager.html',
                 {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, }
-            )
+                )
 
 
 @login_required
 def cancel(request, shift_id, volunteer_id):
+
     if shift_id and volunteer_id:
 
         user = request.user
@@ -149,13 +149,13 @@ def cancel(request, shift_id, volunteer_id):
                 if admin:
                     return HttpResponseRedirect(reverse(
                         'shift:manage_volunteer_shifts',
-                        args=(volunteer_id,)
-                    ))
+                        args=(volunteer_id, )
+                        ))
                 elif volunteer:
                     return HttpResponseRedirect(reverse(
                         'shift:view_volunteer_shifts',
-                        args=(volunteer_id,)
-                    ))
+                        args=(volunteer_id, )
+                        ))
                 else:
                     raise Http404
             except:
@@ -165,21 +165,22 @@ def cancel(request, shift_id, volunteer_id):
                 request,
                 'shift/cancel_shift.html',
                 {'shift_id': shift_id, 'volunteer_id': volunteer_id}
-            )
+                )
     else:
         raise Http404
 
 
 @login_required
 def clear_hours(request, shift_id, volunteer_id):
+
     if shift_id and volunteer_id:
         if request.method == 'POST':
             result = clear_shift_hours(volunteer_id, shift_id)
             if result:
                 return HttpResponseRedirect(reverse(
                     'shift:view_hours',
-                    args=(volunteer_id,)
-                ))
+                    args=(volunteer_id, )
+                    ))
             else:
                 raise Http404
         else:
@@ -207,8 +208,8 @@ def clear_hours_manager(request, shift_id, volunteer_id):
                 if result:
                     return HttpResponseRedirect(reverse(
                         'shift:manage_volunteer_shifts',
-                        args=(volunteer_id,)
-                    ))
+                        args=(volunteer_id, )
+                        ))
                 else:
                     raise Http404
             else:
@@ -238,10 +239,10 @@ def create(request, job_id):
                 if job:
                     form = ShiftForm(request.POST)
                     if form.is_valid():
-                        start_date_job = job.start_date
-                        end_date_job = job.end_date
-                        shift_date = form.cleaned_data['date']
-                        if (shift_date >= start_date_job and shift_date <= end_date_job):
+                        start_date_job=job.start_date
+                        end_date_job=job.end_date
+                        shift_date=form.cleaned_data['date']
+                        if( shift_date >= start_date_job and shift_date <= end_date_job ):
                             shift = form.save(commit=False)
                             shift.job = job
                             shift.save()
@@ -249,17 +250,17 @@ def create(request, job_id):
                         else:
                             messages.add_message(request, messages.INFO, 'Shift date should lie within Job dates')
                             return render(
-                                request,
-                                'shift/create.html',
-                                {'form': form, 'job_id': job_id, 'job': job}
+                            request,
+                            'shift/create.html',
+                            {'form': form, 'job_id': job_id, 'job': job }
                             )
 
                     else:
                         return render(
                             request,
                             'shift/create.html',
-                            {'form': form, 'job_id': job_id, 'job': job}
-                        )
+                            {'form': form, 'job_id': job_id, 'job': job }
+                            )
                 else:
                     raise Http404
             else:
@@ -272,9 +273,8 @@ def create(request, job_id):
                 return render(
                     request,
                     'shift/create.html',
-                    {'form': form, 'job_id': job_id, 'country': country, 'state': state, 'city': city,
-                     'address': address, 'venue': venue, 'job': job}
-                )
+                    {'form': form, 'job_id': job_id, 'country': country, 'state': state, 'city': city, 'address': address, 'venue': venue, 'job': job}
+                    )
         else:
             raise Http404
 
@@ -304,7 +304,7 @@ def delete(request, shift_id):
                 request,
                 'shift/delete.html',
                 {'shift_id': shift_id}
-            )
+                )
         else:
             raise Http404
 
@@ -331,50 +331,65 @@ def edit(request, shift_id):
             form = ShiftForm(request.POST, instance=shift)
             if form.is_valid():
                 shift_to_edit = form.save(commit=False)
-
-                job = shift.job
-                if job:
+                
+		job=shift.job
+		if job:
                     shift_to_edit.job = job
                 else:
                     raise Http404
-                shift_to_edit.save()
+		
+		start_date_job=job.start_date
+		end_date_job=job.end_date
+                shift_date=form.cleaned_data['date']
 
-                start_date_job = job.start_date
-                end_date_job = job.end_date
-                shift_date = form.cleaned_data['date']
-                if (shift_date >= start_date_job and shift_date <= end_date_job):
-                    shift = form.save(commit=False)
-                    shift.job = job
-                    shift.save()
-                    return HttpResponseRedirect(reverse('shift:list_shifts', args=(job.id,)))
+		shift_start_time=form.cleaned_data['start_time']
+		shift_end_time=form.cleaned_data['end_time']
+		if( shift_date >= start_date_job and shift_date <= end_date_job ):
+			if(shift_end_time>shift_start_time):
+                            shift = form.save(commit=False)
+                            shift.job = job
+                            shift.save()
+                            return HttpResponseRedirect(reverse('shift:list_shifts', args=(job.id,)))
+
+			else:
+			    messages.add_message(request, messages.INFO, 'Shift end time should be greater than start time')
+                            return render(
+                            request,
+                            'shift/edit.html',
+                            {'form': form, 'shift': shift, 'job': shift.job }
+                            )
+
                 else:
-                    messages.add_message(request, messages.INFO, 'Shift date should lie within Job dates')
-                    return render(
-                        request,
-                        'shift/edit.html',
-                        {'form': form, 'shift': shift, 'job': shift.job}
-                    )
+                            messages.add_message(request, messages.INFO, 'Shift date should lie within Job dates')
+                            return render(
+                    	    request,
+                            'shift/edit.html',
+                            {'form': form, 'shift': shift, 'job': shift.job}
+                            )
+
+		shift_to_edit.save()
                 return HttpResponseRedirect(reverse(
                     'shift:list_shifts',
-                    args=(job.id,)
-                ))
+                    args=(job.id, )
+                    ))
             else:
                 return render(
                     request,
                     'shift/edit.html',
                     {'form': form, 'shift': shift, 'job': shift.job}
-                )
+                    )
         else:
             form = ShiftForm(instance=shift)
             return render(
                 request,
                 'shift/edit.html',
                 {'form': form, 'shift': shift, 'job': shift.job}
-            )
+                )
 
 
 @login_required
 def edit_hours(request, shift_id, volunteer_id):
+
     if shift_id and volunteer_id:
         volunteer_shift = get_volunteer_shift_by_id(volunteer_id, shift_id)
         user = request.user
@@ -386,23 +401,22 @@ def edit_hours(request, shift_id, volunteer_id):
                         start_time = form.cleaned_data['start_time']
                         end_time = form.cleaned_data['end_time']
                         try:
-                            if (end_time > start_time):
-                                edit_shift_hours(
-                                    volunteer_id,
-                                    shift_id,
-                                    start_time,
-                                    end_time
+			    if(end_time>start_time):
+                        	edit_shift_hours(
+                                volunteer_id,
+                                shift_id,
+                                start_time,
+                                end_time
                                 )
-                                return HttpResponseRedirect(reverse('shift:view_hours', args=(volunteer_id,)))
-                            else:
-                                messages.add_message(request, messages.INFO,
-                                                     'End time should be greater than start time')
-                                return render(
-                                    request,
-                                    'shift/edit_hours.html',
-                                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                                )
-
+                            	return HttpResponseRedirect(reverse('shift:view_hours', args=(volunteer_id,)))
+			    else:
+				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
+				return render(
+                        	request,
+                            	'shift/edit_hours.html',
+                            	{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
+                            	)
+                            
                         except:
                             raise Http404
                     else:
@@ -410,15 +424,14 @@ def edit_hours(request, shift_id, volunteer_id):
                             request,
                             'shift/edit_hours.html',
                             {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                        )
+                            )
                 else:
-                    form = HoursForm(
-                        initial={'start_time': volunteer_shift.start_time, 'end_time': volunteer_shift.end_time})
+                    form = HoursForm(initial={'start_time': volunteer_shift.start_time, 'end_time': volunteer_shift.end_time})
                     return render(
                         request,
                         'shift/edit_hours.html',
                         {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                    )
+                        )
             else:
                 raise Http404
         else:
@@ -449,19 +462,17 @@ def edit_hours_manager(request, shift_id, volunteer_id):
                         start_time = form.cleaned_data['start_time']
                         end_time = form.cleaned_data['end_time']
                         try:
-                            if (end_time > start_time):
-                                edit_shift_hours(volunteer_id, shift_id, start_time, end_time)
-                                return HttpResponseRedirect(
-                                    reverse('shift:manage_volunteer_shifts', args=(volunteer_id,)))
-                            else:
-                                messages.add_message(request, messages.INFO,
-                                                     'End time should be greater than start time')
-                                return render(
-                                    request,
-                                    'shift/edit_hours_manager.html',
-                                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                                )
-
+			    if(end_time>start_time):
+                        	edit_shift_hours(volunteer_id, shift_id, start_time, end_time)
+                                return HttpResponseRedirect(reverse('shift:manage_volunteer_shifts', args=(volunteer_id,)))
+			    else:
+				messages.add_message(request, messages.INFO, 'End time should be greater than start time')
+				return render(
+                        	request,
+                            	'shift/edit_hours_manager.html',
+                            	{'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
+                            	)
+                            
                         except:
                             raise Http404
                     else:
@@ -469,15 +480,14 @@ def edit_hours_manager(request, shift_id, volunteer_id):
                             request,
                             'shift/edit_hours_manager.html',
                             {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                        )
+                            )
                 else:
-                    form = HoursForm(
-                        initial={'start_time': volunteer_shift.start_time, 'end_time': volunteer_shift.end_time})
+                    form = HoursForm(initial={'start_time': volunteer_shift.start_time, 'end_time': volunteer_shift.end_time})
                     return render(
                         request,
                         'shift/edit_hours_manager.html',
                         {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
-                    )
+                        )
             else:
                 raise Http404
         else:
@@ -494,7 +504,7 @@ def list_jobs(request):
     except ObjectDoesNotExist:
         pass
 
-    # check that an admin is logged in
+    #check that an admin is logged in
     if not admin:
         return render(request, 'vms/no_admin_rights.html')
     else:
@@ -502,8 +512,8 @@ def list_jobs(request):
         return render(
             request,
             'shift/list_jobs.html',
-            {'job_list': job_list}
-        )
+            {'job_list' : job_list}
+            )
 
 
 @login_required
@@ -516,7 +526,7 @@ def list_shifts(request, job_id):
     except ObjectDoesNotExist:
         pass
 
-    # check that an admin is logged in
+    #check that an admin is logged in
     if not admin:
         return render(request, 'vms/no_admin_rights.html')
     else:
@@ -528,7 +538,7 @@ def list_shifts(request, job_id):
                     request,
                     'shift/list_shifts.html',
                     {'shift_list': shift_list, 'job_id': job_id}
-                )
+                    )
             else:
                 raise Http404
         else:
@@ -540,12 +550,18 @@ def list_shifts_sign_up(request, job_id, volunteer_id):
     if job_id:
         job = get_job_by_id(job_id)
         if job:
-            shift_list = get_shifts_with_open_slots_for_volunteer(job_id, volunteer_id)
+            shift_list = []
+            shift_list_all = get_shifts_with_open_slots_for_volunteer(job_id, volunteer_id)
+            for shift in shift_list_all:
+                sdate = shift["date"]
+                today = date.today()
+                if sdate >= today:
+                    shift_list.append(shift)
             return render(
                 request,
                 'shift/list_shifts_sign_up.html',
                 {'shift_list': shift_list, 'job': job, 'volunteer_id': volunteer_id}
-            )
+                )
         else:
             raise Http404
     else:
@@ -576,9 +592,8 @@ def manage_volunteer_shifts(request, volunteer_id):
                 return render(
                     request,
                     'shift/manage_volunteer_shifts.html',
-                    {'shift_list': shift_list, 'shift_list_with_hours': shift_list_with_hours,
-                     'volunteer_id': volunteer_id}
-                )
+                    {'shift_list': shift_list,'shift_list_with_hours': shift_list_with_hours, 'volunteer_id': volunteer_id}
+                    )
             else:
                 raise Http404
         else:
@@ -624,7 +639,7 @@ def sign_up(request, shift_id, volunteer_id):
                             request,
                             'shift/sign_up_error.html',
                             {'error_code': result}
-                        )
+                            )
                 except ObjectDoesNotExist:
                     raise Http404
             else:
@@ -632,7 +647,7 @@ def sign_up(request, shift_id, volunteer_id):
                     request,
                     'shift/sign_up.html',
                     {'shift': shift, 'volunteer_id': volunteer_id}
-                )
+                    )
         else:
             raise Http404
     else:
@@ -651,7 +666,7 @@ def view_hours(request, volunteer_id):
                     request,
                     'shift/hours_list.html',
                     {'volunteer_shift_list': volunteer_shift_list, }
-                )
+                    )
             else:
                 return HttpResponse(status=403)
         else:
@@ -682,7 +697,7 @@ def view_volunteer_shifts(request, volunteer_id):
                         request,
                         'shift/volunteer_shifts.html',
                         {'shift_list': shift_list, 'volunteer_id': volunteer_id, }
-                    )
+                        )
                 else:
                     return HttpResponse(status=403)
             else:
@@ -710,6 +725,7 @@ def volunteer_search(request):
         if request.method == 'POST':
             form = SearchVolunteerForm(request.POST)
             if form.is_valid():
+
                 first_name = form.cleaned_data['first_name']
                 last_name = form.cleaned_data['last_name']
                 city = form.cleaned_data['city']
@@ -718,18 +734,18 @@ def volunteer_search(request):
                 organization = form.cleaned_data['organization']
 
                 volunteer_list = search_volunteers(
-                    first_name,
-                    last_name,
-                    city,
-                    state,
-                    country,
-                    organization
-                )
+                        first_name,
+                        last_name,
+                        city,
+                        state,
+                        country,
+                        organization
+                        )
                 return render(
                     request,
                     'shift/volunteer_search.html',
                     {'form': form, 'has_searched': True, 'volunteer_list': volunteer_list}
-                )
+                    )
         else:
             form = SearchVolunteerForm()
             volunteer_list = get_all_volunteers()
@@ -738,4 +754,4 @@ def volunteer_search(request):
             request,
             'shift/volunteer_search.html',
             {'form': form, 'has_searched': False, 'volunteer_list': volunteer_list}
-        )
+            )


### PR DESCRIPTION
shift saving gave 404 error when shift_id was not same as job_id and after saving did not return to the appropriate job shifts because a wrong job_id was sent