### PR TITLE
Show better error mesasge when no organization exists on Sign Up

### DIFF
--- a/vms/home/templates/home/home.html
+++ b/vms/home/templates/home/home.html
@@ -27,5 +27,10 @@
                 <a class="btn btn-lg btn-primary" href="{% url 'authentication:login_process' %}">{% trans "Log In" %}</a>
             </p>
         {% endif %}
+        {% if error %}
+            <div class="alert alert-danger" role="alert">
+              You will need to have atleast one organisation to Sign up as a volunteer
+            </div>
+        {% endif %}
     </div>
 {% endblock %}

--- a/vms/registration/views.py
+++ b/vms/registration/views.py
@@ -68,7 +68,7 @@ def signup_administrator(request):
                        'organization_list': organization_list, })
 
     else:
-        return render(request, 'organization/add_organizations.html')
+        return render(request, 'home/home.html', {'error': True})
 
 
 def signup_volunteer(request):
@@ -138,4 +138,4 @@ def signup_volunteer(request):
                        'organization_list': organization_list, })
 
     else:
-        return render(request, 'organization/add_organizations.html')
+        return render(request, 'home/home.html', {'error': True})


### PR DESCRIPTION
The current approach shows a 503, which is replaced with a friendly
bootstrap alert message in this commit.

Fixes  #257 