### PR TITLE
Add automated tests for registration and shift sign up page

### DIFF
--- a/vms/event/tests/test_shiftSignUp.py
+++ b/vms/event/tests/test_shiftSignUp.py
@@ -281,3 +281,54 @@ class ShiftSignUp(LiveServerTestCase):
 
         # on event page
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
+
+    def test_search_event(self):
+
+        self.register_event_utility()
+        self.register_job_utility()
+        self.register_shift_utility()
+
+        # Login as volunteer 1 and open Shift Sign Up
+        self.login()
+        self.driver.find_element_by_link_text('Shift Sign Up').click()
+
+        # enter date range in which an event starts
+        self.driver.find_element_by_id('from').send_keys('05/08/2016')
+        self.driver.find_element_by_id('to').send_keys('08/31/2017')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+        # verify that the event shows up
+        self.assertEqual(self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[1]').text, 'event')
+
+        # enter date range in which no event starts
+        self.driver.find_element_by_id('from').clear()
+        self.driver.find_element_by_id('to').clear()
+        self.driver.find_element_by_id('from').send_keys('10/08/2016')
+        self.driver.find_element_by_id('to').send_keys('08/31/2017')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+        # verify that no event shows up on event page
+        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
+
+        # enter only incorrect starting date
+        self.driver.find_element_by_id('from').clear()
+        self.driver.find_element_by_id('to').clear()
+        self.driver.find_element_by_id('from').send_keys('10/08/2016')
+        # verify that no event shows up on event page
+        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
+
+        """# enter only correct starting date
+        self.driver.find_element_by_id('from').clear()
+        self.driver.find_element_by_id('from').send_keys('05/10/2016')
+        # verify that the event shows up
+        self.assertEqual(self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[1]').text, 'event')"""
+
+        # enter only incorrect ending date
+        self.driver.find_element_by_id('from').clear()
+        self.driver.find_element_by_id('to').send_keys('10/08/2015')
+        # verify that no event shows up on event page
+        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
+
+        """# enter correct ending date
+        self.driver.find_element_by_id('to').clear()
+        self.driver.find_element_by_id('to').send_keys('06/15/2017')
+        # verify that the event shows up
+        self.assertEqual(self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[1]').text, 'event')"""

--- a/vms/registration/tests/test_functional_admin.py
+++ b/vms/registration/tests/test_functional_admin.py
@@ -34,6 +34,10 @@ class SignUpAdmin(LiveServerTestCase):
         - Test Null Values
         - Test validity of number against country entered
         - Test legit characters as per Models defined
+
+    Organization Field:
+        - Test Null Values
+        - Test legit characters as per Models defined
     '''
     def setUp(self):        
         # create an org prior to registration. Bug in Code
@@ -313,6 +317,8 @@ class SignUpAdmin(LiveServerTestCase):
                 None)
         self.assertEqual(self.driver.find_element_by_class_name('messages').text,
                 'You have successfully registered!')
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
 
         # Try to register admin again with same email address
         self.driver.get(self.live_server_url + self.admin_registration_page)
@@ -331,6 +337,8 @@ class SignUpAdmin(LiveServerTestCase):
         self.driver.find_element_by_xpath('//form[1]').submit()
 
         # verify that user wasn't registered
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.admin_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_email')/div/p/strong").text,
@@ -359,6 +367,8 @@ class SignUpAdmin(LiveServerTestCase):
                 None)
         self.assertEqual(self.driver.find_element_by_class_name('messages').text,
                 'You have successfully registered!')
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
 
         # Try to register admin with incorrect phone number for country
         self.driver.get(self.live_server_url + self.admin_registration_page)
@@ -377,6 +387,8 @@ class SignUpAdmin(LiveServerTestCase):
         self.driver.find_element_by_xpath('//form[1]').submit()
 
         # verify that user wasn't registered
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.admin_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_phone_number')/div/p/strong").text,
@@ -399,8 +411,84 @@ class SignUpAdmin(LiveServerTestCase):
         self.driver.find_element_by_xpath('//form[1]').submit()
 
         # verify that user wasn't registered
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.admin_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_phone_number')/div/p/strong").text,
                 "Please enter a valid phone number")
+
+    def test_organization_field(self):
+
+        # register valid admin user
+        self.driver.get(self.live_server_url + self.admin_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('admin-username')
+        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('email@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('admin-address')
+        self.driver.find_element_by_id('id_city').send_keys('admin-city')
+        self.driver.find_element_by_id('id_state').send_keys('admin-state')
+        self.driver.find_element_by_id('id_country').send_keys('admin-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify successful registration
+        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
+                None)
+        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
+                'You have successfully registered!')
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
+
+        # test numeric characters in organization
+        self.driver.get(self.live_server_url + self.admin_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
+        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('admin-address')
+        self.driver.find_element_by_id('id_city').send_keys('admin-city')
+        self.driver.find_element_by_id('id_state').send_keys('admin-state')
+        self.driver.find_element_by_id('id_country').send_keys('admin-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('13 admin-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify successful registration
+        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
+                None)
+        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
+                'You have successfully registered!')
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
+
+        # Use invalid characters in organization
+        self.driver.get(self.live_server_url + self.admin_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('admin-username-2')
+        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('email2@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('admin-address')
+        self.driver.find_element_by_id('id_city').send_keys('admin-city')
+        self.driver.find_element_by_id('id_state').send_keys('admin-state')
+        self.driver.find_element_by_id('id_country').send_keys('admin-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('!$&admin-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify that user wasn't registered
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.admin_registration_page)
+        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
+                None)
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_unlisted_organization')/div/p/strong").text,
+                "Enter a valid value.")
 

--- a/vms/registration/tests/test_functional_admin.py
+++ b/vms/registration/tests/test_functional_admin.py
@@ -38,6 +38,9 @@ class SignUpAdmin(LiveServerTestCase):
     Organization Field:
         - Test Null Values
         - Test legit characters as per Models defined
+
+    Retention of fields:
+        - Field values are checked to see that they are not lost when the page gets reloaded
     '''
     def setUp(self):        
         # create an org prior to registration. Bug in Code
@@ -492,3 +495,62 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_unlisted_organization')/div/p/strong").text,
                 "Enter a valid value.")
 
