### PR TITLE
Dropdown for volunteer report

### DIFF
--- a/vms/event/services.py
+++ b/vms/event/services.py
@@ -4,6 +4,7 @@ from event.models import Event
 from job.models import Job
 from shift.models import Shift
 from job.services import get_jobs_by_event_id, remove_empty_jobs_for_volunteer
+from shift.services import get_volunteer_shifts_with_hours, get_unlogged_shifts_by_volunteer_id
 
 def event_not_empty(event_id):
     """ Checks if the event exists and is not empty """
@@ -116,6 +117,27 @@ def get_events_ordered_by_name():
     event_list = Event.objects.all().order_by('name')
     return event_list
 
+def get_signed_up_events_for_volunteer(volunteer_id):
+    """ Gets sorted list of signed up events for a volunteer """
+
+    event_list = []
+    unsorted_events = []
+    shift_list_without_hours = get_unlogged_shifts_by_volunteer_id(volunteer_id)
+    shift_list_with_hours = get_volunteer_shifts_with_hours(volunteer_id)
+
+    for shift_with_hours in shift_list_with_hours:
+        event_name = str(shift_with_hours.shift.job.event.name)
+        if event_name not in unsorted_events:
+            unsorted_events.append(event_name)
+    for shift in shift_list_without_hours:
+        event_name = str(shift.job.event.name)
+        if event_name not in unsorted_events:
+            unsorted_events.append(event_name)
+
+    #for sorting events alphabetically
+    for event in sorted(unsorted_events, key=str.lower):
+        event_list.append(event)
+    return event_list
 
 def remove_empty_events_for_volunteer(event_list, volunteer_id):
     """ Removes all events from an event list without jobs or shifts """

--- a/vms/job/services.py
+++ b/vms/job/services.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 
 from job.models import Job
-from shift.services import get_shifts_with_open_slots_for_volunteer
+from shift.services import get_shifts_with_open_slots_for_volunteer, get_volunteer_shifts_with_hours, get_unlogged_shifts_by_volunteer_id
 
 def job_not_empty(job_id):
     """ Check if the job exists and is not empty """
@@ -80,6 +80,27 @@ def get_jobs_ordered_by_title():
     job_list = Job.objects.all().order_by('name')
     return job_list
 
+def get_signed_up_jobs_for_volunteer(volunteer_id):
+    """ Gets sorted list of signed up jobs for a volunteer """
+
+    unsorted_jobs = []
+    job_list = []
+    shift_list_without_hours = get_unlogged_shifts_by_volunteer_id(volunteer_id)
+    shift_list_with_hours = get_volunteer_shifts_with_hours(volunteer_id)
+
+    for shift_with_hours in shift_list_with_hours:
+        job_name = str(shift_with_hours.shift.job.name)
+        if job_name not in unsorted_jobs:
+            unsorted_jobs.append(job_name)
+    for shift in shift_list_without_hours:
+        job_name = str(shift.job.name)
+        if job_name not in unsorted_jobs:
+            unsorted_jobs.append(job_name)
+
+    #to sort jobs as per name
+    for job in sorted(unsorted_jobs, key=str.lower):
+        job_list.append(job)
+    return job_list
 
 def remove_empty_jobs_for_volunteer(job_list, volunteer_id):
     """ Removes all jobs from a job list without shifts """

--- a/vms/volunteer/templates/volunteer/report.html
+++ b/vms/volunteer/templates/volunteer/report.html
@@ -16,7 +16,12 @@
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">{% trans "Event Name" %}</label>
                         <div class="col-md-8">
-                            <input class="form-control" type="text" name="event_name" value="{% if form.event_name.value %}{{ form.event_name.value}}{% endif %}">
+                            <select id="select" class="form-control" name="event_name">
+                                <option value="">-- {% trans "Select Event" %} --</option>
+                                {% for event in event_list %}
+                                    <option value="{{ event }}" {% if selected_event == event %}selected{% endif %}>{{ event }}</option>
+                                {% endfor %}
+                            </select>
                             <p class="help-block">
                                 <strong>
                                     {% for error in form.event_name.errors %}
@@ -30,7 +35,12 @@
                     <div class="form-group">
                         <label class="col-md-2 control-label">{% trans "Event Name" %}</label>
                         <div class="col-md-8">
