### PR TITLE
Retains end date in event edit on erroneus entry

### DIFF
--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -93,6 +93,9 @@ def edit(request, event_id):
                     form.save()
                     return HttpResponseRedirect(reverse('event:list'))
             else:
+                data = request.POST.copy()
+                data['end_date'] = form.cleaned_data['end_date']
+                form = EventForm(data)
                 return render(request, 'event/edit.html', {'form': form, })
         else:
             form = EventForm(instance=event)


### PR DESCRIPTION
As per issue [#307](https://github.com/systers/vms/issues/307) , the `end-date` field would go blank after saving the form with blank `start-date` field (which goes blank on an erroneous entry). This PR resolves the issue by retaining all the entries of the field including the `end-date` field.
Closes  [#307](https://github.com/systers/vms/issues/307)