+    def test_field_value_retention(self):
+
+        # send invalid value in fields - first name, state, phone, organization
+        self.driver.get(self.live_server_url + self.admin_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('admin-username')
+        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name-3')
+        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('admin-address')
+        self.driver.find_element_by_id('id_city').send_keys('admin-city')
+        self.driver.find_element_by_id('id_state').send_keys('admin-state!')
+        self.driver.find_element_by_id('id_country').send_keys('admin-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('99999.!9999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('@#admin-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify that user wasn't registered and that field values are not erased
+        self.assertEqual(self.driver.current_url, self.live_server_url + self.admin_registration_page)
+        self.assertEqual(self.driver.find_element_by_id('id_username').get_attribute('value'),'admin-username')
+        self.assertEqual(self.driver.find_element_by_id('id_first_name').get_attribute('value'),'admin-first-name-3')
+        self.assertEqual(self.driver.find_element_by_id('id_last_name').get_attribute('value'),'admin-last-name')
+        self.assertEqual(self.driver.find_element_by_id('id_email').get_attribute('value'),'email1@systers.org')
+        self.assertEqual(self.driver.find_element_by_id('id_address').get_attribute('value'),'admin-address')
+        self.assertEqual(self.driver.find_element_by_id('id_city').get_attribute('value'),'admin-city')
+        self.assertEqual(self.driver.find_element_by_id('id_state').get_attribute('value'),'admin-state!')
+        self.assertEqual(self.driver.find_element_by_id('id_country').get_attribute('value'),'admin-country')
+        self.assertEqual(self.driver.find_element_by_id('id_phone_number').get_attribute('value'),'99999.!9999')
+        self.assertEqual(self.driver.find_element_by_id('id_unlisted_organization').get_attribute('value'),'@#admin-org')
+
+        # send invalid value in fields - last name, address, city, country
+        self.driver.get(self.live_server_url + self.admin_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('admin-username')
+        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name-3')
+        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('admin-address$@!')
+        self.driver.find_element_by_id('id_city').send_keys('admin-city#$')
+        self.driver.find_element_by_id('id_state').send_keys('admin-state')
+        self.driver.find_element_by_id('id_country').send_keys('admin-country 15')
+        self.driver.find_element_by_id('id_phone_number').send_keys('999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify that user wasn't registered and that field values are not erased
+        self.assertEqual(self.driver.current_url, self.live_server_url + self.admin_registration_page)
+        self.assertEqual(self.driver.find_element_by_id('id_username').get_attribute('value'),'admin-username')
+        self.assertEqual(self.driver.find_element_by_id('id_first_name').get_attribute('value'),'admin-first-name')
+        self.assertEqual(self.driver.find_element_by_id('id_last_name').get_attribute('value'),'admin-last-name-3')
+        self.assertEqual(self.driver.find_element_by_id('id_email').get_attribute('value'),'email1@systers.org')
+        self.assertEqual(self.driver.find_element_by_id('id_address').get_attribute('value'),'admin-address$@!')
+        self.assertEqual(self.driver.find_element_by_id('id_city').get_attribute('value'),'admin-city#$')
+        self.assertEqual(self.driver.find_element_by_id('id_state').get_attribute('value'),'admin-state')
+        self.assertEqual(self.driver.find_element_by_id('id_country').get_attribute('value'),'admin-country 15')
+        self.assertEqual(self.driver.find_element_by_id('id_phone_number').get_attribute('value'),'999999999')
+        self.assertEqual(self.driver.find_element_by_id('id_unlisted_organization').get_attribute('value'),'admin-org')

--- a/vms/registration/tests/test_functional_admin.py
+++ b/vms/registration/tests/test_functional_admin.py
@@ -25,6 +25,10 @@ class SignUpAdmin(LiveServerTestCase):
     Location Field (Address, City, State, Country):
         - Test Null Values
         - Test legit characters as per Models defined
+
+    Email Field:
+        - Test Null Values
+        - Test uniqueness of field
     '''
     def setUp(self):        
         # create an org prior to registration. Bug in Code
@@ -202,7 +206,7 @@ class SignUpAdmin(LiveServerTestCase):
                 None)
         self.assertEqual(self.driver.find_element_by_class_name('messages').text,
                 'You have successfully registered!')
-        
+
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.homepage)
 
@@ -267,4 +271,50 @@ class SignUpAdmin(LiveServerTestCase):
                 'Enter a valid value.')
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_country')/div/p/strong").text,
                 'Enter a valid value.')
+
+    def test_email_field(self):
+
+        # register valid admin user
+        self.driver.get(self.live_server_url + self.admin_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('admin-username')
+        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('email@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('admin-address')
+        self.driver.find_element_by_id('id_city').send_keys('admin-city')
+        self.driver.find_element_by_id('id_state').send_keys('admin-state')
+        self.driver.find_element_by_id('id_country').send_keys('admin-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify successful registration
+        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
+                None)
+        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
+                'You have successfully registered!')
+
+        # Try to register admin again with same email address
+        self.driver.get(self.live_server_url + self.admin_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
+        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('email@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('admin-address')
+        self.driver.find_element_by_id('id_city').send_keys('admin-city')
+        self.driver.find_element_by_id('id_state').send_keys('admin-state')
+        self.driver.find_element_by_id('id_country').send_keys('admin-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify that user wasn't registered
+        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
+                None)
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_email')/div/p/strong").text,
+                'Administrator with this Email already exists.')
 

--- a/vms/registration/tests/test_functional_admin.py
+++ b/vms/registration/tests/test_functional_admin.py
@@ -22,11 +22,7 @@ class SignUpAdmin(LiveServerTestCase):
         - Register admin with already registered username
         - Test length of name fields ( 30 char, limit)
 
-    Address Field:
-        - Test Null Values
-        - Test legit characters as per Models defined
-
-    City Field:
+    Location Field (Address, City, State, Country):
         - Test Null Values
         - Test legit characters as per Models defined
     '''
@@ -65,6 +61,9 @@ class SignUpAdmin(LiveServerTestCase):
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
+        # verify that 10 of the fields are compulsory
+        self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
+                10)
 
     def test_name_fields(self):
         # register valid admin user
@@ -182,7 +181,7 @@ class SignUpAdmin(LiveServerTestCase):
         error_message = self.driver.find_element_by_xpath("id('div_id_last_name')/div/p/strong").text,
         self.assertTrue(bool(re.search(r'Ensure this value has at most 20 characters', str(error_message))))
 
-    def test_address_field(self):
+    def test_location_fields(self):
         # register valid admin user
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
@@ -203,11 +202,11 @@ class SignUpAdmin(LiveServerTestCase):
                 None)
         self.assertEqual(self.driver.find_element_by_class_name('messages').text,
                 'You have successfully registered!')
-
+        
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.homepage)
 
-        # test numeric characters in address
+        # test numeric characters in address, city, state, country
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
         self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
@@ -216,22 +215,29 @@ class SignUpAdmin(LiveServerTestCase):
         self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
         self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
         self.driver.find_element_by_id('id_address').send_keys('123 New-City address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
+        self.driver.find_element_by_id('id_city').send_keys('1 admin-city')
+        self.driver.find_element_by_id('id_state').send_keys('007 admin-state')
+        self.driver.find_element_by_id('id_country').send_keys('54 admin-country')
         self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
         self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
         self.driver.find_element_by_xpath('//form[1]').submit()
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
+        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
-
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
+                self.admin_registration_page)
 
-        # test special characters in address
+        #verify that messages are displayed for city, state and country but not address
+        self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
+                3)
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_city')/div/p/strong").text,
+                'Enter a valid value.')
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_state')/div/p/strong").text,
+                'Enter a valid value.')
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_country')/div/p/strong").text,
+                'Enter a valid value.')
+
+        # test special characters in address, city, state, country
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
         self.driver.find_element_by_id('id_username').send_keys('admin-username-2')
