### PR TITLE
Retains end date in event edit; on wrong start date

### DIFF
--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -84,7 +84,10 @@ def edit(request, event_id):
                         {'count': event_edit['invalid_count'], 'jobs': event_edit['invalid_jobs']}
                         )
                 if start_date_event < datetime.date.today():
+                    data = request.POST.copy()
+                    data['end_date'] = end_date_event
                     messages.add_message(request, messages.INFO, 'Start date should be today\'s date or later.')
+                    form = EventForm(data)
                     return render(request, 'event/edit.html', {'form': form, })
                 else:
                     form.save()


### PR DESCRIPTION
Pertaining to the issue [#301](https://github.com/systers/vms/issues/301), this PR fixes the problem by retaining the end date of event along with the other information (except the faulty start date field).