### PR TITLE
Removed 'from home import views' statement in home/urls.py

### DIFF
--- a/vms/home/urls.py
+++ b/vms/home/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import patterns, url
-from home import views
 from django.views.generic import TemplateView
 
 


### PR DESCRIPTION
The function based view in home application was migrated to TemplateView and the file views.py in home application was deleted as it was empty. 'from home import views' statement in home/urls.py resulted in an error as the file views.py was removed. The error is corrected by removing the statement.