@@ -240,9 +246,9 @@ class SignUpAdmin(LiveServerTestCase):
         self.driver.find_element_by_id('id_last_name').send_keys('last-name')
         self.driver.find_element_by_id('id_email').send_keys('email2@systers.org')
         self.driver.find_element_by_id('id_address').send_keys('admin-address!@#$()')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
+        self.driver.find_element_by_id('id_city').send_keys('!$@%^#&admin-city')
+        self.driver.find_element_by_id('id_state').send_keys('!$@%^#&admin-state')
+        self.driver.find_element_by_id('id_country').send_keys('&%^*admin-country!@$#')
         self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
         self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
         self.driver.find_element_by_xpath('//form[1]').submit()
@@ -251,76 +257,14 @@ class SignUpAdmin(LiveServerTestCase):
                 None)
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.admin_registration_page)
+
+        # verify that messages are displayed for all fields
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_address')/div/p/strong").text,
                 'Enter a valid value.')
-
-    def test_city_field(self):
-        # register valid admin user
-        self.driver.get(self.live_server_url + self.admin_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('admin-username')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
-
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
-
-        # test numeric characters in city
-        self.driver.get(self.live_server_url + self.admin_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('13th admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.admin_registration_page)
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_city')/div/p/strong").text,
                 'Enter a valid value.')
-
-        # test special characters in city
-        self.driver.get(self.live_server_url + self.admin_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('!@#$%^&*()_+city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.admin_registration_page)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_city')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_state')/div/p/strong").text,
                 'Enter a valid value.')
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_country')/div/p/strong").text,
+                'Enter a valid value.')
+

--- a/vms/registration/tests/test_functional_volunteer.py
+++ b/vms/registration/tests/test_functional_volunteer.py
@@ -33,6 +33,10 @@ class SignUpVolunteer(LiveServerTestCase):
         - Test Null Values
         - Test validity of number against country entered
         - Test legit characters as per Models defined
+
+    Organization Field:
+        - Test Null Values
+        - Test legit characters as per Models defined
     '''
     def setUp(self):
         # create an org prior to registration. Bug in Code
@@ -317,6 +321,8 @@ class SignUpVolunteer(LiveServerTestCase):
                 None)
         self.assertEqual(self.driver.find_element_by_class_name('messages').text,
                 'You have successfully registered!')
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
 
         # Try to register volunteer again with same email address
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
@@ -335,6 +341,8 @@ class SignUpVolunteer(LiveServerTestCase):
         self.driver.find_element_by_xpath('//form[1]').submit()
 
         # verify that volunteer wasn't registered
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.volunteer_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_email')/div/p/strong").text,
@@ -363,6 +371,8 @@ class SignUpVolunteer(LiveServerTestCase):
                 None)
         self.assertEqual(self.driver.find_element_by_class_name('messages').text,
                 'You have successfully registered!')
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
 
         # Try to register volunteer with incorrect phone number for country
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
@@ -381,6 +391,8 @@ class SignUpVolunteer(LiveServerTestCase):
         self.driver.find_element_by_xpath('//form[1]').submit()
 
         # verify that user wasn't registered
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.volunteer_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_phone_number')/div/p/strong").text,
@@ -403,7 +415,85 @@ class SignUpVolunteer(LiveServerTestCase):
         self.driver.find_element_by_xpath('//form[1]').submit()
 
         # verify that user wasn't registered
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.volunteer_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_phone_number')/div/p/strong").text,
                 "Please enter a valid phone number")
+
+    def test_organization_field(self):
+
+        # register valid volunteer user
+        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
+        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('volunteer-email@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
+        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
+        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
+        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify successful registration
+        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
+                None)
+        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
+                'You have successfully registered!')
+
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
+
+        # test numeric characters in organization
+        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
+        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
+        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
+        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
+        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org 13')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify successful registration
+        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
+                None)
+        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
+                'You have successfully registered!')
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
+
+        # Use invalid characters in organization
+        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-2')
+        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('volunteer-email2@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
+        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
+        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
+        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('!*^$volunteer-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify that user wasn't registered
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.volunteer_registration_page)
+        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
+                None)
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_unlisted_organization')/div/p/strong").text,
+                "Enter a valid value.")
+

--- a/vms/registration/tests/test_functional_volunteer.py
+++ b/vms/registration/tests/test_functional_volunteer.py
@@ -7,6 +7,7 @@ from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
 from organization.models import Organization #hack to pass travis,Bug in Code
+from cities_light.models import Country
 
 
 class SignUpVolunteer(LiveServerTestCase):
@@ -31,12 +32,30 @@ class SignUpVolunteer(LiveServerTestCase):
     Email Field:
         - Test Null Values
         - Test uniqueness of field
+
+    Phone Number Field:
+        - Test Null Values
+        - Test validity of number against country entered
+        - Test legit characters as per Models defined
     '''
     def setUp(self):
         # create an org prior to registration. Bug in Code
         # added to pass CI
         Organization.objects.create(
                 name = 'DummyOrg')
+
+        # country created so that phone number can be checked
+        Country.objects.create(
+                name_ascii = 'India',
+                slug ='india',
+                geoname_id = '1269750',
+                alternate_names = '',
+                name = 'India',
+                code2 = 'IN',
+                code3 = 'IND',
+                continent = 'AS',
+                tld = 'in',
+                phone = '91')
 
         self.homepage = '/'
         self.volunteer_registration_page = '/registration/signup_volunteer/'
@@ -378,3 +397,71 @@ class SignUpVolunteer(LiveServerTestCase):
                 None)
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_email')/div/p/strong").text,
                 'Volunteer with this Email already exists.')
