### PR TITLE
Hide textbox if organization selected

### DIFF
--- a/vms/registration/templates/registration/signup_administrator.html
+++ b/vms/registration/templates/registration/signup_administrator.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% load static %}
+
 {% block content %}
 
     <form class="signup form-signup" id="signup_form" method="post" action="{% url 'registration:signup_administrator' %}" enctype="multipart/form-data">
@@ -272,7 +274,7 @@
             <label class="control-label">
                 {% trans "Organization" %}
             </label>
-            <select id="select" class="form-control" name="organization_name">
+            <select id="select" class="form-control" name="organization_name" onchange="hide_organization()">
                 <option value="0">-- {% trans "Select Organization" %} --</option>
                 {% for organization in organization_list %}
                     <option value="{{ organization.id }}">{{ organization.name }}</option>
@@ -305,6 +307,7 @@
                 </div>
             </div>
         {% endif %}
+        <script type="text/javascript" src="{% static 'vms/js/hide_organization.js' %}"></script>
         <button type="submit" class="btn btn-lg btn-primary btn-block">{% trans "Create Account" %}</button>
         <!--<p>
             Already have an account? Then please <a href="{% url 'authentication:login_process' %}">sign in</a>.

--- a/vms/registration/templates/registration/signup_volunteer.html
+++ b/vms/registration/templates/registration/signup_volunteer.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% load static %}
+
 {% block content %}
 
     <form class="signup form-signup" id="signup_form" method="post" action="{% url 'registration:signup_volunteer' %}" enctype="multipart/form-data">
@@ -298,7 +300,7 @@
             <label class="control-label">
                 {% trans "Organization" %}
             </label>
-            <select id="select" class="form-control" name="organization_name">
+            <select id="select" class="form-control" name="organization_name" onchange="hide_organization()">
                 <option value="0">-- {% trans "Select Organization" %} --</option>
                 {% for organization in organization_list %}
                     <option value="{{ organization.id }}">{{ organization.name }}</option>
@@ -331,6 +333,7 @@
                 </div>
             </div>
         {% endif %}
+        <script type="text/javascript" src="{% static 'vms/js/hide_organization.js' %}"></script>
         {% if volunteer_form.websites.errors %}
             <div id="div_id_websites" class="form-group has-error">
                 <label class="control-label" for="id_websites">

--- a/vms/vms/static/vms/js/hide_organization.js
+++ b/vms/vms/static/vms/js/hide_organization.js
@@ -1,0 +1,8 @@
+function hide_organization(){
+    var value= $('#select').val();
+    if(value != '0'){
+      $("#div_id_unlisted_organization").hide();}
+      else
+      {$("#div_id_unlisted_organization").show();}
+}
+hide_organization();


### PR DESCRIPTION
If the admin/volunteer selects a organization from the dropdown menu, the text input for 'others' will disappear. If none of the organization is selected then it will appear again. 
Closes #106 