### PR TITLE
Saving selected event dropdown option in report on reload

### DIFF
--- a/vms/administrator/templates/administrator/report.html
+++ b/vms/administrator/templates/administrator/report.html
@@ -95,7 +95,7 @@
                             <select id="select" class="form-control" name="event_name">
 								<option value="">-- {% trans "Select Event" %} --</option>
 								{% for event in event_list %}
-									<option value="{{ event.name }}">{{ event.name }}</option>
+									<option value="{{ event.name }}" {% if selected_event == event.name %}selected{% endif %}>{{ event.name }}</option>
 								{% endfor %}
 							</select>
                             <p class="help-block">
@@ -114,7 +114,7 @@
                             <select id="select" class="form-control" name="event_name">
 								<option value="">-- {% trans "Select Event" %} --</option>
 								{% for event in event_list %}
-									<option value="{{ event.name }}">{{ event.name }}</option>
+									<option value="{{ event.name }}" {% if selected_event == event.name %}selected{% endif %}>{{ event.name }}</option>
 								{% endfor %}
 							</select>
                         </div>

--- a/vms/administrator/views.py
+++ b/vms/administrator/views.py
@@ -45,7 +45,7 @@ def report(request):
                 end_date
                 )
             total_hours = calculate_total_report_hours(report_list)
-            return render(request, 'administrator/report.html', {'form': form, 'report_list': report_list, 'total_hours': total_hours, 'notification': True, 'organization_list': organization_list, 'selected_organization': organization, 'event_list': event_list})
+            return render(request, 'administrator/report.html', {'form': form, 'report_list': report_list, 'total_hours': total_hours, 'notification': True, 'organization_list': organization_list, 'selected_organization': organization, 'event_list': event_list, 'selected_event': event_name})
         else:
             return render(request, 'administrator/report.html', {'form': form, 'notification': False, 'organization_list': organization_list, 'event_list': event_list})
     else:


### PR DESCRIPTION
Minor change to prevent event value from getting reset on page reload in admin report

Fixes #292 , Please review and suggest changes