+
+    def test_phone_field(self):
+
+        # register valid volunteer user with valid phone number for country
+        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
+        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('volunteer-email@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
+        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
+        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
+        self.driver.find_element_by_id('id_country').send_keys('India')
+        self.driver.find_element_by_id('id_phone_number').send_keys('022 2403 6606')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify successful registration
+        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
+                None)
+        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
+                'You have successfully registered!')
+
+        # Try to register volunteer with incorrect phone number for country
+        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
+        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
+        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
+        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
+        self.driver.find_element_by_id('id_country').send_keys('India')
+        self.driver.find_element_by_id('id_phone_number').send_keys('237937913')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify that user wasn't registered
+        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
+                None)
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_phone_number')/div/p/strong").text,
+                "This phone number isn't valid for the selected country")
+
+        # Use invalid characters in phone number
+        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
+        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
+        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
+        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
+        self.driver.find_element_by_id('id_country').send_keys('India')
+        self.driver.find_element_by_id('id_phone_number').send_keys('23&79^37913')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify that user wasn't registered
+        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
+                None)
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_phone_number')/div/p/strong").text,
+                "Please enter a valid phone number")

--- a/vms/registration/tests/test_functional_volunteer.py
+++ b/vms/registration/tests/test_functional_volunteer.py
@@ -21,11 +21,7 @@ class SignUpVolunteer(LiveServerTestCase):
         - Register volunteer with already registered username
         - Test length of name fields ( 30 char, limit)
 
