### PR TITLE
Adding continuous integration with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+  - "2.7"
+services: postgresql
+install:
+  - pip install -r requirements.txt
+before_script:
+  - psql -c "CREATE DATABASE vms;" -U postgres
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3
+script:
+  - cd vms
+  - python manage.py syncdb --noinput
+  - python manage.py migrate --noinput --traceback --settings=vms.settings
+  - coverage run --source='.' manage.py test
+after_success:
+    coveralls --rcfile=.coveragerc

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services: postgresql
 install:
   - pip install -r requirements.txt
 before_script:
+  - psql -c "create role vmsadmin with createrole createdb login password '0xdeadbeef';" -U postgres
   - psql -c "CREATE DATABASE vms;" -U postgres
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ psycopg2==2.5.4
 PyYAML==3.11
 requests==2.7.0
 selenium==2.53.1
+phonenumbers==7.2.6
+django-cities-light==3.2.0
+Unidecode==0.4.19


### PR DESCRIPTION
This PR sets up continuous integration with travis for systers vms repository. For convenience, a separate requirements.txt file has been updated with all the installations easier. The database credentials (vmsadmin and password ) have been removed to allow travis to login as default postgres user and carry out the tests. The travis file has also been configured to support GUI and headless browser testing.

After merging this PR, every commit/PR to the VMS repository will be checked to see if they break the tests (unit as well as functional). The requirements.txt file will also make vms setup more convenient.

_The build is failing at this point._ This failure is due to failing automated tests due to bugs (#327 and #325 ). Link to latest travis build - [here](https://travis-ci.org/smarshy/vms/builds/135449707)

To verify that the cause of failure is only test failures, I tried commenting out these test cases and running the build again. It worked and the build passed. Link to passing travis build -[here](https://travis-ci.org/smarshy/vms/builds/135430065)

Fixes #140 