-                            <input class="form-control" type="text" name="event_name" value="{% if form.event_name.value %}{{ form.event_name.value}}{% endif %}">
+                            <select id="select" class="form-control" name="event_name">
+                                <option value="">-- {% trans "Select Event" %} --</option>
+                                {% for event in event_list %}
+                                    <option value="{{ event }}" {% if selected_event == event %}selected{% endif %}>{{ event }}</option>
+                                {% endfor %}
+                            </select>
                         </div>
                     </div>
                 {% endif %}
@@ -38,7 +48,12 @@
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">{% trans "Job Name" %}</label>
                         <div class="col-md-8">
-                            <input class="form-control" type="text" name="job_name" value="{% if form.job_name.value %}{{ form.job_name.value}}{% endif %}">
+                            <select id="select" class="form-control" name="job_name">
+                                <option value="">-- {% trans "Select Job" %} --</option>
+                                {% for job in job_list %}
+                                    <option value="{{ job }}" {% if selected_job == job %}selected{% endif %}>{{ job }}</option>
+                                {% endfor %}
+                            </select>
                             <p class="help-block">
                                 <strong>
                                     {% for error in form.job_name.errors %}
@@ -52,7 +67,12 @@
                     <div class="form-group">
                         <label class="col-md-2 control-label">{% trans "Job Name" %}</label>
                         <div class="col-md-8">
-                            <input class="form-control" type="text" name="job_name" value="{% if form.job_name.value %}{{ form.job_name.value}}{% endif %}">
+                            <select id="select" class="form-control" name="job_name">
+                                <option value="">-- {% trans "Select Job" %} --</option>
+                                {% for job in job_list %}
+                                    <option value="{{ job }}" {% if selected_job == job %}selected{% endif %}>{{ job }}</option>
+                                {% endfor %}
+                            </select>
                         </div>
                     </div>
                 {% endif %}

--- a/vms/volunteer/views.py
+++ b/vms/volunteer/views.py
@@ -10,6 +10,8 @@ from django.shortcuts import render
 
 from organization.services import *
 from shift.services import *
+from event.services import get_signed_up_events_for_volunteer
+from job.services import get_signed_up_jobs_for_volunteer
 from volunteer.forms import ReportForm, SearchVolunteerForm, VolunteerForm
 from volunteer.models import Volunteer
 from volunteer.services import * 
@@ -117,6 +119,8 @@ def report(request, volunteer_id):
     if volunteer:
         user = request.user
         if int(user.volunteer.id) == int(volunteer_id):
+            event_list = get_signed_up_events_for_volunteer(volunteer_id)
+            job_list = get_signed_up_jobs_for_volunteer(volunteer_id)
             if request.method == 'POST':
                 form = ReportForm(request.POST)
                 if form.is_valid():
@@ -126,12 +130,12 @@ def report(request, volunteer_id):
                     end_date = form.cleaned_data['end_date']
                     report_list = get_volunteer_report(volunteer_id, event_name, job_name, start_date, end_date)
                     total_hours = calculate_total_report_hours(report_list)
-                    return render(request, 'volunteer/report.html', {'form' : form, 'report_list' : report_list, 'total_hours' : total_hours, 'notification' : True})
+                    return render(request, 'volunteer/report.html', {'form' : form, 'report_list' : report_list, 'total_hours' : total_hours, 'notification' : True,  'job_list' : job_list, 'event_list' : event_list, 'selected_event': event_name, 'selected_job': job_name})
                 else:
-                    return render(request, 'volunteer/report.html', {'form' : form, 'notification' : False})
+                    return render(request, 'volunteer/report.html', {'form' : form, 'notification' : False, 'job_list' : job_list, 'event_list' : event_list})
             else:
                 form = ReportForm()
-                return render(request, 'volunteer/report.html', {'form' : form, 'notification' : False})
+                return render(request, 'volunteer/report.html', {'form' : form, 'notification' : False, 'job_list' : job_list, 'event_list' : event_list})
         else:
             return HttpResponse(status=403)
     else:


### PR DESCRIPTION
Creates a dropdown for events and jobs in volunteer report - Rather than displaying an entire list of events and jobs, only the ones that volunteer has signed up for are displayed since there wouldn't be any results returned for other events/jobs. This keeps the length of the lists small, only listing those which are relevant for a particular volunteer. This can also be modified from including signed up events/jobs to including only logged events/jobs. 

![dropdowns](https://cloud.githubusercontent.com/assets/13931206/14233969/bdf11100-f9f4-11e5-82d6-0ec5ea7e50c7.png)

Fixes #290

New services and their tests have also been added. Please review and suggest changes