-    Address Field:
-        - Test Null Values
-        - Test legit characters as per Models defined
-
-    City Field:
+    Location Field (Address, City, State, Country):
         - Test Null Values
         - Test legit characters as per Models defined
 
@@ -209,7 +205,8 @@ class SignUpVolunteer(LiveServerTestCase):
         error_message = self.driver.find_element_by_xpath("id('div_id_last_name')/div/p/strong").text,
         self.assertTrue(bool(re.search(r'Ensure this value has at most 30 characters', str(error_message))))
 
-    def test_address_field(self):
+    def test_location_fields(self):
+
         # register valid volunteer user
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
@@ -234,7 +231,7 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.homepage)
 
-        # test numeric characters in address
+        # test numeric characters in address, city, state, country
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
         self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
@@ -243,33 +240,41 @@ class SignUpVolunteer(LiveServerTestCase):
         self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
         self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
         self.driver.find_element_by_id('id_address').send_keys('123 New-City address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
+        self.driver.find_element_by_id('id_city').send_keys('1 volunteer-city')
+        self.driver.find_element_by_id('id_state').send_keys('007 volunteer-state')
+        self.driver.find_element_by_id('id_country').send_keys('54 volunteer-country')
         self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
         self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
         self.driver.find_element_by_xpath('//form[1]').submit()
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
+        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
-
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
+                self.volunteer_registration_page)
 
-        # test special characters in address
+        # Verify that messages are displayed for city, state and country but not address
+        # Test commented out as there is a bug in the template
+        """self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
+                3)"""
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_city')/div/p/strong").text,
+                'Enter a valid value.')
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_state')/div/p/strong").text,
+                'Enter a valid value.')
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_country')/div/p/strong").text,
+                'Enter a valid value.')
+
+        # Test special characters in address, city, state, country
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
         self.driver.find_element_by_id('id_username').send_keys('volunteer-username-2')
         self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('last-name')
+        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
         self.driver.find_element_by_id('id_email').send_keys('volunteer-email2@systers.org')
         self.driver.find_element_by_id('id_address').send_keys('volunteer-address!@#$()')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
+        self.driver.find_element_by_id('id_city').send_keys('!$@%^#&volunteer-city')
+        self.driver.find_element_by_id('id_state').send_keys('!$@%^#&volunteer-state')
+        self.driver.find_element_by_id('id_country').send_keys('&%^*volunteer-country!@$#')
         self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
         self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
         self.driver.find_element_by_xpath('//form[1]').submit()
@@ -278,78 +283,15 @@ class SignUpVolunteer(LiveServerTestCase):
                 None)
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.volunteer_registration_page)
+
+        # verify that messages are displayed for all fields
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_address')/div/p/strong").text,
                 'Enter a valid value.')
-
-    def test_city_field(self):
-        # register valid volunteer user
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
-
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
-
-        # test numeric characters in city
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('13th volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.volunteer_registration_page)
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_city')/div/p/strong").text,
                 'Enter a valid value.')
-
-        # test special characters in city
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('!@#$%^&*()_+city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.volunteer_registration_page)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_city')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_state')/div/p/strong").text,
+                'Enter a valid value.')
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_country')/div/p/strong").text,
                 'Enter a valid value.')
 
     def test_email_field(self):

--- a/vms/registration/tests/test_functional_volunteer.py
+++ b/vms/registration/tests/test_functional_volunteer.py
@@ -27,6 +27,10 @@ class SignUpVolunteer(LiveServerTestCase):
     City Field:
         - Test Null Values
         - Test legit characters as per Models defined
+
+    Email Field:
+        - Test Null Values
+        - Test uniqueness of field
     '''
     def setUp(self):
         # create an org prior to registration. Bug in Code
@@ -64,6 +68,9 @@ class SignUpVolunteer(LiveServerTestCase):
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
+        # verify that all of the fields are compulsory
+        self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
+                11)
 
     def test_name_fields(self):
         # register valid volunteer user
@@ -325,3 +332,49 @@ class SignUpVolunteer(LiveServerTestCase):
                 self.volunteer_registration_page)
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_city')/div/p/strong").text,
                 'Enter a valid value.')
+
+    def test_email_field(self):
+
+        # register valid volunteer user
+        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
+        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('volunteer-email@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
+        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
+        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
+        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify successful registration
+        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
+                None)
+        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
+                'You have successfully registered!')
+
+        # Try to register volunteer again with same email address
+        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
+        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('volunteer-email@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
+        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
+        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
+        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify that volunteer wasn't registered
+        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
+                None)
+        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_email')/div/p/strong").text,
+                'Volunteer with this Email already exists.')

--- a/vms/registration/tests/test_functional_volunteer.py
+++ b/vms/registration/tests/test_functional_volunteer.py
@@ -37,6 +37,9 @@ class SignUpVolunteer(LiveServerTestCase):
     Organization Field:
         - Test Null Values
         - Test legit characters as per Models defined
+
+    Retention of fields:
+        - Field values are checked to see that they are not lost when the page gets reloaded
     '''
     def setUp(self):
         # create an org prior to registration. Bug in Code
@@ -496,4 +499,64 @@ class SignUpVolunteer(LiveServerTestCase):
                 None)
         self.assertEqual(self.driver.find_element_by_xpath("id('div_id_unlisted_organization')/div/p/strong").text,
                 "Enter a valid value.")
+
+    def test_field_value_retention(self):
+
+        # send invalid value in fields - first name, state, phone, organization
+        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
+        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name-3')
+        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
+        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
+        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
+        self.driver.find_element_by_id('id_state').send_keys('volunteer-state!')
+        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
+        self.driver.find_element_by_id('id_phone_number').send_keys('99999.!9999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('@#volunteer-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify that user wasn't registered and that field values are not erased
+        self.assertEqual(self.driver.current_url, self.live_server_url + self.volunteer_registration_page)
+        self.assertEqual(self.driver.find_element_by_id('id_username').get_attribute('value'),'volunteer-username')
+        self.assertEqual(self.driver.find_element_by_id('id_first_name').get_attribute('value'),'volunteer-first-name-3')
+        self.assertEqual(self.driver.find_element_by_id('id_last_name').get_attribute('value'),'volunteer-last-name')
+        self.assertEqual(self.driver.find_element_by_id('id_email').get_attribute('value'),'email1@systers.org')
+        self.assertEqual(self.driver.find_element_by_id('id_address').get_attribute('value'),'volunteer-address')
+        self.assertEqual(self.driver.find_element_by_id('id_city').get_attribute('value'),'volunteer-city')
+        self.assertEqual(self.driver.find_element_by_id('id_state').get_attribute('value'),'volunteer-state!')
+        self.assertEqual(self.driver.find_element_by_id('id_country').get_attribute('value'),'volunteer-country')
+        self.assertEqual(self.driver.find_element_by_id('id_phone_number').get_attribute('value'),'99999.!9999')
+        self.assertEqual(self.driver.find_element_by_id('id_unlisted_organization').get_attribute('value'),'@#volunteer-org')
+
+        # send invalid value in fields - last name, address, city, country
+        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+
+        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
+        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
+        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
+        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name-3')
+        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
+        self.driver.find_element_by_id('id_address').send_keys('volunteer-address$@!')
+        self.driver.find_element_by_id('id_city').send_keys('volunteer-city#$')
+        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
+        self.driver.find_element_by_id('id_country').send_keys('volunteer-country 15')
+        self.driver.find_element_by_id('id_phone_number').send_keys('999999999')
+        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+        # verify that user wasn't registered and that field values are not erased
+        self.assertEqual(self.driver.current_url, self.live_server_url + self.volunteer_registration_page)
+        self.assertEqual(self.driver.find_element_by_id('id_username').get_attribute('value'),'volunteer-username')
+        self.assertEqual(self.driver.find_element_by_id('id_first_name').get_attribute('value'),'volunteer-first-name')
+        self.assertEqual(self.driver.find_element_by_id('id_last_name').get_attribute('value'),'volunteer-last-name-3')
+        self.assertEqual(self.driver.find_element_by_id('id_email').get_attribute('value'),'email1@systers.org')
+        self.assertEqual(self.driver.find_element_by_id('id_address').get_attribute('value'),'volunteer-address$@!')
+        self.assertEqual(self.driver.find_element_by_id('id_city').get_attribute('value'),'volunteer-city#$')
+        self.assertEqual(self.driver.find_element_by_id('id_state').get_attribute('value'),'volunteer-state')
+        self.assertEqual(self.driver.find_element_by_id('id_country').get_attribute('value'),'volunteer-country 15')
+        self.assertEqual(self.driver.find_element_by_id('id_phone_number').get_attribute('value'),'999999999')
+        self.assertEqual(self.driver.find_element_by_id('id_unlisted_organization').get_attribute('value'),'volunteer-org')
 


### PR DESCRIPTION
This PR is to add automated tests for admin/volunteer registration and shift sign up page

Earlier, 3 tests existed for name, address and city fields on admin/volunteer registration page.
Now tests for state, country phone number, organization and email have been added. The tests for address, city, state, country have been clubbed as a single location test, hence ensuring that 1 test does the job which earlier 4 tests would have completed. This has been done for both volunteer and admin separately.

Please review.

@tapasweni-pathak I have added in more tests here for the shift sign up page too. The list of all tests now added are

- test for phone field (both volunteer and admin)

- test for state field (both volunteer and admin)

- test for email field (both volunteer and admin)

- test for country field (both volunteer and admin)

- test for organization field (both volunteer and admin)

- test for retention of form field values, when reloaded (both volunteer and admin)

- test for search events on shift sign up page

- test for shift sign up when events are outdated

- test for shift sign up when shift does not have slots left

In total there are 150 tests now and this is the corresponding [Build](https://travis-ci.org/smarshy/vms/builds/137120599)