### PR TITLE
Restructuring selenium tests

### DIFF
--- a/vms/administrator/tests/test_formFields.py
+++ b/vms/administrator/tests/test_formFields.py
@@ -1,11 +1,11 @@
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
-from django.contrib.auth.models import User
-from administrator.models import Administrator
-from volunteer.models import Volunteer
-from event.models import Event
-from job.models import Job
-from shift.models import Shift, VolunteerShift
+from shift.utils import (
+    create_admin,
+    create_event_with_details,
+    create_job_with_details,
+    create_shift_with_details
+    )
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
@@ -20,99 +20,92 @@ class FormFields(LiveServerTestCase):
     - validation of number of volunteers field
     '''
 
+    @classmethod
+    def setUpClass(cls):
+        cls.homepage = '/'
+        cls.authentication_page = '/authentication/login/'
+        cls.event_list_page = '/event/list/'
+        cls.job_list_page = '/job/list/'
+        cls.shift_list_page = '/shift/list_jobs/'
+        cls.login_id = 'id_login'
+        cls.login_password = 'id_password'
+
+        cls.create_event_name ='//input[@placeholder = "Event Name"]'
+        cls.create_event_start_date = '//input[@name = "start_date"]'
+        cls.create_event_end_date = '//input[@name = "end_date"]'
+        cls.create_event_id = '//select[@name = "event_id"]'
+        cls.create_job_name = '//input[@placeholder = "Job Name"]'
+        cls.create_job_description = '//textarea[@name = "description"]'
+        cls.create_job_start_date = '//input[@name = "start_date"]'
+        cls.create_job_end_date = '//input[@name = "end_date"]'
+        cls.create_shift_date = '//input[@name = "date"]'
+        cls.create_shift_start_time = '//input[@name = "start_time"]'
+        cls.create_shift_end_time = '//input[@name = "end_time"]'
+        cls.create_shift_max_volunteer = '//input[@name = "max_volunteers"]'
+
+        cls.create_event_url = '/event/create/'
+
+        cls.driver = webdriver.Firefox()
+        cls.driver.implicitly_wait(5)
+        cls.driver.maximize_window()
+        super(FormFields, cls).setUpClass()
+
     def setUp(self):
-        admin_user = User.objects.create_user(
-            username='admin',
-            password='admin')
-
-        Administrator.objects.create(
-            user=admin_user,
-            address='address',
-            city='city',
-            state='state',
-            country='country',
-            email='admin@admin.com',
-            phone_number='9999999999',
-            unlisted_organization='organization')
-
-        self.homepage = '/'
-        self.authentication_page = '/authentication/login/'
-        self.event_list_page = '/event/list/'
-        self.job_list_page = '/job/list/'
-        self.shift_list_page = '/shift/list_jobs/'
-        self.driver = webdriver.Firefox()
-        self.driver.implicitly_wait(10)
-        self.driver.maximize_window()
-        super(FormFields, self).setUp()
+        create_admin()
+        self.login_admin()
+        self.go_to_events_page()
 
     def tearDown(self):
-        self.driver.quit()
-        super(FormFields, self).tearDown()
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        super(FormFields, cls).tearDownClass()
 
     def login(self, credentials):
         self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id(
-            'id_login').send_keys(credentials['username'])
-        self.driver.find_element_by_id('id_password').send_keys(
+        self.driver.find_element_by_id(self.login_id).send_keys(credentials['username'])
+        self.driver.find_element_by_id(self.login_password).send_keys(
             credentials['password'])
         self.driver.find_element_by_xpath('//form[1]').submit()
 
-    def register_volunteer_utility(self, name, number):
-        volunteer_user = User.objects.create_user(
-            username=name,
-            password='volunteer')
+    def check_event_form_values(self, event):
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//input[@placeholder = "Event Name"]').get_attribute('value'),
+            event[0])
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//input[@name = "start_date"]').get_attribute('value'),
+            event[1])
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//input[@name = "end_date"]').get_attribute('value'),
+            event[2])
 
-        e_id = 'volunteer@volunteer' + str(number)
+    def check_job_form_values(self, job):
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//input[@placeholder = "Job Name"]').get_attribute('value'),
+            job[1])
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//textarea[@name = "description"]').get_attribute(
+            'value'), job[2])
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//input[@name = "start_date"]').get_attribute(
+            'value'), job[3])
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//input[@name = "end_date"]').get_attribute(
+            'value'), job[4])
 
-        volunteer = Volunteer.objects.create(
-            user=volunteer_user,
-            first_name='Michael',
-            last_name='Reed',
-            address='address',
-            city='city',
-            state='state',
-            country='country',
-            phone_number='9999999999',
-            email=e_id,
-            unlisted_organization='organization')
-
-        return volunteer
-
-    def register_event_utility(self, ):
-
-        event = Event.objects.create(
-            name='event',
-            start_date='2017-06-15',
-            end_date='2017-06-17')
-
-        return event
-
-    def register_job_utility(self, event):
-
-        job = Job.objects.create(
-            name='job',
-            start_date='2017-06-15',
-            end_date='2017-06-15',
-            event=event)
-
-        return job
-
-    def register_shift_utility(self, job):
-
-        shift = Shift.objects.create(
-            date='2017-06-15',
-            start_time='09:00',
-            end_time='15:00',
-            max_volunteers='6',
-            job=job)
-
-        return shift
-
-    def register_volunteer_for_shift_utility(self, shift, volunteer):
-        vol_shift = VolunteerShift.objects.create(
-            shift=shift,
-            volunteer=volunteer)
-        return vol_shift
+    def check_shift_form_values(self, shift):
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//input[@name = "date"]').get_attribute('value'), shift[0])
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//input[@name = "start_time"]').get_attribute('value'), shift[1])
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//input[@name = "end_time"]').get_attribute(
+            'value'), shift[2])
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//input[@name = "max_volunteers"]').get_attribute(
+            'value'), shift[3])
 
     def navigate_to_event_list_view(self):
         self.driver.get(self.live_server_url + self.event_list_page)
@@ -125,254 +118,374 @@ class FormFields(LiveServerTestCase):
         self.driver.find_element_by_xpath(
             '//table//tbody//tr[1]/td[5]//a').click()
 
-    def fill_event_form(self, event):
-        self.driver.find_element_by_xpath(
-            '//input[@placeholder = "Event Name"]').send_keys(
-            event[0])
-        self.driver.find_element_by_xpath(
-            '//input[@name = "start_date"]').send_keys(
-            event[1])
-        self.driver.find_element_by_xpath(
-            '//input[@name = "end_date"]').send_keys(
-            event[2])
-        self.driver.find_element_by_xpath('//form[1]').submit()
+    def go_to_events_page(self):
+        self.driver.find_element_by_link_text('Events').send_keys("\n")
 
-    def fill_job_form(self, job):
-        self.driver.find_element_by_xpath(
-            '//select[@name = "event_id"]').send_keys(
-            job[0])
-        self.driver.find_element_by_xpath(
-            '//input[@placeholder = "Job Name"]').send_keys(
-            job[1])
-        self.driver.find_element_by_xpath(
-            '//textarea[@name = "description"]').send_keys(
-            job[2])
-        self.driver.find_element_by_xpath(
-            '//input[@name = "start_date"]').send_keys(
-            job[3])
-        self.driver.find_element_by_xpath(
-            '//input[@name = "end_date"]').send_keys(
-            job[4])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def fill_shift_form(self, shift):
-        self.driver.find_element_by_xpath(
-            '//input[@name = "date"]').send_keys(
-            shift[0])
-        self.driver.find_element_by_xpath(
-            '//input[@name = "start_time"]').send_keys(
-            shift[1])
-        self.driver.find_element_by_xpath(
-            '//input[@name = "end_time"]').send_keys(
-            shift[2])
-        self.driver.find_element_by_xpath(
-            '//input[@name = "max_volunteers"]').send_keys(
-            shift[3])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def test_field_value_retention_for_event(self):
-        self.login({'username': 'admin', 'password': 'admin'})
-        self.navigate_to_event_list_view()
-
+    def go_to_create_event_page(self):
         self.driver.find_element_by_link_text('Create Event').click()
-        self.assertEqual(self.driver.current_url,
-                         self.live_server_url + '/event/create/')
+        self.assertEqual(self.driver.current_url,self.live_server_url +
+            '/event/create/')
 
-        event = ['event-name!@', '07/21/2016', '09/28/2017']
-        self.fill_event_form(event)
-
-        # verify that event was not created and that field values are not
-        # erased
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                         '/event/create/')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@placeholder = "Event Name"]').get_attribute('value'),
-            'event-name!@')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "start_date"]').get_attribute('value'),
-            '07/21/2016')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "end_date"]').get_attribute('value'),
-            '09/28/2017')
-
-        # now create an event and edit it
-        # verify that event was not edited and that field values are not
-        # erased
-        event_1 = self.register_event_utility()
-        self.navigate_to_event_list_view()
+    def go_to_edit_event_page(self):
         self.assertEqual(self.driver.find_element_by_xpath(
             '//table//tbody//tr[1]//td[5]').text, 'Edit')
         self.driver.find_element_by_xpath(
             '//table//tbody//tr[1]//td[5]//a').click()
 
-        self.driver.find_element_by_xpath(
-            '//input[@placeholder = "Event Name"]').clear()
-        self.driver.find_element_by_xpath(
-            '//input[@name = "start_date"]').clear()
-        self.driver.find_element_by_xpath(
-            '//input[@name = "end_date"]').clear()
+    def go_to_create_job_page(self):
+        self.driver.get(self.live_server_url +'/job/create/')
 
-        self.fill_event_form(event)
-        self.assertNotEqual(self.driver.current_url, self.live_server_url +
-                            '/event/create/')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@placeholder = "Event Name"]').get_attribute('value'),
-            'event-name!@')
-        """self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "start_date"]').get_attribute('value'),
-            '07/21/2016')"""
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "end_date"]').get_attribute('value'),
-            '09/28/2017')
-
-    def test_field_value_retention_for_job(self):
-        self.login({'username': 'admin', 'password': 'admin'})
-        event_1 = self.register_event_utility()
-        self.navigate_to_job_list_view()
-
-        self.driver.find_element_by_link_text('Create Job').click()
-        self.assertEqual(self.driver.current_url,
-                         self.live_server_url + '/job/create/')
-
-        job = [
-            'event',
-            'job name#$',
-            'job description',
-            '05/29/2016',
-            '09/11/2017']
-        self.fill_job_form(job)
-
-        # verify that job was not created and that field values are not
-        # erased
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                         '/job/create/')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@placeholder = "Job Name"]').get_attribute('value'),
-            'job name#$')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//textarea[@name = "description"]').get_attribute(
-            'value'), 'job description')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "start_date"]').get_attribute(
-            'value'), '05/29/2016')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "end_date"]').get_attribute(
-            'value'), '09/11/2017')
-
-        # now create job and edit it
-        # verify that job was not edited and that field values are not
-        # erased
-        job_1 = self.register_job_utility(event_1)
-        self.navigate_to_job_list_view()
-
+    def go_to_edit_job_page(self):
         self.assertEqual(self.driver.find_element_by_xpath(
             '//table//tbody//tr[1]//td[6]').text, 'Edit')
         self.driver.find_element_by_xpath(
             '//table//tbody//tr[1]//td[6]//a').click()
 
-        self.driver.find_element_by_xpath(
-            '//input[@name = "name"]').clear()
-        self.driver.find_element_by_xpath(
-            '//textarea[@name = "description"]').clear()
-        self.driver.find_element_by_xpath(
-            '//input[@name = "start_date"]').clear()
-        self.driver.find_element_by_xpath(
-            '//input[@name = "end_date"]').clear()
-
-        self.fill_job_form(job)
-        # verify that job was not created and that field values are not
-        # erased
-        self.assertNotEqual(self.driver.current_url, self.live_server_url +
-                            self.job_list_page)
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@placeholder = "Job Name"]').get_attribute('value'),
-            'job name#$')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//textarea[@name = "description"]').get_attribute('value'),
-            'job description')
-        """self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "start_date"]').get_attribute('value'),
-            '05/29/2016')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "end_date"]').get_attribute('value'),
-            '09/11/2017')"""
-
-    def test_field_value_retention_for_shift(self):
-        self.login({'username': 'admin', 'password': 'admin'})
-        event_1 = self.register_event_utility()
-        job_1 = self.register_job_utility(event_1)
-
-        self.navigate_to_shift_list_view()
+    def go_to_create_shift_page(self):
         self.driver.find_element_by_link_text('Create Shift').click()
 
-        shift = [
-            '01/01/2016',
-            '12:00',
-            '11:00',
-            '10']
-        self.fill_shift_form(shift)
-
-        # verify that shift was not created and that field values are not
-        # erased
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "date"]').get_attribute('value'), '01/01/2016')
-        """self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "start_time"]').get_attribute('value'), '12:00')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "end_time"]').get_attribute(
-            'value'), '11:00')"""
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "max_volunteers"]').get_attribute(
-            'value'), '10')
-
-        # now create shift and edit it
-        # verify that shift was not edited and that field values are not
-        # erased
-        shift_1 = self.register_shift_utility(job_1)
-        self.navigate_to_shift_list_view()
-
+    def go_to_edit_shift_page(self):
         self.assertEqual(self.driver.find_element_by_xpath(
             '//table//tbody//tr[1]//td[5]').text, 'Edit')
         self.driver.find_element_by_xpath(
             '//table//tbody//tr[1]//td[5]//a').click()
 
-        self.driver.find_element_by_xpath(
-            '//input[@name = "date"]').clear()
-        self.driver.find_element_by_xpath(
-            '//input[@name = "start_time"]').clear()
-        self.driver.find_element_by_xpath(
-            '//input[@name = "end_time"]').clear()
-        self.driver.find_element_by_xpath(
-            '//input[@name = "max_volunteers"]').clear()
-
-        self.fill_shift_form(shift)
-        # verify that shift was not created and that field values are not
-        # erased
-        """self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "date"]').get_attribute('value'), '01/01/2016')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "start_time"]').get_attribute('value'), '12:00')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "end_time"]').get_attribute(
-            'value'), '11:00')"""
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "max_volunteers"]').get_attribute(
-            'value'), '10')
-
-    def test_max_volunteer_field(self):
+    def login_admin(self):
         self.login({'username': 'admin', 'password': 'admin'})
-        event_1 = self.register_event_utility()
-        job_1 = self.register_job_utility(event_1)
+
+    def fill_event_form(self, event):
+        self.driver.find_element_by_xpath(
+            self.create_event_name).clear()
+        self.driver.find_element_by_xpath(
+            self.create_event_start_date).clear()
+        self.driver.find_element_by_xpath(
+            self.create_event_end_date).clear()
+        self.driver.find_element_by_xpath(
+            self.create_event_name).send_keys(
+            event[0])
+        self.driver.find_element_by_xpath(
+            self.create_event_start_date).send_keys(
+            event[1])
+        self.driver.find_element_by_xpath(
+            self.create_event_end_date).send_keys(
+            event[2])
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+    def fill_job_form(self, job):
+        self.driver.find_element_by_xpath(
+            self.create_job_name).clear()
+        self.driver.find_element_by_xpath(
+            self.create_job_description).clear()
+        self.driver.find_element_by_xpath(
+            self.create_job_start_date).clear()
+        self.driver.find_element_by_xpath(
+            self.create_job_end_date).clear()
+
+        self.driver.find_element_by_xpath(
+            self.create_event_id).send_keys(
+            job[0])
+        self.driver.find_element_by_xpath(
+            self.create_job_name).send_keys(
+            job[1])
+        self.driver.find_element_by_xpath(
+            self.create_job_description).send_keys(
+            job[2])
+        self.driver.find_element_by_xpath(
+            self.create_job_start_date).send_keys(
+            job[3])
+        self.driver.find_element_by_xpath(
+            self.create_job_end_date).send_keys(
+            job[4])
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+    def fill_shift_form(self, shift):
+        self.driver.find_element_by_xpath(
+            self.create_shift_date).clear()
+        self.driver.find_element_by_xpath(
+            self.create_shift_start_time).clear()
+        self.driver.find_element_by_xpath(
+            self.create_shift_end_time).clear()
+        self.driver.find_element_by_xpath(
+            self.create_shift_max_volunteer).clear()
+
+        self.driver.find_element_by_xpath(
+            self.create_shift_date).send_keys(
+            shift[0])
+        self.driver.find_element_by_xpath(
+            self.create_shift_start_time).send_keys(
+            shift[1])
+        self.driver.find_element_by_xpath(
+            self.create_shift_end_time).send_keys(
+            shift[2])
+        self.driver.find_element_by_xpath(
+            self.create_shift_max_volunteer).send_keys(
+            shift[3])
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+    def test_null_values_in_create_event(self):
+        event = ['', '', '']
+        self.go_to_create_event_page()
+        self.fill_event_form(event)
+
+        # check that event was not created and that error messages appear as
+        # expected
+        self.assertEqual(self.driver.current_url,self.live_server_url +
+            self.create_event_url)
+        self.assertEqual(
+            len(self.driver.find_elements_by_class_name('help-block')), 3)
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[1]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[2]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[3]/div/p/strong").text, 'This field is required.')
+
+    # Parts of test commented out, as they are throwing server error
+    def test_null_values_in_edit_event(self):
+        event = ['event-name', '2017-08-21', '2017-09-28']
+        created_event = create_event_with_details(event)
+
+        self.assertEqual(self.driver.find_element_by_xpath(
+            '//table//tbody//tr[1]//td[1]').text, created_event.name)
+
+        self.go_to_edit_event_page()
+        edited_event = ['', '', '']
+        self.fill_event_form(edited_event)
+
+        # check that event was not edited and that error messages appear as
+        # expected
+        self.assertNotEqual(self.driver.current_url,self.live_server_url +
+            self.event_list_page)
+        """self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),3)
+
+        self.assertEqual(self.driver.find_element_by_xpath("//form//div[1]/div/p/strong").text,
+                'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath("//form//div[2]/div/p/strong").text,
+                'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath("//form//div[3]/div/p/strong").text,
+                'This field is required.')"""
+
+    def test_null_values_in_create_job(self):
+
+        # register event first to create job
+        event = ['event-name', '2017-08-21', '2017-09-28']
+        created_event = create_event_with_details(event)
+
+        # create job with null values
+        job = [created_event.id, '', '', '', '']
+        self.go_to_create_job_page()
+        self.fill_job_form(job)
+
+        # check that job was not created and that error messages appear as
+        # expected
+        self.assertEqual(self.driver.current_url,self.live_server_url +
+            '/job/create/')
+        self.assertEqual(
+            len(self.driver.find_elements_by_class_name('help-block')), 3)
+
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[3]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[5]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[6]/div/p/strong").text, 'This field is required.')
+
+    def test_null_values_in_edit_job(self):
+
+        # register event first to create job
+        event = ['event-name', '2017-08-21', '2017-09-28']
+        created_event = create_event_with_details(event)
+
+        # create job with values
+        job = ['job', '2017-08-21', '2017-08-21', '',created_event]
+        created_job = create_job_with_details(job)
+
+        # verify the job was created and proceed to edit it
+        self.navigate_to_job_list_view()
+        self.go_to_edit_job_page()
+
+        # send null values to fields
+        self.fill_job_form([created_event.id,'','','',''])
+
+        # check that job was not edited and that error messages appear as
+        # expected
+        self.assertNotEqual(self.driver.current_url, 
+            self.live_server_url + '/job/list/')
+        self.assertEqual(
+            len(self.driver.find_elements_by_class_name('help-block')), 3)
+
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[3]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[5]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[6]/div/p/strong").text, 'This field is required.')
+
+    def test_null_values_in_create_shift(self):
+
+        # register event to create job
+        event = ['event-name', '2017-08-21', '2017-09-28']
+        created_event = create_event_with_details(event)
+
+        # create job with values
+        job = ['job', '2017-08-21', '2017-08-21', '',created_event]
+        created_job = create_job_with_details(job)
 
         self.navigate_to_shift_list_view()
-        self.driver.find_element_by_link_text('Create Shift').click()
+        self.go_to_create_shift_page()
 
-        shift = [
-            '01/01/2016',
-            '12:00',
-            '11:00',
-            '0']
+        # create shift
+        shift = ['', '', '', '']
         self.fill_shift_form(shift)
+
+        # verify that shift was not created and error messages appear as
+        # expected
+        self.assertEqual(
+            len(self.driver.find_elements_by_class_name('help-block')), 4)
+
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[4]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[5]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[6]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[7]/div/p/strong").text, 'This field is required.')
+
+    def test_null_values_in_edit_shift(self):
+        # register event to create job
+        event = ['event-name', '2017-08-21', '2017-09-28']
+        created_event = create_event_with_details(event)
+
+        # create job with values
+        job = ['job', '2017-08-21', '2017-08-21', '',created_event]
+        created_job = create_job_with_details(job)
+
+        # create shift
+        shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
+        created_shift = create_shift_with_details(shift)
+
+        self.navigate_to_shift_list_view()
+        self.go_to_edit_shift_page()
+
+        # edit shift with null values
+        shift = ['', '', '', '']
+        self.fill_shift_form(shift)
+
+        # verify that shift was not edited and error messages appear as
+        # expected
+        self.assertEqual(
+            len(self.driver.find_elements_by_class_name('help-block')), 4)
+
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[4]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[5]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[6]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            "//form//div[7]/div/p/strong").text, 'This field is required.')
+
+    def test_field_value_retention_for_event(self):
+        self.navigate_to_event_list_view()
+        self.go_to_create_event_page()
+
+        invalid_event = ['event-name!@', '07/21/2016', '09/28/2017']
+        self.fill_event_form(invalid_event)
+
+        # verify that event was not created and that field values are not
+        # erased
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                         '/event/create/')
+        self.check_event_form_values(invalid_event)
+
+        # now create an event and edit it
+        # verify that event was not edited and that field values are not
+        # erased
+        event = ['event-name', '2017-08-21', '2017-09-28']
+        created_event = create_event_with_details(event)
+        self.navigate_to_event_list_view()
+        self.go_to_edit_event_page()
+        self.fill_event_form(invalid_event)
+        self.assertNotEqual(self.driver.current_url, self.live_server_url +
+                            '/event/create/')
+        # self.check_event_form_values(invalid_event)
+
+    def test_field_value_retention_for_job(self):
+        event = ['event-name', '2017-08-21', '2017-09-28']
+        created_event = create_event_with_details(event)
+        self.navigate_to_job_list_view()
+        self.go_to_create_job_page()
+
+        invalid_job = [
+            created_event.id,
+            'job name#$',
+            'job description',
+            '27/05/2016',
+            '09/11/2017']
+        self.fill_job_form(invalid_job)
+
+        # verify that job was not created and that field values are not
+        # erased
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                         '/job/create/')
+        self.check_job_form_values(invalid_job)
+
+        # now create job and edit it
+        # verify that job was not edited and that field values are not
+        # erased
+        job = ['job', '2017-08-21', '2017-08-21', '',created_event]
+        created_job = create_job_with_details(job)
+        self.navigate_to_job_list_view()
+
+        self.go_to_edit_job_page()
+        self.fill_job_form(invalid_job)
+        # verify that job was not created and that field values are not
+        # erased
+        self.assertNotEqual(self.driver.current_url, self.live_server_url +
+                            self.job_list_page)
+        #self.check_job_form_values(invalid_job)
+
+    def test_field_value_retention_for_shift(self):
+        event = ['event-name', '2017-08-21', '2017-09-28']
+        created_event = create_event_with_details(event)
+        job = ['job', '2017-08-21', '2017-08-21', '',created_event]
+        created_job = create_job_with_details(job)
+
+        self.navigate_to_shift_list_view()
+        self.go_to_create_shift_page()
+
+        invalid_shift = ['01/01/2016', '12:00', '11:00', '10']
+        self.fill_shift_form(invalid_shift)
+
+        # verify that shift was not created and that field values are not
+        # erased
+        # self.check_shift_form_values(invalid_shift)
+
+        # now create shift and edit it
+        # verify that shift was not edited and that field values are not
+        # erased
+        shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
+        created_shift = create_shift_with_details(shift)
+        self.navigate_to_shift_list_view()
+        self.go_to_edit_shift_page()
+
+        self.fill_shift_form(invalid_shift)
+        # verify that shift was not created and that field values are not
+        # erased
+        # self.check_shift_form_values(invalid_shift)
+
+    def test_max_volunteer_field(self):
+        event = ['event-name', '2017-08-21', '2017-09-28']
+        created_event = create_event_with_details(event)
+        job = ['job', '2017-08-21', '2017-08-21', '',created_event]
+        created_job = create_job_with_details(job)
+
+        self.navigate_to_shift_list_view()
+        self.go_to_create_shift_page()
+
+        invalid_shift = ['01/01/2016','12:00','11:00','0']
+        self.fill_shift_form(invalid_shift)
 
         # verify that error message displayed
         self.assertEqual(self.driver.find_element_by_xpath(
@@ -380,24 +493,12 @@ class FormFields(LiveServerTestCase):
             'Ensure this value is greater than or equal to 1.')
 
         # Create shift and try editing it with 0 value
-        shift_1 = self.register_shift_utility(job_1)
+        shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
+        created_shift = create_shift_with_details(shift)
+
         self.navigate_to_shift_list_view()
-
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]').text, 'Edit')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]//a').click()
-
-        self.driver.find_element_by_xpath(
-            '//input[@name = "date"]').clear()
-        self.driver.find_element_by_xpath(
-            '//input[@name = "start_time"]').clear()
-        self.driver.find_element_by_xpath(
-            '//input[@name = "end_time"]').clear()
-        self.driver.find_element_by_xpath(
-            '//input[@name = "max_volunteers"]').clear()
-
-        self.fill_shift_form(shift)
+        self.go_to_edit_shift_page()
+        self.fill_shift_form(invalid_shift)
 
         # verify that error message displayed
         self.assertEqual(self.driver.find_element_by_xpath(
@@ -405,46 +506,42 @@ class FormFields(LiveServerTestCase):
             'Ensure this value is greater than or equal to 1.')
 
     def test_simplify_shift(self):
-        self.login({'username': 'admin', 'password': 'admin'})
-        event_1 = self.register_event_utility()
-        job_1 = self.register_job_utility(event_1)
+        event = ['event-name', '2017-08-21', '2017-09-28']
+        created_event = create_event_with_details(event)
+        job = ['job', '2017-08-21', '2017-08-21', '',created_event]
+        created_job = create_job_with_details(job)
 
         self.navigate_to_shift_list_view()
-        self.driver.find_element_by_link_text('Create Shift').click()
+        self.go_to_create_shift_page()
 
         # verify that the correct job name and date are displayed
         self.assertEqual(self.driver.find_element_by_xpath(
             "//div[2]//div[1]/p").text, 'job')
         self.assertEqual(self.driver.find_element_by_xpath(
-            "//div[2]//div[2]/p").text, 'June 15, 2017')
+            "//div[2]//div[2]/p").text, 'Aug. 21, 2017')
         self.assertEqual(self.driver.find_element_by_xpath(
-            "//div[2]//div[3]/p").text, 'June 15, 2017')
+            "//div[2]//div[3]/p").text, 'Aug. 21, 2017')
 
         # Create shift and check job details in edit form
-        shift_1 = self.register_shift_utility(job_1)
+        shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
+        created_shift = create_shift_with_details(shift)
         self.navigate_to_shift_list_view()
-
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]').text, 'Edit')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]//a').click()
+        self.go_to_edit_shift_page()
 
         # verify that the correct job name and date are displayed
         self.assertEqual(self.driver.find_element_by_xpath(
             "//div[2]//div[1]/p").text, 'job')
         self.assertEqual(self.driver.find_element_by_xpath(
-            "//div[2]//div[2]/p").text, 'June 15, 2017')
+            "//div[2]//div[2]/p").text, 'Aug. 21, 2017')
         self.assertEqual(self.driver.find_element_by_xpath(
-            "//div[2]//div[3]/p").text, 'June 15, 2017')
+            "//div[2]//div[3]/p").text, 'Aug. 21, 2017')
 
     """def test_simplify_job(self):
-        self.login({'username': 'admin', 'password': 'admin'})
-        event_1 = self.register_event_utility()
-        self.navigate_to_job_list_view()
+        event = ['event-name', '2017-08-21', '2017-09-28']
+        created_event = create_event_with_details(event)
 
-        self.driver.find_element_by_link_text('Create Job').click()
-        self.assertEqual(self.driver.current_url,
-                         self.live_server_url + '/job/create/')
+        self.navigate_to_job_list_view()
+        self.go_to_create_job_page()
 
         # verify that the correct event name and date are displayed
         select = Select(self.driver.find_element_by_id(
@@ -458,11 +555,7 @@ class FormFields(LiveServerTestCase):
         # Create job and check event details in edit form
         job_1 = self.register_job_utility(event_1)
         self.navigate_to_job_list_view()
-
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[6]').text, 'Edit')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[6]//a').click()
+        self.go_to_edit_job_page()
 
         # verify that the correct event name and date are displayed
         select = Select(self.driver.find_element_by_id(
@@ -472,3 +565,4 @@ class FormFields(LiveServerTestCase):
             'start_date_here').text, 'June 15, 2017')
         self.assertEqual(self.driver.find_element_by_id(
             'end_date_here').text, 'June 17, 2017')"""
+    

--- a/vms/authentication/tests/test_login.py
+++ b/vms/authentication/tests/test_login.py
@@ -1,0 +1,118 @@
+from django.contrib.staticfiles.testing import LiveServerTestCase
+
+from selenium import webdriver
+from selenium.common.exceptions import NoSuchElementException
+
+from shift.utils import (
+    create_admin,
+    create_volunteer
+    )
+
+import re
+
+class TestAccessControl(LiveServerTestCase):
+    '''
+    TestAccessControl class contains the functional tests to check Admin and
+    Volunteer can access '/home' view of VMS. Following tests are included:
+    Administrator:
+        - Login admin with correct credentials
+        - Login admin with incorrect credentials 
+    Volunteer:
+        - Login volunteer with correct credentials
+        - Login volunteer with incorrect credentials 
+    '''
+    @classmethod
+    def setUpClass(cls):
+        cls.homepage = '/'
+        cls.authentication_page = '/authentication/login/'
+        cls.login_id = 'id_login'
+        cls.login_password = 'id_password'
+        cls.incorrect_login_error = 'alert-danger'
+
+        cls.driver = webdriver.Firefox()
+        cls.driver.maximize_window()
+        super(TestAccessControl, cls).setUpClass()
+
+    def setUp(self):
+        admin = create_admin()
+        volunteer = create_volunteer()
+
+    def tearDown(self):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        super(TestAccessControl, cls).tearDownClass()
+
+    def login(self, credentials):
+        self.driver.get(self.live_server_url + self.authentication_page)
+        self.driver.find_element_by_id(self.login_id).send_keys(credentials['username'])
+        self.driver.find_element_by_id(self.login_password).send_keys(credentials['password'])
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+    def logout(self):
+        self.driver.find_element_by_link_text('Log Out').click()
+
+    def test_authentication_page(self):
+        self.driver.get(self.live_server_url + self.homepage)
+        self.driver.find_element_by_link_text('Log In').click()
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.authentication_page)
+
+    def test_correct_admin_credentials(self):
+        '''
+        Method to simulate logging in of a valid admin user and check if they
+        redirected to '/home' and no errors are generated.
+        '''
+        self.login({ 'username' : 'admin', 'password' : 'admin'})
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
+
+        with self.assertRaises(NoSuchElementException):
+            self.driver.find_element_by_class_name(self.incorrect_login_error)
+        self.logout()
+
+    def test_incorrect_admin_credentials(self):
+        '''
+        Method to simulate logging in of an Invalid admin user and check if
+        they are displayed an error and redirected to login page again.
+        '''
+        self.login({ 'username' : 'admin', 'password' : 'wrong_password'})
+        self.assertNotEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
+
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.authentication_page)
+
+        self.assertNotEqual(self.driver.find_element_by_class_name(
+            self.incorrect_login_error), None)
+
+    def test_correct_volunteer_credentials(self):
+        '''
+        Method to simulate logging in of a valid volunteer user and check if
+        they are redirected to '/home'
+        '''
+        self.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
+
+        with self.assertRaises(NoSuchElementException):
+            self.driver.find_element_by_class_name(self.incorrect_login_error)
+        self.logout()
+
+    def test_incorrect_volunteer_credentials(self):
+        '''
+        Method to simulate logging in of a Invalid volunteer user and check if
+        they are displayed an error and redirected to login page again.
+        '''
+        self.login({ 'username' : 'volunteer', 'password' : 'wrong_password'})
+        
+        self.assertNotEqual(self.driver.current_url, self.live_server_url +
+                self.homepage)
+
+        self.assertEqual(self.driver.current_url, self.live_server_url +
+                self.authentication_page)
+
+        self.assertNotEqual(self.driver.find_element_by_class_name(
+            self.incorrect_login_error), None)

--- a/vms/event/tests/test_shiftSignUp.py
+++ b/vms/event/tests/test_shiftSignUp.py
@@ -1,120 +1,108 @@
-from django.test import TestCase
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
-from django.contrib.auth.models import User
-from volunteer.models import Volunteer
-from event.models import Event
 from job.models import Job
-from shift.models import Shift, VolunteerShift
+from shift.models import VolunteerShift
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
-from organization.models import Organization #hack to pass travis,Bug in Code
-
+from shift.utils import (
+    create_organization,
+    create_volunteer,
+    register_event_utility,
+    register_job_utility,
+    register_shift_utility,
+    create_volunteer_with_details,
+    create_shift_with_details
+    )
 
 class ShiftSignUp(LiveServerTestCase):
     '''
     '''
+    @classmethod
+    def setUpClass(cls):
+        cls.homepage = '/'
+        cls.authentication_page = '/authentication/login/'
+        cls.login_id = 'id_login'
+        cls.login_password = 'id_password'
+        cls.view_jobs_path = '//table//tbody//tr[1]//td[4]'
+        cls.view_shifts_path = '//table//tbody//tr[1]//td[4]'
+        cls.event_signup_path = '//table//tbody//tr[1]//td[4]'
+        cls.shift_job_path = '//table//tbody//tr[1]//td[1]'
+        cls.shift_date_path = '//table//tbody//tr[1]//td[2]'
+        cls.shift_stime_path = '//table//tbody//tr[1]//td[3]'
+        cls.shift_etime_path = '//table//tbody//tr[1]//td[4]'
+        cls.event_list = '//table//tbody//tr[1]//td[1]'
+
+        cls.driver = webdriver.Firefox()
+        cls.driver.implicitly_wait(5)
+        cls.driver.maximize_window()
+        super(ShiftSignUp, cls).setUpClass()
+
     def setUp(self):
-        volunteer_user = User.objects.create_user(
-                username = 'volunteer',
-                password = 'volunteer')
-
-        Volunteer.objects.create(
-                user = volunteer_user,
-                address = 'address',
-                city = 'city',
-                state = 'state',
-                country = 'country',
-                phone_number = '9999999999',
-                email = 'volunteer@volunteer.com',
-                unlisted_organization = 'organization')
-
-        # create an org prior to registration. Bug in Code
-        # added to pass CI
-        Organization.objects.create(
-                name = 'DummyOrg')
-
-        self.homepage = '/'
-        self.authentication_page = '/authentication/login/'
-        self.driver = webdriver.Firefox()
-        self.driver.implicitly_wait(5)
-        self.driver.maximize_window()
-        super(ShiftSignUp, self).setUp()
+        create_volunteer()
 
     def tearDown(self):
-        self.driver.quit()
-        super(ShiftSignUp, self).tearDown()
+        pass
 
-    def login(self):
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        super(ShiftSignUp, cls).tearDownClass()
+
+    def click_to_view_jobs(self):
+        self.driver.find_element_by_xpath(
+                self.view_jobs_path + "//a").click()
+
+    def click_to_view_shifts(self):
+        self.driver.find_element_by_xpath(
+                self.view_shifts_path + "//a").click()
+
+    def click_to_sign_up(self):
+        self.assertEqual(self.driver.find_element_by_xpath(
+            self.event_signup_path).text, 'Sign Up')
+        self.driver.find_element_by_xpath(
+            self.event_signup_path + "//a").click()
+
+    def login(self, credentials):
         self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id('id_login').send_keys('volunteer')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer')
+        self.driver.find_element_by_id(self.login_id).send_keys(credentials['username'])
+        self.driver.find_element_by_id(self.login_password).send_keys(credentials['password'])
         self.driver.find_element_by_xpath('//form[1]').submit()
 
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url + self.homepage)
-
-    def register_event_utility(self):
-        Event.objects.create(
-                name = 'event',
-                start_date = '2016-05-10',
-                end_date = '2018-06-16')
-
-    def register_job_utility(self):
-        Job.objects.create(
-                name = 'job',
-                start_date = '2016-05-10',
-                end_date = '2017-06-15',
-                event = Event.objects.get(name = 'event'))
-
-    def register_shift_utility(self):
-        Shift.objects.create(
-                date = '2017-06-15',
-                start_time = '09:00',
-                end_time = '15:00',
-                max_volunteers ='6',
-                job = Job.objects.get(name = 'job'))
-
-    def test_events_page_with_no_events(self):
-        self.login()
-
-        # open Shift Sign Up
+    def login_volunteer_and_navigate_to_sign_up(self):
+        self.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
         self.driver.find_element_by_link_text('Shift Sign Up').click()
 
+    def fill_search_form(self, date):
+        self.driver.find_element_by_id('from').clear()
+        self.driver.find_element_by_id('to').clear()
+        self.driver.find_element_by_id('from').send_keys(date[0])
+        self.driver.find_element_by_id('to').send_keys(date[1])
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+    def test_events_page_with_no_events(self):
+        self.login_volunteer_and_navigate_to_sign_up()
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
                'There are no events.')
 
-
     def test_signup_shifts_with_registered_shifts(self):
-        # login
-        self.login()
 
-        self.register_event_utility()
-        self.register_job_utility()
-        self.register_shift_utility()
+        register_event_utility()
+        register_job_utility()
+        register_shift_utility()
 
-        # open Shift Sign Up
-        self.driver.find_element_by_link_text('Shift Sign Up').click()
+        # login and open Shift Sign Up
+        self.login_volunteer_and_navigate_to_sign_up()
 
         # on event page
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text, 'View Jobs')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+        self.click_to_view_jobs()
 
         # on jobs page
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text, 'View Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+        self.click_to_view_shifts()
 
         # on shifts page
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text, 'Sign Up')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+        self.click_to_sign_up()
 
         # confirm shift assignment
         self.driver.find_element_by_xpath('//form[1]').submit()
@@ -126,51 +114,37 @@ class ShiftSignUp(LiveServerTestCase):
             'html/body/div[2]/h3').text,
             'Upcoming Shifts')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text,
+            self.shift_job_path).text,
             'job')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[2]').text,
+            self.shift_date_path).text,
             'June 15, 2017')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[3]').text,
+            self.shift_stime_path).text,
             '9 a.m.')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
+            self.shift_etime_path).text,
             '3 p.m.')
 
     def test_signup_for_same_shift_again(self):
-        # login
-        self.login()
 
-        self.register_event_utility()
-        self.register_job_utility()
-        self.register_shift_utility()
+        register_event_utility()
+        register_job_utility()
+        register_shift_utility()
 
-        # open Shift Sign Up
-        self.driver.find_element_by_link_text('Shift Sign Up').click()
+        # login and open Shift Sign Up
+        self.login_volunteer_and_navigate_to_sign_up()
 
         # events shown in table
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_class_name('alert-info')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Jobs')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+        self.click_to_view_jobs()
 
         # on jobs page
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+        self.click_to_view_shifts()
 
         # on shifts page, Sign up this shift !
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'Sign Up')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+        self.click_to_sign_up()
 
         # confirm on shift sign up
         self.driver.find_element_by_xpath('//form[1]').submit()
@@ -187,148 +161,113 @@ class ShiftSignUp(LiveServerTestCase):
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_tag_name('table')
             self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text, 'View Jobs')
-
+            self.view_jobs_path).text, 'View Jobs')
 
     def test_empty_events(self):
-        self.login()
-
-        self.register_event_utility()
-
-        # open Shift Sign Up
-        self.driver.find_element_by_link_text('Shift Sign Up').click()
+        
+        register_event_utility()
+        self.login_volunteer_and_navigate_to_sign_up()
 
         # on event page
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
                'There are no events.')
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_tag_name('table')
-            self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text, 'View Jobs')
+            self.click_to_view_jobs()
 
-        self.register_job_utility()
+        register_job_utility()
 
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
                'There are no events.')
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_tag_name('table')
             self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text, 'View Jobs')
+            self.view_jobs_path).text, 'View Jobs')
 
     def test_shift_sign_up_with_outdated_shifts(self):
-        self.login()
 
-        self.register_event_utility()
-        self.register_job_utility()
+        register_event_utility()
+        register_job_utility()
 
         # create outdated shift
-        Shift.objects.create(
-                date = '2016-05-11',
-                start_time = '09:00',
-                end_time = '15:00',
-                max_volunteers ='6',
-                job = Job.objects.get(name = 'job'))
+        shift_1 = ["2016-05-11","9:00","15:00",6,Job.objects.get(name = 'job')]
+        s1 = create_shift_with_details(shift_1)
 
         # open Shift Sign Up
-        self.driver.find_element_by_link_text('Shift Sign Up').click()
+        self.login_volunteer_and_navigate_to_sign_up()
 
         # on event page
-        self.assertEqual(self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[4]').text, 'View Jobs')
-        self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[4]//a').click()
+        self.click_to_view_jobs()
 
         # on jobs page
-        self.assertEqual(self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[4]').text, 'View Shifts')
-        self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[4]//a').click()
-
+        self.click_to_view_shifts()
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are currently no shifts for the job job.')
 
     def test_shift_sign_up_with_no_slots(self):
 
-        self.register_event_utility()
-        self.register_job_utility()
+        register_event_utility()
+        register_job_utility()
 
         # create shift with no slot
-        shift_2 = Shift.objects.create(
-                date = '2016-05-11',
-                start_time = '09:00',
-                end_time = '15:00',
-                max_volunteers ='1',
-                job = Job.objects.get(name = 'job'))
+        shift_2 = ["2016-05-11","9:00","15:00",1,Job.objects.get(name = 'job')]
+        s2 = create_shift_with_details(shift_2)
 
         # Create another volunteer
-        volunteer_user_2 = User.objects.create_user(
-                username = 'volunteer-2',
-                password = 'volunteer')
-
-        volunteer_2 = Volunteer.objects.create(
-                user = volunteer_user_2,
-                address = 'address',
-                city = 'city',
-                state = 'state',
-                country = 'country',
-                phone_number = '9999999999',
-                email = 'volunteer2@volunteer.com',
-                unlisted_organization = 'organization')
+        volunteer_2 = ['volunteer-2',"Sam","Turtle","Mario Land","Nintendo Land","Nintendo State","Nintendo Nation","2374983247","volunteer2@volunteer.com"]
+        v2 = create_volunteer_with_details(volunteer_2)
 
         # Assign shift to the volunteer
         VolunteerShift.objects.create(
-                shift = shift_2,
-                volunteer = volunteer_2)
+                shift = s2,
+                volunteer = v2)
 
         # Login as volunteer 1 and open Shift Sign Up
-        self.login()
-        self.driver.find_element_by_link_text('Shift Sign Up').click()
+        self.login_volunteer_and_navigate_to_sign_up()
 
         # on event page
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
 
     def test_search_event(self):
 
-        self.register_event_utility()
-        self.register_job_utility()
-        self.register_shift_utility()
+        register_event_utility()
+        register_job_utility()
+        register_shift_utility()
 
         # Login as volunteer 1 and open Shift Sign Up
-        self.login()
-        self.driver.find_element_by_link_text('Shift Sign Up').click()
+        self.login_volunteer_and_navigate_to_sign_up()
 
         # enter date range in which an event starts
-        self.driver.find_element_by_id('from').send_keys('05/08/2016')
-        self.driver.find_element_by_id('to').send_keys('08/31/2017')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        date = ['05/08/2016', '08/31/2017']
+        self.fill_search_form(date)
         # verify that the event shows up
-        self.assertEqual(self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[1]').text, 'event')
+        self.assertEqual(self.driver.find_element_by_xpath(self.event_list).text, 'event')
 
         # enter date range in which no event starts
-        self.driver.find_element_by_id('from').clear()
-        self.driver.find_element_by_id('to').clear()
-        self.driver.find_element_by_id('from').send_keys('10/08/2016')
-        self.driver.find_element_by_id('to').send_keys('08/31/2017')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        date = ['10/08/2016', '08/31/2017']
+        self.fill_search_form(date)
         # verify that no event shows up on event page
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
 
-        # enter only incorrect starting date
-        self.driver.find_element_by_id('from').clear()
-        self.driver.find_element_by_id('to').clear()
-        self.driver.find_element_by_id('from').send_keys('10/08/2016')
+        """# enter only incorrect starting date
+        date = ['10/08/2016', '']
+        self.fill_search_form(date)
         # verify that no event shows up on event page
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
 
-        """# enter only correct starting date
-        self.driver.find_element_by_id('from').clear()
-        self.driver.find_element_by_id('from').send_keys('05/10/2016')
+        # enter only correct starting date
+        date = ['05/10/2016', '']
+        self.fill_search_form(date)
         # verify that the event shows up
-        self.assertEqual(self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[1]').text, 'event')"""
+        self.assertEqual(self.driver.find_element_by_xpath(self.event_list).text, 'event')
 
         # enter only incorrect ending date
-        self.driver.find_element_by_id('from').clear()
-        self.driver.find_element_by_id('to').send_keys('10/08/2015')
+        date = ['', '10/08/2015']
+        self.fill_search_form(date)
         # verify that no event shows up on event page
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
 
-        """# enter correct ending date
-        self.driver.find_element_by_id('to').clear()
-        self.driver.find_element_by_id('to').send_keys('06/15/2017')
+        # enter correct ending date
+        date = ['', '06/15/2017']
+        self.fill_search_form(date)
         # verify that the event shows up
-        self.assertEqual(self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[1]').text, 'event')"""
+        self.assertEqual(self.driver.find_element_by_xpath(self.event_list).text, 'event')"""

--- a/vms/registration/tests/test_functional_admin.py
+++ b/vms/registration/tests/test_functional_admin.py
@@ -1,15 +1,12 @@
-from django.test import TestCase
 from django.contrib.staticfiles.testing import LiveServerTestCase
-
-from django.contrib.auth.models import User
-
-import re
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
-from organization.models import Organization #hack to pass travis,Bug in Code
-from cities_light.models import Country
+import re
+
+from organization.models import Organization
+from shift.utils import create_organization, create_country
 
 class SignUpAdmin(LiveServerTestCase):
     '''
@@ -42,51 +39,92 @@ class SignUpAdmin(LiveServerTestCase):
     Retention of fields:
         - Field values are checked to see that they are not lost when the page gets reloaded
     '''
-    def setUp(self):        
+
+    @classmethod
+    def setUpClass(cls):
+        cls.homepage = '/'
+        cls.admin_registration_page = '/registration/signup_administrator/'
+        cls.authentication_page = '/authentication/login/'
+
+        cls.username = 'id_username'
+        cls.password = 'id_password'
+        cls.first_name = 'id_first_name'
+        cls.last_name = 'id_last_name'
+        cls.email = 'id_email'
+        cls.address = 'id_address'
+        cls.city = 'id_city'
+        cls.state = 'id_state'
+        cls.country = 'id_country'
+        cls.phone = 'id_phone_number'
+        cls.organization = 'id_unlisted_organization'
+
+        cls.username_error = "id('div_id_username')/div/p/strong"
+        cls.first_name_error = "id('div_id_first_name')/div/p/strong"
+        cls.last_name_error = "id('div_id_last_name')/div/p/strong"
+        cls.email_error = "id('div_id_email')/div/p/strong"
+        cls.address_error = "id('div_id_address')/div/p/strong"
+        cls.city_error = "id('div_id_city')/div/p/strong"
+        cls.state_error = "id('div_id_state')/div/p/strong"
+        cls.country_error = "id('div_id_country')/div/p/strong"
+        cls.phone_error = "id('div_id_phone_number')/div/p/strong"
+        cls.organization_error = "id('div_id_unlisted_organization')/div/p/strong"
+
+        cls.driver = webdriver.Firefox()
+        cls.driver.maximize_window()
+        super(SignUpAdmin, cls).setUpClass()
+
+    def setUp(self):
         # create an org prior to registration. Bug in Code
         # added to pass CI
-        Organization.objects.create(
-                name = 'DummyOrg')
+        create_organization()
 
         # country created so that phone number can be checked
-        Country.objects.create(
-                name_ascii = 'India',
-                slug ='india',
-                geoname_id = '1269750',
-                alternate_names = '',
-                name = 'India',
-                code2 = 'IN',
-                code3 = 'IND',
-                continent = 'AS',
-                tld = 'in',
-                phone = '91')
-
-        self.homepage = '/'
-        self.admin_registration_page = '/registration/signup_administrator/'
-        self.authentication_page = '/authentication/login/'
-        self.driver = webdriver.Firefox()
-        self.driver.maximize_window()
-        super(SignUpAdmin, self).setUp()
+        create_country()
 
     def tearDown(self):
-        self.driver.quit()
-        super(SignUpAdmin, self).tearDown()
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        super(SignUpAdmin, cls).tearDownClass()
+
+    def fill_registration_form(self, info):
+        self.driver.find_element_by_id(self.username).send_keys(info[0])
+        self.driver.find_element_by_id(self.password).send_keys(info[1])
+        self.driver.find_element_by_id(self.first_name).send_keys(info[2])
+        self.driver.find_element_by_id(self.last_name).send_keys(info[3])
+        self.driver.find_element_by_id(self.email).send_keys(info[4])
+        self.driver.find_element_by_id(self.address).send_keys(info[5])
+        self.driver.find_element_by_id(self.city).send_keys(info[6])
+        self.driver.find_element_by_id(self.state).send_keys(info[7])
+        self.driver.find_element_by_id(self.country).send_keys(info[8])
+        self.driver.find_element_by_id(self.phone).send_keys(info[9])
+        self.driver.find_element_by_id(self.organization).send_keys(info[10])
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+    def verify_field_values(self, info):
+        self.assertEqual(self.driver.find_element_by_id(self.username).get_attribute('value'),info[0])
+        self.assertEqual(self.driver.find_element_by_id(self.first_name).get_attribute('value'),info[1])
+        self.assertEqual(self.driver.find_element_by_id(self.last_name).get_attribute('value'),info[2])
+        self.assertEqual(self.driver.find_element_by_id(self.email).get_attribute('value'),info[3])
+        self.assertEqual(self.driver.find_element_by_id(self.address).get_attribute('value'),info[4])
+        self.assertEqual(self.driver.find_element_by_id(self.city).get_attribute('value'),info[5])
+        self.assertEqual(self.driver.find_element_by_id(self.state).get_attribute('value'),info[6])
+        self.assertEqual(self.driver.find_element_by_id(self.country).get_attribute('value'),info[7])
+        self.assertEqual(self.driver.find_element_by_id(self.phone).get_attribute('value'),info[8])
+        self.assertEqual(self.driver.find_element_by_id(self.organization).get_attribute('value'),info[9])
+
+    def register_valid_details(self):
+        self.driver.get(self.live_server_url + self.admin_registration_page)
+        entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
+        self.fill_registration_form(entry)
 
     def test_null_values(self):
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('')
-        self.driver.find_element_by_id('id_password').send_keys('')
-        self.driver.find_element_by_id('id_first_name').send_keys('')
-        self.driver.find_element_by_id('id_last_name').send_keys('')
-        self.driver.find_element_by_id('id_email').send_keys('')
-        self.driver.find_element_by_id('id_address').send_keys('')
-        self.driver.find_element_by_id('id_city').send_keys('')
-        self.driver.find_element_by_id('id_state').send_keys('')
-        self.driver.find_element_by_id('id_country').send_keys('')
-        self.driver.find_element_by_id('id_phone_number').send_keys('')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['','','','','','','','','','','']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
@@ -94,22 +132,16 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
                 10)
 
+    def test_successful_registration(self):
+        self.register_valid_details()
+        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
+                None)
+        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
+                'You have successfully registered!')
+
     def test_name_fields(self):
         # register valid admin user
-        self.driver.get(self.live_server_url + self.admin_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('admin-username')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        self.register_valid_details()
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
                 None)
@@ -122,134 +154,60 @@ class SignUpAdmin(LiveServerTestCase):
 
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email1@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_username')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.username_error).text,
                 'User with this Username already exists.')
 
         # test numeric characters in first-name, last-name
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name-1')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name-1')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name-1','admin-last-name-1','admin-email1@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_first_name')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.first_name_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_last_name')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.last_name_error).text,
                 'Enter a valid value.')
 
         # test special characters in first-name, last-name
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('name-!@#$%^&*()_')
-        self.driver.find_element_by_id('id_last_name').send_keys('name-!@#$%^&*()_')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username','admin-password!@#$%^&*()_','name-!@#$%^&*()_','name-!@#$%^&*()_','admin-email1@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_first_name')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.first_name_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_last_name')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.last_name_error).text,
                 'Enter a valid value.')
 
         # test length of first-name, last-name not exceed 30
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name-!@#$%^&*()_')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name-!@#$%^&*()_')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name-!@#$%^&*()_','admin-last-name-!@#$%^&*()_','admin-email1@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        error_message = self.driver.find_element_by_xpath("id('div_id_first_name')/div/p/strong").text
+        error_message = self.driver.find_element_by_xpath(self.first_name_error).text
         self.assertTrue(bool(re.search(r'Ensure this value has at most 20 characters', str(error_message))))
 
-        error_message = self.driver.find_element_by_xpath("id('div_id_last_name')/div/p/strong").text,
+        error_message = self.driver.find_element_by_xpath(self.last_name_error).text,
         self.assertTrue(bool(re.search(r'Ensure this value has at most 20 characters', str(error_message))))
 
     def test_location_fields(self):
-        # register valid admin user
-        self.driver.get(self.live_server_url + self.admin_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('admin-username')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
-
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
-
         # test numeric characters in address, city, state, country
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('123 New-City address')
-        self.driver.find_element_by_id('id_city').send_keys('1 admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('007 admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('54 admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','email1@systers.org','123 New-City address','1 admin-city','007 admin-state','54 admin-country','9999999999','admin-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
@@ -259,28 +217,18 @@ class SignUpAdmin(LiveServerTestCase):
         #verify that messages are displayed for city, state and country but not address
         self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
                 3)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_city')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.city_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_state')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.state_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_country')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.country_error).text,
                 'Enter a valid value.')
 
         # test special characters in address, city, state, country
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-2')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email2@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address!@#$()')
-        self.driver.find_element_by_id('id_city').send_keys('!$@%^#&admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('!$@%^#&admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('&%^*admin-country!@$#')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username-2','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','email2@systers.org','admin-address!@#$()','!$@%^#&admin-city','!$@%^#&admin-state','&%^*admin-country!@$#','9999999999','admin-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
@@ -288,32 +236,19 @@ class SignUpAdmin(LiveServerTestCase):
                 self.admin_registration_page)
 
         # verify that messages are displayed for all fields
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_address')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.address_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_city')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.city_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_state')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.state_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_country')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.country_error).text,
                 'Enter a valid value.')
 
     def test_email_field(self):
 
         # register valid admin user
-        self.driver.get(self.live_server_url + self.admin_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('admin-username')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        self.register_valid_details()
 
         # verify successful registration
         self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
@@ -326,25 +261,15 @@ class SignUpAdmin(LiveServerTestCase):
         # Try to register admin again with same email address
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
+        self.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.admin_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_email')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.email_error).text,
                 'Administrator with this Email already exists.')
 
     def test_phone_field(self):
@@ -352,18 +277,8 @@ class SignUpAdmin(LiveServerTestCase):
         # register valid admin user with valid phone number for country
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('India')
-        self.driver.find_element_by_id('id_phone_number').send_keys('022 2403 6606')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email@systers.org','admin-address','admin-city','admin-state','India','022 2403 6606','admin-org']
+        self.fill_registration_form(entry)
 
         # verify successful registration
         self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
@@ -376,92 +291,38 @@ class SignUpAdmin(LiveServerTestCase):
         # Try to register admin with incorrect phone number for country
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('India')
-        self.driver.find_element_by_id('id_phone_number').send_keys('237937913')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email1@systers.org','admin-address','admin-city','admin-state','India','237937913','admin-org']
+        self.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.admin_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_phone_number')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.phone_error).text,
                 "This phone number isn't valid for the selected country")
 
         # Use invalid characters in phone number
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('India')
-        self.driver.find_element_by_id('id_phone_number').send_keys('23&79^37913')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email1@systers.org','admin-address','admin-city','admin-state','India','23&79^37913','admin-org']
+        self.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.admin_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_phone_number')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.phone_error).text,
                 "Please enter a valid phone number")
 
     def test_organization_field(self):
 
-        # register valid admin user
-        self.driver.get(self.live_server_url + self.admin_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('admin-username')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        # verify successful registration
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
-
         # test numeric characters in organization
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('13 admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','email1@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','13 admin-org']
+        self.fill_registration_form(entry)
 
         # verify successful registration
         self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
@@ -474,25 +335,15 @@ class SignUpAdmin(LiveServerTestCase):
         # Use invalid characters in organization
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username-2')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email2@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('!$&admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username-2','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','email2@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','!$&admin-org']
+        self.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.admin_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_unlisted_organization')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.organization_error).text,
                 "Enter a valid value.")
 
     def test_field_value_retention(self):
@@ -500,57 +351,19 @@ class SignUpAdmin(LiveServerTestCase):
         # send invalid value in fields - first name, state, phone, organization
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name-3')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state!')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('99999.!9999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('@#admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name-3','admin-last-name','email1@systers.org','admin-address','admin-city','admin-state','admin-country','99999.!9999','@#admin-org']
+        self.fill_registration_form(entry)
 
         # verify that user wasn't registered and that field values are not erased
-        self.assertEqual(self.driver.current_url, self.live_server_url + self.admin_registration_page)
-        self.assertEqual(self.driver.find_element_by_id('id_username').get_attribute('value'),'admin-username')
-        self.assertEqual(self.driver.find_element_by_id('id_first_name').get_attribute('value'),'admin-first-name-3')
-        self.assertEqual(self.driver.find_element_by_id('id_last_name').get_attribute('value'),'admin-last-name')
-        self.assertEqual(self.driver.find_element_by_id('id_email').get_attribute('value'),'email1@systers.org')
-        self.assertEqual(self.driver.find_element_by_id('id_address').get_attribute('value'),'admin-address')
-        self.assertEqual(self.driver.find_element_by_id('id_city').get_attribute('value'),'admin-city')
-        self.assertEqual(self.driver.find_element_by_id('id_state').get_attribute('value'),'admin-state!')
-        self.assertEqual(self.driver.find_element_by_id('id_country').get_attribute('value'),'admin-country')
-        self.assertEqual(self.driver.find_element_by_id('id_phone_number').get_attribute('value'),'99999.!9999')
-        self.assertEqual(self.driver.find_element_by_id('id_unlisted_organization').get_attribute('value'),'@#admin-org')
+        details = ['admin-username','admin-first-name-3','admin-last-name','email1@systers.org','admin-address','admin-city','admin-state','admin-country','99999.!9999','@#admin-org']
+        self.verify_field_values(details)
 
         # send invalid value in fields - last name, address, city, country
         self.driver.get(self.live_server_url + self.admin_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('admin-username')
-        self.driver.find_element_by_id('id_password').send_keys('admin-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('admin-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('admin-last-name-3')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('admin-address$@!')
-        self.driver.find_element_by_id('id_city').send_keys('admin-city#$')
-        self.driver.find_element_by_id('id_state').send_keys('admin-state')
-        self.driver.find_element_by_id('id_country').send_keys('admin-country 15')
-        self.driver.find_element_by_id('id_phone_number').send_keys('999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('admin-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name','admin-last-name-3','email1@systers.org','admin-address$@!','admin-city#$','admin-state','admin-country 15','99999.!9999','@#admin-org']
+        self.fill_registration_form(entry)
 
         # verify that user wasn't registered and that field values are not erased
-        self.assertEqual(self.driver.current_url, self.live_server_url + self.admin_registration_page)
-        self.assertEqual(self.driver.find_element_by_id('id_username').get_attribute('value'),'admin-username')
-        self.assertEqual(self.driver.find_element_by_id('id_first_name').get_attribute('value'),'admin-first-name')
-        self.assertEqual(self.driver.find_element_by_id('id_last_name').get_attribute('value'),'admin-last-name-3')
-        self.assertEqual(self.driver.find_element_by_id('id_email').get_attribute('value'),'email1@systers.org')
-        self.assertEqual(self.driver.find_element_by_id('id_address').get_attribute('value'),'admin-address$@!')
-        self.assertEqual(self.driver.find_element_by_id('id_city').get_attribute('value'),'admin-city#$')
-        self.assertEqual(self.driver.find_element_by_id('id_state').get_attribute('value'),'admin-state')
-        self.assertEqual(self.driver.find_element_by_id('id_country').get_attribute('value'),'admin-country 15')
-        self.assertEqual(self.driver.find_element_by_id('id_phone_number').get_attribute('value'),'999999999')
-        self.assertEqual(self.driver.find_element_by_id('id_unlisted_organization').get_attribute('value'),'admin-org')
+        details = ['admin-username','admin-first-name','admin-last-name-3','email1@systers.org','admin-address$@!','admin-city#$','admin-state','admin-country 15','99999.!9999','@#admin-org']
+        self.verify_field_values(details)

--- a/vms/registration/tests/test_functional_volunteer.py
+++ b/vms/registration/tests/test_functional_volunteer.py
@@ -1,14 +1,12 @@
-from django.test import TestCase
 from django.contrib.staticfiles.testing import LiveServerTestCase
-
-import re
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
-from organization.models import Organization #hack to pass travis,Bug in Code
-from cities_light.models import Country
+import re
 
+from organization.models import Organization
+from shift.utils import create_organization, create_country
 
 class SignUpVolunteer(LiveServerTestCase):
     '''
@@ -41,52 +39,92 @@ class SignUpVolunteer(LiveServerTestCase):
     Retention of fields:
         - Field values are checked to see that they are not lost when the page gets reloaded
     '''
+    @classmethod
+    def setUpClass(cls):
+        cls.homepage = '/'
+        cls.volunteer_registration_page = '/registration/signup_volunteer/'
+        cls.authentication_page = '/authentication/login/'
+
+        cls.username = 'id_username'
+        cls.password = 'id_password'
+        cls.first_name = 'id_first_name'
+        cls.last_name = 'id_last_name'
+        cls.email = 'id_email'
+        cls.address = 'id_address'
+        cls.city = 'id_city'
+        cls.state = 'id_state'
+        cls.country = 'id_country'
+        cls.phone = 'id_phone_number'
+        cls.organization = 'id_unlisted_organization'
+
+        cls.username_error = "id('div_id_username')/div/p/strong"
+        cls.first_name_error = "id('div_id_first_name')/div/p/strong"
+        cls.last_name_error = "id('div_id_last_name')/div/p/strong"
+        cls.email_error = "id('div_id_email')/div/p/strong"
+        cls.address_error = "id('div_id_address')/div/p/strong"
+        cls.city_error = "id('div_id_city')/div/p/strong"
+        cls.state_error = "id('div_id_state')/div/p/strong"
+        cls.country_error = "id('div_id_country')/div/p/strong"
+        cls.phone_error = "id('div_id_phone_number')/div/p/strong"
+        cls.organization_error = "id('div_id_unlisted_organization')/div/p/strong"
+
+        cls.driver = webdriver.Firefox()
+        cls.driver.maximize_window()
+        super(SignUpVolunteer, cls).setUpClass()
+
     def setUp(self):
         # create an org prior to registration. Bug in Code
         # added to pass CI
-        Organization.objects.create(
-                name = 'DummyOrg')
+        create_organization()
 
         # country created so that phone number can be checked
-        Country.objects.create(
-                name_ascii = 'India',
-                slug ='india',
-                geoname_id = '1269750',
-                alternate_names = '',
-                name = 'India',
-                code2 = 'IN',
-                code3 = 'IND',
-                continent = 'AS',
-                tld = 'in',
-                phone = '91')
-
-        self.homepage = '/'
-        self.volunteer_registration_page = '/registration/signup_volunteer/'
-        self.authentication_page = '/authentication/login/'
-        self.driver = webdriver.Firefox()
-        self.driver.maximize_window()
-        super(SignUpVolunteer, self).setUp()
+        create_country()
 
     def tearDown(self):
-        self.driver.quit()
-        super(SignUpVolunteer, self).tearDown()
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        super(SignUpVolunteer, cls).tearDownClass()
+
+    def fill_registration_form(self, info):
+        self.driver.find_element_by_id(self.username).send_keys(info[0])
+        self.driver.find_element_by_id(self.password).send_keys(info[1])
+        self.driver.find_element_by_id(self.first_name).send_keys(info[2])
+        self.driver.find_element_by_id(self.last_name).send_keys(info[3])
+        self.driver.find_element_by_id(self.email).send_keys(info[4])
+        self.driver.find_element_by_id(self.address).send_keys(info[5])
+        self.driver.find_element_by_id(self.city).send_keys(info[6])
+        self.driver.find_element_by_id(self.state).send_keys(info[7])
+        self.driver.find_element_by_id(self.country).send_keys(info[8])
+        self.driver.find_element_by_id(self.phone).send_keys(info[9])
+        self.driver.find_element_by_id(self.organization).send_keys(info[10])
+        self.driver.find_element_by_xpath('//form[1]').submit()
+
+    def verify_field_values(self, info):
+        self.assertEqual(self.driver.find_element_by_id(self.username).get_attribute('value'),info[0])
+        self.assertEqual(self.driver.find_element_by_id(self.first_name).get_attribute('value'),info[1])
+        self.assertEqual(self.driver.find_element_by_id(self.last_name).get_attribute('value'),info[2])
+        self.assertEqual(self.driver.find_element_by_id(self.email).get_attribute('value'),info[3])
+        self.assertEqual(self.driver.find_element_by_id(self.address).get_attribute('value'),info[4])
+        self.assertEqual(self.driver.find_element_by_id(self.city).get_attribute('value'),info[5])
+        self.assertEqual(self.driver.find_element_by_id(self.state).get_attribute('value'),info[6])
+        self.assertEqual(self.driver.find_element_by_id(self.country).get_attribute('value'),info[7])
+        self.assertEqual(self.driver.find_element_by_id(self.phone).get_attribute('value'),info[8])
+        self.assertEqual(self.driver.find_element_by_id(self.organization).get_attribute('value'),info[9])
+
+    def register_valid_details(self):
+        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
+        self.fill_registration_form(entry)
 
     def test_null_values(self):
         self.driver.get(self.live_server_url
                         + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('')
-        self.driver.find_element_by_id('id_password').send_keys('')
-        self.driver.find_element_by_id('id_first_name').send_keys('')
-        self.driver.find_element_by_id('id_last_name').send_keys('')
-        self.driver.find_element_by_id('id_email').send_keys('')
-        self.driver.find_element_by_id('id_address').send_keys('')
-        self.driver.find_element_by_id('id_city').send_keys('')
-        self.driver.find_element_by_id('id_state').send_keys('')
-        self.driver.find_element_by_id('id_country').send_keys('')
-        self.driver.find_element_by_id('id_phone_number').send_keys('')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['','','','','','','','','','','']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
@@ -94,24 +132,16 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
                 11)
 
+    def test_successful_registration(self):
+        self.register_valid_details()
+        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
+                None)
+        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
+                'You have successfully registered!')
+
     def test_name_fields(self):
         # register valid volunteer user
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
-
-
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
+        self.register_valid_details()
         self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
                 None)
         self.assertEqual(self.driver.find_element_by_class_name('messages').text,
@@ -123,136 +153,60 @@ class SignUpVolunteer(LiveServerTestCase):
 
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email1@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_username')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.username_error).text,
                 'User with this Username already exists.')
 
         # test numeric characters in first-name, last-name
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name-1')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name-1')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys(
-            'volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name-1','volunteer-last-name-1','volunteer-email1@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_first_name')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.first_name_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_last_name')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.last_name_error).text,
                 'Enter a valid value.')
 
         # test special characters in first-name, last-name
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('first-name-!@#$%^&*()_')
-        self.driver.find_element_by_id('id_last_name').send_keys('last-name-!@#$%^&*()_')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','first-name-!@#$%^&*()_','last-name!@#$%^&*()_','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_first_name')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.first_name_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_last_name')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.last_name_error).text,
                 'Enter a valid value.')
 
         # test length of first-name, last-name not exceed 30
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name-!@#$%^&*()_')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name-!@#$%^&*()_')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name-long-asdfghjkl','volunteer-last-name-long-asdfghjkl','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        error_message = self.driver.find_element_by_xpath("id('div_id_first_name')/div/p/strong").text
+        error_message = self.driver.find_element_by_xpath(self.first_name_error).text
         self.assertTrue(bool(re.search(r'Ensure this value has at most 30 characters', str(error_message))))
 
-        error_message = self.driver.find_element_by_xpath("id('div_id_last_name')/div/p/strong").text,
+        error_message = self.driver.find_element_by_xpath(self.last_name_error).text,
         self.assertTrue(bool(re.search(r'Ensure this value has at most 30 characters', str(error_message))))
 
     def test_location_fields(self):
-
-        # register valid volunteer user
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
-
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
-
         # test numeric characters in address, city, state, country
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('123 New-City address')
-        self.driver.find_element_by_id('id_city').send_keys('1 volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('007 volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('54 volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email1@systers.org','123 New-City address','1 volunteer-city','007 volunteer-state','54 volunteer-country','9999999999','volunteer-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
@@ -263,28 +217,18 @@ class SignUpVolunteer(LiveServerTestCase):
         # Test commented out as there is a bug in the template
         """self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
                 3)"""
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_city')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.city_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_state')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.state_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_country')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.country_error).text,
                 'Enter a valid value.')
 
         # Test special characters in address, city, state, country
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-2')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email2@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address!@#$()')
-        self.driver.find_element_by_id('id_city').send_keys('!$@%^#&volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('!$@%^#&volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('&%^*volunteer-country!@$#')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username-2','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email2@systers.org','volunteer-address!@#$()','!$@%^#&volunteer-city','!$@%^#&volunteer-state','&%^*volunteer-country!@$#','9999999999','volunteer-org']
+        self.fill_registration_form(entry)
 
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
@@ -292,32 +236,19 @@ class SignUpVolunteer(LiveServerTestCase):
                 self.volunteer_registration_page)
 
         # verify that messages are displayed for all fields
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_address')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.address_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_city')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.city_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_state')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.state_error).text,
                 'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_country')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.country_error).text,
                 'Enter a valid value.')
 
     def test_email_field(self):
 
         # register valid volunteer user
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        self.register_valid_details()
 
         # verify successful registration
         self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
@@ -330,25 +261,15 @@ class SignUpVolunteer(LiveServerTestCase):
         # Try to register volunteer again with same email address
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
+        self.fill_registration_form(entry)
 
         # verify that volunteer wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.volunteer_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_email')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.email_error).text,
                 'Volunteer with this Email already exists.')
 
     def test_phone_field(self):
@@ -356,18 +277,8 @@ class SignUpVolunteer(LiveServerTestCase):
         # register valid volunteer user with valid phone number for country
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('India')
-        self.driver.find_element_by_id('id_phone_number').send_keys('022 2403 6606')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
+        self.fill_registration_form(entry)
 
         # verify successful registration
         self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
@@ -380,93 +291,38 @@ class SignUpVolunteer(LiveServerTestCase):
         # Try to register volunteer with incorrect phone number for country
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('India')
-        self.driver.find_element_by_id('id_phone_number').send_keys('237937913')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email1@systers.org','volunteer-address','volunteer-city','volunteer-state','India','237937913','volunteer-org']
+        self.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.volunteer_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_phone_number')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.phone_error).text,
                 "This phone number isn't valid for the selected country")
 
         # Use invalid characters in phone number
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('India')
-        self.driver.find_element_by_id('id_phone_number').send_keys('23&79^37913')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email1@systers.org','volunteer-address','volunteer-city','volunteer-state','India','23&79^37913','volunteer-org']
+        self.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.volunteer_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_phone_number')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.phone_error).text,
                 "Please enter a valid phone number")
 
     def test_organization_field(self):
 
-        # register valid volunteer user
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        # verify successful registration
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
-
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
-
         # test numeric characters in organization
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-1')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org 13')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email1@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org 13']
+        self.fill_registration_form(entry)
 
         # verify successful registration
         self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
@@ -479,25 +335,15 @@ class SignUpVolunteer(LiveServerTestCase):
         # Use invalid characters in organization
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username-2')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('volunteer-email2@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('9999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('!*^$volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username-2','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email2@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','!*^$volunteer-org']
+        self.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.volunteer_registration_page)
         self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
                 None)
-        self.assertEqual(self.driver.find_element_by_xpath("id('div_id_unlisted_organization')/div/p/strong").text,
+        self.assertEqual(self.driver.find_element_by_xpath(self.organization_error).text,
                 "Enter a valid value.")
 
     def test_field_value_retention(self):
@@ -505,58 +351,22 @@ class SignUpVolunteer(LiveServerTestCase):
         # send invalid value in fields - first name, state, phone, organization
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name-3')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state!')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country')
-        self.driver.find_element_by_id('id_phone_number').send_keys('99999.!9999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('@#volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name-3','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state!','volunteer-country','99999.!9999','@#volunteer-org']
+        self.fill_registration_form(entry)
 
         # verify that user wasn't registered and that field values are not erased
         self.assertEqual(self.driver.current_url, self.live_server_url + self.volunteer_registration_page)
-        self.assertEqual(self.driver.find_element_by_id('id_username').get_attribute('value'),'volunteer-username')
-        self.assertEqual(self.driver.find_element_by_id('id_first_name').get_attribute('value'),'volunteer-first-name-3')
-        self.assertEqual(self.driver.find_element_by_id('id_last_name').get_attribute('value'),'volunteer-last-name')
-        self.assertEqual(self.driver.find_element_by_id('id_email').get_attribute('value'),'email1@systers.org')
-        self.assertEqual(self.driver.find_element_by_id('id_address').get_attribute('value'),'volunteer-address')
-        self.assertEqual(self.driver.find_element_by_id('id_city').get_attribute('value'),'volunteer-city')
-        self.assertEqual(self.driver.find_element_by_id('id_state').get_attribute('value'),'volunteer-state!')
-        self.assertEqual(self.driver.find_element_by_id('id_country').get_attribute('value'),'volunteer-country')
-        self.assertEqual(self.driver.find_element_by_id('id_phone_number').get_attribute('value'),'99999.!9999')
-        self.assertEqual(self.driver.find_element_by_id('id_unlisted_organization').get_attribute('value'),'@#volunteer-org')
+        details = ['volunteer-username','volunteer-first-name-3','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state!','volunteer-country','99999.!9999','@#volunteer-org']
+        self.verify_field_values(details)
+        
 
         # send invalid value in fields - last name, address, city, country
         self.driver.get(self.live_server_url + self.volunteer_registration_page)
 
-        self.driver.find_element_by_id('id_username').send_keys('volunteer-username')
-        self.driver.find_element_by_id('id_password').send_keys('volunteer-password!@#$%^&*()_')
-        self.driver.find_element_by_id('id_first_name').send_keys('volunteer-first-name')
-        self.driver.find_element_by_id('id_last_name').send_keys('volunteer-last-name-3')
-        self.driver.find_element_by_id('id_email').send_keys('email1@systers.org')
-        self.driver.find_element_by_id('id_address').send_keys('volunteer-address$@!')
-        self.driver.find_element_by_id('id_city').send_keys('volunteer-city#$')
-        self.driver.find_element_by_id('id_state').send_keys('volunteer-state')
-        self.driver.find_element_by_id('id_country').send_keys('volunteer-country 15')
-        self.driver.find_element_by_id('id_phone_number').send_keys('999999999')
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys('volunteer-org')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name-3','volunteer-email@systers.org','volunteer-address$@!','volunteer-city#$','volunteer-state','volunteer-country 15','9999999999','volunteer-org']
+        self.fill_registration_form(entry)
 
         # verify that user wasn't registered and that field values are not erased
         self.assertEqual(self.driver.current_url, self.live_server_url + self.volunteer_registration_page)
-        self.assertEqual(self.driver.find_element_by_id('id_username').get_attribute('value'),'volunteer-username')
-        self.assertEqual(self.driver.find_element_by_id('id_first_name').get_attribute('value'),'volunteer-first-name')
-        self.assertEqual(self.driver.find_element_by_id('id_last_name').get_attribute('value'),'volunteer-last-name-3')
-        self.assertEqual(self.driver.find_element_by_id('id_email').get_attribute('value'),'email1@systers.org')
-        self.assertEqual(self.driver.find_element_by_id('id_address').get_attribute('value'),'volunteer-address$@!')
-        self.assertEqual(self.driver.find_element_by_id('id_city').get_attribute('value'),'volunteer-city#$')
-        self.assertEqual(self.driver.find_element_by_id('id_state').get_attribute('value'),'volunteer-state')
-        self.assertEqual(self.driver.find_element_by_id('id_country').get_attribute('value'),'volunteer-country 15')
-        self.assertEqual(self.driver.find_element_by_id('id_phone_number').get_attribute('value'),'999999999')
-        self.assertEqual(self.driver.find_element_by_id('id_unlisted_organization').get_attribute('value'),'volunteer-org')
-
+        details = ['volunteer-username','volunteer-first-name','volunteer-last-name-3','volunteer-email@systers.org','volunteer-address$@!','volunteer-city#$','volunteer-state','volunteer-country 15','9999999999','volunteer-org']
+        self.verify_field_values(details)

--- a/vms/shift/tests/test_manageVolunteerShift.py
+++ b/vms/shift/tests/test_manageVolunteerShift.py
@@ -1,13 +1,15 @@
-from django.test import TestCase
 from django.contrib.staticfiles.testing import LiveServerTestCase
-
-from django.contrib.auth.models import User
-from administrator.models import Administrator
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
-from organization.models import Organization #hack to pass travis,Bug in Code
+from shift.utils import (
+    create_admin,
+    create_volunteer_with_details,
+    create_event_with_details,
+    create_job_with_details,
+    create_shift_with_details
+    )
 
 
 class ManageVolunteerShift(LiveServerTestCase):
@@ -37,284 +39,202 @@ class ManageVolunteerShift(LiveServerTestCase):
     - Test if a shift can be assigned to a volunteer who has already been
       assigned the same shift
     '''
+    @classmethod
+    def setUpClass(cls):
+        cls.homepage = '/'
+        cls.shift_page = '/shift/volunteer_search/'
+        cls.authentication_page = '/authentication/login/'
+        cls.settings_page = '/event/list/'
+
+        cls.volunteer_1 = ['volunteer-one', 'volunteer-one', 'volunteer-one',
+                'volunteer-one', 'volunteer-one', 'volunteer-one', 'volunteer-one',
+                '9999999999', 'volunteer-email@systers.org', 'volunteer-one']
+        cls.volunteer_2 = ['volunteer-two', 'volunteer-two', 'volunteer-two',
+                'volunteer-two', 'volunteer-two', 'volunteer-two', 'volunteer-two',
+                '9999999999', 'volunteer-email2@systers.org', 'volunteer-two']
+
+        cls.job_name_path = '//table//tbody//tr[1]//td[1]'
+        cls.job_date_path = '//table//tbody//tr[1]//td[2]'
+        cls.job_stime_path = '//table//tbody//tr[1]//td[3]'
+        cls.job_etime_path = '//table//tbody//tr[1]//td[4]'
+        cls.view_jobs_path = '//table//tbody//tr[1]//td[4]'
+        cls.view_shifts_path = '//table//tbody//tr[1]//td[4]'
+        cls.assign_shifts_path = '//table//tbody//tr[1]//td[4]'
+        cls.slots_remaining_path = '//table//tbody//tr[1]//td[5]'
+        cls.cancel_shift_path = '//table//tbody//tr[1]//td[5]'
+
+        cls.driver = webdriver.Firefox()
+        cls.driver.implicitly_wait(5)
+        cls.driver.maximize_window()
+        super(ManageVolunteerShift, cls).setUpClass()
+
     def setUp(self):
-        admin_user = User.objects.create_user(
-                username = 'admin',
-                password = 'admin',
-                email = 'admin@admin.com')
-
-        Administrator.objects.create(
-                user = admin_user,
-                address = 'address',
-                city = 'city',
-                state = 'state',
-                country = 'country',
-                phone_number = '9999999999',
-                unlisted_organization = 'organization')
-
-        # create an org prior to registration. Bug in Code
-        # added to pass CI
-        Organization.objects.create(
-                name = 'DummyOrg')
-
-        self.homepage = '/'
-        self.authentication_page = '/authentication/login/'
-        self.shift_page = '/shift/volunteer_search/'
-        self.volunteer_registration_page = '/registration/signup_volunteer/'
-        self.settings_page = '/event/list/'
-        self.driver = webdriver.Firefox()
-        self.driver.implicitly_wait(5)
-        self.driver.maximize_window()
-        super(ManageVolunteerShift, self).setUp()
+        create_admin()
 
     def tearDown(self):
-        self.driver.quit()
-        super(ManageVolunteerShift, self).tearDown()
+        pass
 
-    def login_admin(self):
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        super(ManageVolunteerShift, cls).tearDownClass()
+
+    def login(self, credentials):
         self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id('id_login').send_keys('admin')
-        self.driver.find_element_by_id('id_password').send_keys('admin')
+        self.driver.find_element_by_id('id_login').send_keys(credentials['username'])
+        self.driver.find_element_by_id('id_password').send_keys(credentials['password'])
         self.driver.find_element_by_xpath('//form[1]').submit()
 
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url + self.homepage)
-
-    def register_volunteer(self, credentials):
-        self.driver.get(self.live_server_url
-                        + self.volunteer_registration_page)
-
-        self.driver.find_element_by_id('id_username').send_keys(credentials[0])
-        self.driver.find_element_by_id('id_password').send_keys(credentials[1])
-        self.driver.find_element_by_id('id_first_name').send_keys(credentials[2])
-        self.driver.find_element_by_id('id_last_name').send_keys(credentials[3])
-        self.driver.find_element_by_id('id_email').send_keys(credentials[4])
-        self.driver.find_element_by_id('id_address').send_keys(credentials[5])
-        self.driver.find_element_by_id('id_city').send_keys(credentials[6])
-        self.driver.find_element_by_id('id_state').send_keys(credentials[7])
-        self.driver.find_element_by_id('id_country').send_keys(credentials[8])
-        self.driver.find_element_by_id('id_phone_number').send_keys(credentials[9])
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys(credentials[10])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('help-block'),
-
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url + self.homepage)
-
-    def register_test_dataset(self):
-        credentials = ['volunteer-one', 'volunteer-password',
-                'volunteer-one', 'volunteer-one', 'volunteer-email@systers.org',
-                'volunteer-one', 'volunteer-one', 'volunteer-one',
-                'volunteer-one', '9999999999', 'volunteer-one']
-
-        self.register_volunteer(credentials)
-
-        credentials = ['volunteer-two', 'volunteer-password',
-                'volunteer-two', 'volunteer-two', 'volunteer-email2@systers.org',
-                'volunteer-two', 'volunteer-two', 'volunteer-two',
-                'volunteer-two', '9999999999', 'volunteer-two']
-
-        self.register_volunteer(credentials)
-
-    def register_event_utility(self, event):
-        self.driver.find_element_by_link_text('Events').send_keys("\n")
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.settings_page)
-
-        self.driver.find_element_by_link_text('Create Event').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url + '/event/create/')
-
-        self.driver.find_element_by_xpath(
-                '//input[@placeholder = "Event Name"]').send_keys(
-                        event[0])
-        self.driver.find_element_by_xpath(
-                '//input[@name = "start_date"]').send_keys(
-                        event[1])
-        self.driver.find_element_by_xpath(
-                '//input[@name = "end_date"]').send_keys(
-                        event[2])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('help-block'),
-
-    def register_job_utility(self, job):
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.settings_page)
-        self.driver.find_element_by_link_text('Jobs').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url + '/job/list/')
-
-        self.driver.find_element_by_link_text('Create Job').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url + '/job/create/')
-
-        self.driver.find_element_by_xpath(
-                '//select[@name = "event_id"]').send_keys(
-                        job[0])
-        self.driver.find_element_by_xpath(
-                '//input[@placeholder = "Job Name"]').send_keys(
-                        job[1])
-        self.driver.find_element_by_xpath(
-                '//textarea[@name = "description"]').send_keys(
-                        job[2])
-        self.driver.find_element_by_xpath(
-                '//input[@name = "start_date"]').send_keys(
-                        job[3])
-        self.driver.find_element_by_xpath(
-                '//input[@name = "end_date"]').send_keys(
-                        job[4])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('help-block'),
-
-    def register_shift_utility(self, shift):
-        self.login_admin()
-
-        # register event to create job
-        event = ['event-name', '05/20/2017', '05/20/2017']
-        self.register_event_utility(event)
-
-        # create job to create shift
-        job = ['event-name', 'job name', 'job description', '05/20/2017',
-                '05/20/2017']
-        self.register_job_utility(job)
-
-        # create shift
-        self.driver.find_element_by_link_text('Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url + '/shift/list_jobs/')
-
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]/td[5]//a').click()
-
-        self.driver.find_element_by_link_text('Create Shift').click()
-
-        self.driver.find_element_by_xpath(
-                '//input[@name = "date"]').send_keys(
-                        shift[0])
-        self.driver.find_element_by_xpath(
-                '//input[@name = "start_time"]').send_keys(
-                        shift[1])
-        self.driver.find_element_by_xpath(
-                '//input[@name = "end_time"]').send_keys(
-                        shift[2])
-        self.driver.find_element_by_xpath(
-                '//input[@name = "max_volunteers"]').send_keys(
-                        shift[3])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-        self.assertNotEqual(self.driver.find_elements_by_xpath(
-                '//table//tbody'), None)
-
-    def test_landing_page_without_any_registered_volunteers(self):
-        self.login_admin()
+    def navigate_to_manage_shift_page(self):
         self.driver.find_element_by_link_text('Manage Volunteer Shifts').click()
         self.assertEqual(self.driver.current_url,
                 self.live_server_url + self.shift_page)
+
+    def login_admin(self):
+        self.login({ 'username' : 'admin', 'password' : 'admin'})
+
+    def select_volunteer(self, number):
+        link_path = '//table//tbody//tr[' + str(number) + ']//td[10]//a'
+        self.driver.find_element_by_xpath(link_path).click()
+
+    def navigate_to_shift_assignment_page(self):
+        self.driver.find_element_by_xpath(
+                self.view_jobs_path + "//a").click()
+        self.driver.find_element_by_xpath(
+                self.view_shifts_path + "//a").click()
+        self.driver.find_element_by_xpath(
+                self.assign_shifts_path + "//a").click()
+
+    def create_shift(self, shift):
+        # register event to create job
+        event = ['event-name', '2017-05-20', '2017-05-20']
+        e1 = create_event_with_details(event)
+
+        # create job to create shift
+        job = ['job name', '2017-05-20', '2017-05-20', 'job description', e1]
+        j1 = create_job_with_details(job)
+
+        # create shift to assign
+        shift_1 = ['2017-05-20', shift[0], shift[1], shift[2], j1]
+        s1 = create_shift_with_details(shift_1)
+
+        return s1
+
+    def check_job_details(self, details):
+        self.assertEqual(self.driver.find_element_by_xpath(
+            self.job_name_path).text, details[0])
+        self.assertEqual(self.driver.find_element_by_xpath(
+            self.job_date_path).text, details[1])
+        self.assertEqual(self.driver.find_element_by_xpath(
+            self.job_stime_path).text, details[2])
+        self.assertEqual(self.driver.find_element_by_xpath(
+            self.job_etime_path).text, details[3])
+
+    def assign_shift(self):
+        self.driver.find_element_by_link_text('Assign Shift').click()
+
+    def test_table_layout(self):
+        # register volunteers
+        v1 = create_volunteer_with_details(self.volunteer_1)
+
+        shift = ['09:00', '15:00', '1']
+        s1 = self.create_shift(shift)
+
+        self.login_admin()
+        # open manage volunteer shift
+        self.navigate_to_manage_shift_page()
+
+        # volunteer-one does not have any registered shifts
+        self.select_volunteer(1)
+        self.assign_shift()
+
+        # events shown in table
+        with self.assertRaises(NoSuchElementException):
+            self.driver.find_element_by_class_name('alert-info')
+        self.assertEqual(self.driver.find_element_by_xpath(
+            self.view_jobs_path).text, 'View Jobs')
+        self.driver.find_element_by_xpath(
+                self.view_jobs_path + "//a").click()
+
+        # arrived on page2 with jobs
+        self.assertEqual(self.driver.find_element_by_xpath(
+            self.view_shifts_path).text, 'View Shifts')
+        self.driver.find_element_by_xpath(
+                self.view_shifts_path + "//a").click()
+
+        # arrived on page3 with shifts, assign shift to volunteer one
+        self.assertEqual(self.driver.find_element_by_xpath(
+            self.assign_shifts_path).text, 'Assign Shift')
+
+    def test_landing_page_without_any_registered_volunteers(self):
+        self.login_admin()
+        self.navigate_to_manage_shift_page()
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_tag_name('tr')
 
     def test_landing_page_with_registered_volunteers(self):
-        # register volunteers
-        self.register_test_dataset()
+        # register volunteer
+        v1 = create_volunteer_with_details(self.volunteer_1)
 
         # login admin user
         self.login_admin()
-
-        # open manage volunteer shift
-        self.driver.find_element_by_link_text('Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url + self.shift_page)
+        self.navigate_to_manage_shift_page()
 
         self.assertNotEqual(self.driver.find_element_by_tag_name('tr'), None)
-
-        self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[10]//a').click()
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
-               'This volunteer does not have any upcoming shifts.')
-
-        self.driver.back()
-        self.assertEqual(self.driver.current_url, 
-                self.live_server_url + '/shift/volunteer_search/')
-
-        self.driver.find_element_by_xpath('//table//tbody//tr[2]//td[10]//a').click()
+        self.select_volunteer(1)
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
                'This volunteer does not have any upcoming shifts.')
 
     def test_events_page_with_no_events(self):
         # register volunteers
-        self.register_test_dataset()
+        v1 = create_volunteer_with_details(self.volunteer_1)
 
         # login admin user
         self.login_admin()
+        self.navigate_to_manage_shift_page()
 
-        # open manage volunteer shift
-        self.driver.find_element_by_link_text('Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url + self.shift_page)
-
-        self.driver.find_element_by_xpath('//table//tbody//tr[1]//td[10]//a').click()
-
-        self.driver.find_element_by_link_text('Assign Shift').click()
+        self.select_volunteer(1)
+        self.assign_shift()
 
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
                'There are no events.')
 
     def test_jobs_page_with_no_jobs(self):
         # register volunteers
-        self.register_test_dataset()
+        v1 = create_volunteer_with_details(self.volunteer_1)
+
+        # create events
+        event = ['event-name', '2017-05-20', '2017-05-20']
+        e1 = create_event_with_details(event)
 
         # login admin
         self.login_admin()
-
-        # create events
-        event = ['event-name', '05/20/2017', '05/20/2017']
-        self.register_event_utility(event)
-
         # open manage volunteer shift
-        self.driver.find_element_by_link_text(
-                'Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.shift_page)
-
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[10]//a').click()
-
-        self.driver.find_element_by_link_text('Assign Shift').click()
+        self.navigate_to_manage_shift_page()
+        self.select_volunteer(1)
+        self.assign_shift()
 
         self.assertEqual(self.driver.find_element_by_class_name(
             'alert-info').text,'There are no events.')
 
     def test_assign_shifts_with_no_shifts(self):
         # register volunteers
-        self.register_test_dataset()
+        v1 = create_volunteer_with_details(self.volunteer_1)
+
+        # create events
+        event = ['event-name', '2017-05-20', '2017-05-20']
+        e1 = create_event_with_details(event)
+
+        # create jobs
+        job = ['job name', '2017-05-20', '2017-05-20', 'job description', e1]
+        j1 = create_job_with_details(job)
 
         # login admin
         self.login_admin()
-
-        # create events
-        event = ['event-name', '05/20/2017', '05/20/2017']
-        self.register_event_utility(event)
-
-        # create jobs
-        job = ['event-name', 'job name', 'job description', '05/20/2017',
-            '05/20/2017']
-        self.register_job_utility(job)
-
         # open manage volunteer shift
-        self.driver.find_element_by_link_text(
-                'Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.shift_page)
-
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[10]//a').click()
-
-        self.driver.find_element_by_link_text('Assign Shift').click()
+        self.navigate_to_manage_shift_page()
+        self.select_volunteer(1)
+        self.assign_shift()
 
         # no events shown in table
         self.assertEqual(self.driver.find_element_by_class_name(
@@ -322,52 +242,27 @@ class ManageVolunteerShift(LiveServerTestCase):
 
     def test_assign_shifts_with_registered_shifts(self):
         # register volunteers
-        self.register_test_dataset()
+        v1 = create_volunteer_with_details(self.volunteer_1)
 
-        # create shift to assign
-        shift = ['05/20/2017', '09:00', '15:00', '1']
-        self.register_shift_utility(shift)
+        shift = ['09:00', '15:00', '1']
+        s1 = self.create_shift(shift)
 
+        self.login_admin()
         # open manage volunteer shift
-        self.driver.find_element_by_link_text(
-                'Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.shift_page)
+        self.navigate_to_manage_shift_page()
 
         # volunteer-one does not have any registered shifts
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[10]').text,
-            'Manage Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[10]//a').click()
+        self.select_volunteer(1)
         self.assertEqual(self.driver.find_element_by_class_name(
             'alert-info').text, 
             'This volunteer does not have any upcoming shifts.')
 
-        self.driver.find_element_by_link_text('Assign Shift').click()
+        self.assign_shift()
 
         # events shown in table
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_class_name('alert-info')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Jobs')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
-
-        # arrived on page2 with jobs
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
-
-        # arrived on page3 with shifts, assign shift to volunteer one
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'Assign Shift')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+        self.navigate_to_shift_assignment_page()
 
         # confirm on shift assignment to volunteer-one
         self.driver.find_element_by_xpath('//form[1]').submit()
@@ -375,76 +270,34 @@ class ManageVolunteerShift(LiveServerTestCase):
             self.driver.find_element_by_class_name('alert-danger')
 
         # check shift assignment to volunteer-one
-        self.driver.find_element_by_link_text(
-                'Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.shift_page)
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[10]').text,
-            'Manage Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[10]//a').click()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text,
-            'job name')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[2]').text,
-            'May 20, 2017')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[3]').text,
-            '9 a.m.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            '3 p.m.')
+        self.navigate_to_manage_shift_page()
+        self.select_volunteer(1)
+        self.check_job_details(['job name', 'May 20, 2017', '9 a.m.', '3 p.m.'])
 
     def test_slots_remaining_in_shift(self):
         # register volunteers
-        self.register_test_dataset()
+        v1 = create_volunteer_with_details(self.volunteer_1)
+        v2 = create_volunteer_with_details(self.volunteer_2)
 
-        # create shift to assign, with only 1 volunteer required
-        shift = ['05/20/2017', '09:00', '15:00', '1']
-        self.register_shift_utility(shift)
+        shift = ['09:00', '15:00', '1']
+        s1 = self.create_shift(shift)
 
+        self.login_admin()
         # open manage volunteer shift
-        self.driver.find_element_by_link_text(
-                'Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.shift_page)
+        self.navigate_to_manage_shift_page()
 
         # volunteer-one does not have any registered shifts
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[10]').text,
-            'Manage Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[10]//a').click()
+        self.select_volunteer(1)
         self.assertEqual(self.driver.find_element_by_class_name(
             'alert-info').text, 
             'This volunteer does not have any upcoming shifts.')
 
-        self.driver.find_element_by_link_text('Assign Shift').click()
+        self.assign_shift()
 
         # events shown in table
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_class_name('alert-info')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Jobs')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
-
-        # arrived on page2 with jobs
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
-
-        # arrived on page3 with shifts, assign shift to volunteer one
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'Assign Shift')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+        self.navigate_to_shift_assignment_page()
 
         # confirm on shift assignment to volunteer-one
         self.driver.find_element_by_xpath('//form[1]').submit()
@@ -452,45 +305,20 @@ class ManageVolunteerShift(LiveServerTestCase):
             self.driver.find_element_by_class_name('alert-danger')
 
         # check shift assignment to volunteer-one
-        self.driver.find_element_by_link_text(
-                'Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.shift_page)
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[10]').text,
-            'Manage Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[10]//a').click()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text,
-            'job name')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[2]').text,
-            'May 20, 2017')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[3]').text,
-            '9 a.m.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            '3 p.m.')
+        self.navigate_to_manage_shift_page()
+        self.select_volunteer(1)
+        self.check_job_details(['job name', 'May 20, 2017', '9 a.m.', '3 p.m.'])
 
         # open manage volunteer shift again to assign shift to volunteer two
-        self.driver.find_element_by_link_text(
-                'Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.shift_page)
+        self.navigate_to_manage_shift_page()
 
         # volunteer-two does not have any registered shifts
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[2]//td[10]').text,
-            'Manage Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[2]//td[10]//a').click()
+        self.select_volunteer(2)
         self.assertEqual(self.driver.find_element_by_class_name(
             'alert-info').text, 
             'This volunteer does not have any upcoming shifts.')
 
-        self.driver.find_element_by_link_text('Assign Shift').click()
+        self.assign_shift()
 
         #no events shown in table
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
@@ -498,54 +326,36 @@ class ManageVolunteerShift(LiveServerTestCase):
             
     def test_cancel_assigned_shift(self):
         # register volunteers
-        self.register_test_dataset()
+        v1 = create_volunteer_with_details(self.volunteer_1)
 
-        # create shift to assign
-        shift = ['05/20/2017', '09:00', '15:00', '1']
-        self.register_shift_utility(shift)
+        shift = ['09:00', '15:00', '1']
+        s1 = self.create_shift(shift)
 
+        self.login_admin()
         # open manage volunteer shift
-        self.driver.find_element_by_link_text(
-                'Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.shift_page)
+        self.navigate_to_manage_shift_page()
 
         # volunteer-one does not have any registered shifts
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[10]').text,
-            'Manage Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[10]//a').click()
+        self.select_volunteer(1)
         self.assertEqual(self.driver.find_element_by_class_name(
             'alert-info').text, 
             'This volunteer does not have any upcoming shifts.')
 
-        self.driver.find_element_by_link_text('Assign Shift').click()
+        self.assign_shift()
 
         # events shown in table
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_class_name('alert-info')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Jobs')
         self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
-
-        # arrived on jobs page
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Shifts')
+                self.view_jobs_path + "//a").click()
         self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+                self.view_shifts_path + "//a").click()
 
         # arrived on shifts page, assign shift to volunteer one
         slots_remaining_before_assignment = self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[5]').text
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'Assign Shift')
+                self.slots_remaining_path).text
         self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+                self.assign_shifts_path + "//a").click()
 
         # confirm on shift assignment to volunteer-one
         self.driver.find_element_by_xpath('//form[1]').submit()
@@ -553,34 +363,15 @@ class ManageVolunteerShift(LiveServerTestCase):
             self.driver.find_element_by_class_name('alert-danger')
 
         # check shift assignment to volunteer-one
-        self.driver.find_element_by_link_text(
-                'Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.shift_page)
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[10]').text,
-            'Manage Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[10]//a').click()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text,
-            'job name')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[2]').text,
-            'May 20, 2017')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[3]').text,
-            '9 a.m.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            '3 p.m.')
+        self.navigate_to_manage_shift_page()
+        self.select_volunteer(1)
+        self.check_job_details(['job name', 'May 20, 2017', '9 a.m.', '3 p.m.'])
 
         # cancel assigned shift
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]').text,
-            'Cancel Shift Registration')
+            self.cancel_shift_path).text, 'Cancel Shift Registration')
         self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[5]//a').click()
+                self.cancel_shift_path + "//a").click()
         self.assertNotEqual(self.driver.find_element_by_class_name(
             'panel-danger'), None)
         self.assertEqual(self.driver.find_element_by_class_name(
@@ -594,70 +385,39 @@ class ManageVolunteerShift(LiveServerTestCase):
 
         # check slots remaining increases by one, after cancellation of
         # assigned shift
-        self.driver.find_element_by_link_text('Assign Shift').click()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Jobs')
+        self.assign_shift()
         self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Shifts')
+                self.view_jobs_path + "//a").click()
         self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+                self.view_shifts_path + "//a").click()
         slots_after_cancellation = self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[5]').text
+                self.slots_remaining_path).text
         self.assertEqual(slots_remaining_before_assignment,
                 slots_after_cancellation)
 
     def test_assign_same_shift_to_volunteer_twice(self):
         # register volunteers
-        self.register_test_dataset()
+        v1 = create_volunteer_with_details(self.volunteer_1)
 
-        # create shift to assign, with slots = 2
-        shift = ['05/20/2017', '09:00', '15:00', '2']
-        self.register_shift_utility(shift)
+        shift = ['09:00', '15:00', '1']
+        s1 = self.create_shift(shift)
 
+        self.login_admin()
         # open manage volunteer shift
-        self.driver.find_element_by_link_text(
-                'Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url +  self.shift_page)
+        self.navigate_to_manage_shift_page()
 
         # volunteer-one does not have any registered shifts
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[10]').text,
-            'Manage Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[10]//a').click()
+        self.select_volunteer(1)
         self.assertEqual(self.driver.find_element_by_class_name(
             'alert-info').text, 
             'This volunteer does not have any upcoming shifts.')
 
-        self.driver.find_element_by_link_text('Assign Shift').click()
+        self.assign_shift()
 
         # events shown in table
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element_by_class_name('alert-info')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Jobs')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
-
-        # arrived on jobs page
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'View Shifts')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
-
-        # arrived on shifts page, assign shift to volunteer one
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[4]').text,
-            'Assign Shift')
-        self.driver.find_element_by_xpath(
-                '//table//tbody//tr[1]//td[4]//a').click()
+        self.navigate_to_shift_assignment_page()
 
         # confirm on shift assignment to volunteer-one
         self.driver.find_element_by_xpath('//form[1]').submit()
@@ -667,10 +427,8 @@ class ManageVolunteerShift(LiveServerTestCase):
         # assign same shift to voluteer-one again
         # Check volunteer-one has one registered shift now
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'job name')
-        self.driver.find_element_by_link_text('Assign Shift').click()
+            self.job_name_path).text, 'job name')
+        self.assign_shift()
 
         # events page
         self.assertEqual(self.driver.find_element_by_class_name('alert-info').text, 'There are no events.')
-
-

--- a/vms/shift/tests/test_shiftDetails.py
+++ b/vms/shift/tests/test_shiftDetails.py
@@ -1,11 +1,15 @@
 from django.contrib.staticfiles.testing import LiveServerTestCase
+from shift.models import VolunteerShift
 
-from django.contrib.auth.models import User
-from administrator.models import Administrator
-from volunteer.models import Volunteer
-from event.models import Event
-from job.models import Job
-from shift.models import Shift, VolunteerShift
+from shift.utils import (
+    create_volunteer_with_details,
+    create_admin,
+    create_event_with_details,
+    create_job_with_details,
+    create_shift_with_details,
+    log_hours_with_details,
+    register_volunteer_for_shift_utility
+    )
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
@@ -21,121 +25,87 @@ class ShiftDetails(LiveServerTestCase):
     - Volunteer with logged shift hours
     '''
 
+    @classmethod
+    def setUpClass(cls):
+        cls.homepage = '/'
+        cls.authentication_page = '/authentication/login/'
+        cls.shift_list_page = '/shift/list_jobs/'
+
+        cls.vol_email = '//table[2]//tr//td[9]'
+        cls.shift_max_vol = '//table[1]//tr//td[9]'
+        cls.shift_job_path = '//table[1]//tr//td[1]'
+        cls.shift_date_path = '//table[1]//tr//td[3]'
+        cls.shift_stime_path = '//table[1]//tr//td[4]'
+        cls.shift_etime_path = '//table[1]//tr//td[5]'
+        cls.logged_volunteer = '//table[3]//tr//td[1]'
+        cls.logged_stime_path = '//table[3]//tr//td[4]'
+        cls.logged_etime_path = '//table[3]//tr//td[5]'
+
+        cls.view_shift = '//table//tbody//tr[1]/td[5]//a'
+        cls.view_details = '//table//tbody//tr[1]//td[7]'
+        cls.logged_volunteer_list = '//table[3]//tbody//tr'
+
+        cls.registered_volunteer_name = '//table[2]//tr//td[1]'
+        cls.registered_volunteer_list = '//table[2]//tbody//tr'
+
+        cls.volunteer_detail = ['volunteer-usernameq', 'Michael', 'Reed',
+                'address', 'city', 'state', 'country', '9999999999',
+                'volunteer@volunteer.com', 'organization']
+
+        cls.driver = webdriver.Firefox()
+        cls.driver.implicitly_wait(5)
+        cls.driver.maximize_window()
+        super(ShiftDetails, cls).setUpClass()
+
     def setUp(self):
-        admin_user = User.objects.create_user(
-            username='admin',
-            password='admin')
-
-        Administrator.objects.create(
-            user=admin_user,
-            address='address',
-            city='city',
-            state='state',
-            country='country',
-            email='admin@admin.com',
-            phone_number='9999999999',
-            unlisted_organization='organization')
-
-        self.homepage = '/'
-        self.authentication_page = '/authentication/login/'
-        self.shift_list_page = '/shift/list_jobs/'
-        self.driver = webdriver.Firefox()
-        self.driver.implicitly_wait(5)
-        self.driver.maximize_window()
-        super(ShiftDetails, self).setUp()
+        self.admin = create_admin()
+        self.login_admin()
+        self.shift = self.register_dataset()
 
     def tearDown(self):
-        self.driver.quit()
-        super(ShiftDetails, self).tearDown()
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        super(ShiftDetails, cls).tearDownClass()
 
     def login(self, credentials):
         self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id(
-            'id_login').send_keys(credentials['username'])
-        self.driver.find_element_by_id('id_password').send_keys(
-            credentials['password'])
+        self.driver.find_element_by_id('id_login').send_keys(credentials['username'])
+        self.driver.find_element_by_id('id_password').send_keys(credentials['password'])
         self.driver.find_element_by_xpath('//form[1]').submit()
 
-    def register_volunteer_utility(self, name):
-        volunteer_user = User.objects.create_user(
-            username=name,
-            password='volunteer')
+    def login_admin(self):
+        self.login({'username': 'admin', 'password': 'admin'})
 
-        volunteer = Volunteer.objects.create(
-            user=volunteer_user,
-            first_name='Michael',
-            last_name='Reed',
-            address='address',
-            city='city',
-            state='state',
-            country='country',
-            phone_number='9999999999',
-            email='volunteer@volunteer.com',
-            unlisted_organization='organization')
-
-        return volunteer
-
-    def register_shift_utility(self, ):
-
-        # create shift and log hours
-        event = Event.objects.create(
-            name='event',
-            start_date='2017-06-15',
-            end_date='2017-06-17')
-
-        job = Job.objects.create(
-            name='job',
-            start_date='2017-06-15',
-            end_date='2017-06-15',
-            event=event)
-
-        shift = Shift.objects.create(
-            date='2017-06-15',
-            start_time='09:00',
-            end_time='15:00',
-            max_volunteers='6',
-            job=job)
-
-        return shift
-
-    def log_hours_utility(self, shift, volunteer, s_time, e_time):
-        VolunteerShift.objects.create(
-            shift=shift,
-            volunteer=volunteer,
-            start_time=s_time,
-            end_time=e_time)
-
-    def register_volunteer_for_shift_utility(self, shift, volunteer):
-        vol_shift = VolunteerShift.objects.create(
-            shift=shift,
-            volunteer=volunteer)
-        return vol_shift
+    def register_dataset(self):
+        e1 = create_event_with_details(['event', '2017-06-15', '2017-06-17'])
+        j1 = create_job_with_details(['job', '2017-06-15', '2017-06-15', 'job description', e1])
+        s1 = create_shift_with_details(['2017-06-15', '09:00', '15:00', '6', j1])
+        return s1
 
     def navigate_to_shift_details_view(self):
         self.driver.get(self.live_server_url + self.shift_list_page)
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]/td[5]//a').click()
+        self.driver.find_element_by_xpath(self.view_shift).click()
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[7]').text, 'View')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[7]//a').click()
+            self.view_details).text, 'View')
+        self.driver.find_element_by_xpath(self.view_details + '//a').click()
 
     def test_view_with_unregistered_volunteers(self):
-        self.login({'username': 'admin', 'password': 'admin'})
-        shift = self.register_shift_utility()
         self.navigate_to_shift_details_view()
 
         # verify details and slots remaining
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[1]//tr//td[1]').text, 'job')
+            self.shift_job_path).text, 'job')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[1]//tr//td[3]').text, 'June 15, 2017')
+            self.shift_date_path).text, 'June 15, 2017')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[1]//tr//td[9]').text, '6')
+            self.shift_max_vol).text, '6')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[1]//tr//td[4]').text, '9 a.m.')
+            self.shift_stime_path).text, '9 a.m.')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[1]//tr//td[5]').text, '3 p.m.')
+            self.shift_etime_path).text, '3 p.m.')
 
         # verify that there are no registered shifts or logged hours
         self.assertEqual(
@@ -143,54 +113,51 @@ class ShiftDetails(LiveServerTestCase):
             'There are currently no volunteers assigned to this shift. Please assign volunteers to view more details')
 
     def test_view_with_only_registered_volunteers(self):
-        self.login({'username': 'admin', 'password': 'admin'})
-        shift = self.register_shift_utility()
-        volunteer = self.register_volunteer_utility('volunteer')
-        volunteer_shift = self.register_volunteer_for_shift_utility(
-            shift, volunteer)
+
+        volunteer = create_volunteer_with_details(self.volunteer_detail)
+        volunteer_shift = register_volunteer_for_shift_utility(
+            self.shift, volunteer)
         self.navigate_to_shift_details_view()
 
         # verify that the shift slot is decreased by 1
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[1]//tr//td[1]').text, 'job')
+            self.shift_job_path).text, 'job')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[1]//tr//td[9]').text, '5')
+            self.shift_max_vol).text, '5')
 
         # verify that assigned volunteers shows up but no logged hours yet
         self.assertEqual(
-            len(self.driver.find_elements_by_xpath('//table[2]//tbody//tr')), 1)
+            len(self.driver.find_elements_by_xpath(self.registered_volunteer_list)), 1)
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[2]//tr//td[1]').text, 'Michael')
+            self.registered_volunteer_name).text, 'Michael')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[2]//tr//td[9]').text, 'volunteer@volunteer.com')
+            self.vol_email).text, 'volunteer@volunteer.com')
         self.assertEqual(self.driver.find_element_by_class_name(
             'alert-success').text, 'There are no logged hours at the moment')
 
     def test_view_with_logged_hours(self):
-        self.login({'username': 'admin', 'password': 'admin'})
-        shift = self.register_shift_utility()
-        volunteer = self.register_volunteer_utility('volunteer')
-        self.log_hours_utility(shift, volunteer, '13:00', '14:00')
+        volunteer = create_volunteer_with_details(self.volunteer_detail)
+        log_hours_with_details(volunteer, self.shift, '13:00', '14:00')
         self.navigate_to_shift_details_view()
 
         # verify that the shift slot is decreased by 1
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[1]//tr//td[1]').text, 'job')
+            self.shift_job_path).text, 'job')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[1]//tr//td[9]').text, '5')
+            self.shift_max_vol).text, '5')
 
         # verify that assigned volunteers shows up
         self.assertEqual(
-            len(self.driver.find_elements_by_xpath('//table[2]//tbody//tr')), 1)
+            len(self.driver.find_elements_by_xpath(self.registered_volunteer_list)), 1)
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[2]//tr//td[9]').text, 'volunteer@volunteer.com')
+            self.vol_email).text, 'volunteer@volunteer.com')
 
         # verify that hours are logged by volunteer
         self.assertEqual(
-            len(self.driver.find_elements_by_xpath('//table[3]//tbody//tr')), 1)
+            len(self.driver.find_elements_by_xpath(self.logged_volunteer_list)), 1)
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[3]//tr//td[1]').text, 'Michael')
+            self.registered_volunteer_name).text, 'Michael')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[3]//tr//td[4]').text, '1 p.m.')
+            self.logged_stime_path).text, '1 p.m.')
         self.assertEqual(self.driver.find_element_by_xpath(
-            '//table[3]//tr//td[5]').text, '2 p.m.')
+            self.logged_etime_path).text, '2 p.m.')

--- a/vms/shift/utils.py
+++ b/vms/shift/utils.py
@@ -1,9 +1,11 @@
 from event.models import Event
 from job.models import Job
+from administrator.models import Administrator
 from django.contrib.auth.models import User
 from shift.models import Shift, VolunteerShift
 from volunteer.models import Volunteer
 from organization.models import Organization
+from cities_light.models import Country
 
 # Contains common functions which need to be frequently called by tests
 
@@ -53,7 +55,10 @@ def create_volunteer_with_details(volunteer):
     """
     Creates and returns volunteer with passed name and dates
     """
-    u1 = User.objects.create_user(volunteer[0])
+    u1 = User.objects.create_user(
+        username = volunteer[0],
+        password = 'volunteer'
+        )
     v1 = Volunteer(
         first_name=volunteer[1],
         last_name=volunteer[2],
@@ -65,6 +70,7 @@ def create_volunteer_with_details(volunteer):
         email=volunteer[8],
         user=u1
         )
+
     v1.save()
     return v1
 
@@ -81,6 +87,22 @@ def create_shift_with_details(shift):
         )
     s1.save()
     return s1
+
+def log_hours_with_details(volunteer, shift, start, end):
+    logged_shift = VolunteerShift.objects.create(
+        shift = shift,
+        volunteer = volunteer,
+        start_time = start,
+        end_time = end
+        )
+
+    return logged_shift
+
+def create_organization_with_details(org_name):
+    org = Organization.objects.create(
+        name = org_name)
+
+    return org
 
 def set_shift_location(shift,loc):
     """
@@ -102,9 +124,104 @@ def get_report_list(duration_list, report_list, total_hours):
     """
 
     for duration in duration_list:
-		total_hours += duration
-		report = {}
-		report["duration"] = duration
-		report_list.append(report)
+        total_hours += duration
+        report = {}
+        report["duration"] = duration
+        report_list.append(report)
 
     return (report_list, total_hours)
+
+def create_organization():
+    org = Organization.objects.create(
+        name = 'DummyOrg')
+
+    return org
+
+def create_country():
+    Country.objects.create(
+        name_ascii = 'India',
+        slug ='india',
+        geoname_id = '1269750',
+        alternate_names = '',
+        name = 'India',
+        code2 = 'IN',
+        code3 = 'IND',
+        continent = 'AS',
+        tld = 'in',
+        phone = '91')
+
+def create_admin():
+
+    user_1 = User.objects.create_user(
+        username = 'admin',
+        password = 'admin'
+        )
+
+    admin = Administrator.objects.create(
+        user = user_1,
+        address = 'address',
+        city = 'city',
+        state = 'state',
+        country = 'country',
+        phone_number = '9999999999',
+        email = 'admin@admin.com',
+        unlisted_organization = 'organization')
+
+    return admin
+
+def create_volunteer():
+
+    user_1 = User.objects.create_user(
+        username = 'volunteer',
+        password = 'volunteer'
+        )
+
+    volunteer = Volunteer.objects.create(
+        user = user_1,
+        address = 'address',
+        city = 'city',
+        state = 'state',
+        country = 'country',
+        phone_number = '9999999999',
+        email = 'volunteer@volunteer.com',
+        unlisted_organization = 'organization')
+
+    return volunteer
+
+def register_event_utility():
+    Event.objects.create(
+        name = 'event',
+        start_date = '2016-05-10',
+        end_date = '2018-06-16'
+        )
+
+def register_job_utility():
+    Job.objects.create(
+        name = 'job',
+        start_date = '2016-05-10',
+        end_date = '2017-06-15',
+        event = Event.objects.get(name = 'event')
+        )
+
+def register_shift_utility():
+    Shift.objects.create(
+        date = '2017-06-15',
+        start_time = '09:00',
+        end_time = '15:00',
+        max_volunteers ='6',
+        job = Job.objects.get(name = 'job')
+        )
+
+def register_volunteer_for_shift_utility(shift, volunteer):
+        vol_shift = VolunteerShift.objects.create(
+            shift=shift,
+            volunteer=volunteer)
+        return vol_shift
+
+def log_hours_utility():
+    VolunteerShift.objects.create(
+        shift = Shift.objects.get(job__name = 'job'),
+        volunteer = Volunteer.objects.get(user__username = 'volunteer'),
+        start_time = '09:00',
+        end_time = '12:00'
+        )

--- a/vms/volunteer/tests/test_searchVolunteer.py
+++ b/vms/volunteer/tests/test_searchVolunteer.py
@@ -1,13 +1,12 @@
-from django.test import TestCase
 from django.contrib.staticfiles.testing import LiveServerTestCase
-
-from django.contrib.auth.models import User
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
-from administrator.models import Administrator
-from organization.models import Organization #hack to pass travis,Bug in Code
+from shift.utils import (
+    create_admin,
+    create_volunteer_with_details
+    )
 
 
 class SearchVolunteer(LiveServerTestCase):
@@ -24,682 +23,480 @@ class SearchVolunteer(LiveServerTestCase):
     if a combination of parameters entered, then intersection of all results is
     obtained.
     '''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.homepage = '/'
+        cls.authentication_page = '/authentication/login/'
+        cls.volunteer_search = '/volunteer/search/'
+        cls.first_name_field = ".form-control[name='first_name']"
+        cls.last_name_field = ".form-control[name='last_name']"
+        cls.city_field = ".form-control[name='city']"
+        cls.state_field = ".form-control[name='state']"
+        cls.country_field = ".form-control[name='country']"
+        cls.org_field = ".form-control[name='organization']"
+
+        cls.driver = webdriver.Firefox()
+        cls.driver.implicitly_wait(5)
+        cls.driver.maximize_window()
+        super(SearchVolunteer, cls).setUpClass()
+
     def setUp(self):
-        admin_user = User.objects.create_user(
-                username = 'admin',
-                password = 'admin',
-                email = 'admin@admin.com')
-
-        Administrator.objects.create(
-                user = admin_user,
-                address = 'address',
-                city = 'city',
-                state = 'state',
-                country = 'country',
-                phone_number = '9999999999',
-                unlisted_organization = 'organization')
-
-        # create an org prior to registration. Bug in Code
-        # added to pass CI
-        Organization.objects.create(
-                name = 'DummyOrg')
-
-        self.homepage = '/'
-        self.registration_page = '/registration/signup_volunteer/'
-        self.authentication_page = '/authentication/login/'
-        self.driver = webdriver.Firefox()
-        self.driver.implicitly_wait(5)
-        self.driver.maximize_window()
-        super(SearchVolunteer, self).setUp()
+        create_admin()
 
     def tearDown(self):
-        self.driver.quit()
-        super(SearchVolunteer, self).tearDown()
+        pass
 
-    def register_volunteer(self,credentials):
-        '''
-        Utility function to register a volunteer with supplied credentials.
-        Credentials is a list of parameters to register a volunteer. Parameters
-        are in following order.
-        - username
-        - password
-        - first_name
-        - last_name
-        - email
-        - address
-        - city
-        - state
-        - country
-        - phone_number
-        - organization
-        '''
-        self.driver.get(self.live_server_url + '/registration/signup_volunteer/')
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        super(SearchVolunteer, cls).tearDownClass()
 
-        self.driver.find_element_by_id('id_username').send_keys(credentials[0])
-        self.driver.find_element_by_id('id_password').send_keys(credentials[1])
-        self.driver.find_element_by_id('id_first_name').send_keys(credentials[2])
-        self.driver.find_element_by_id('id_last_name').send_keys(credentials[3])
-        self.driver.find_element_by_id('id_email').send_keys(credentials[4])
-        self.driver.find_element_by_id('id_address').send_keys(credentials[5])
-        self.driver.find_element_by_id('id_city').send_keys(credentials[6])
-        self.driver.find_element_by_id('id_state').send_keys(credentials[7])
-        self.driver.find_element_by_id('id_country').send_keys(credentials[8])
-        self.driver.find_element_by_id('id_phone_number').send_keys(credentials[9])
-        self.driver.find_element_by_id('id_unlisted_organization').send_keys(credentials[10])
+    def login(self, credentials):
+        self.driver.get(self.live_server_url + self.authentication_page)
+        self.driver.find_element_by_id('id_login').send_keys(credentials['username'])
+        self.driver.find_element_by_id('id_password').send_keys(credentials['password'])
         self.driver.find_element_by_xpath('//form[1]').submit()
-
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
 
     def login_admin(self):
         '''
         Utility function to login an admin user to perform all tests.
         '''
-        self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id('id_login').send_keys('admin')
-        self.driver.find_element_by_id('id_password').send_keys('admin')
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
+        self.login({ 'username' : 'admin', 'password' : 'admin'})
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 self.homepage)
 
-    def test_volunteer_first_name_field(self):            
-        credentials = ['volunteer-username', 'volunteer-password',
-                'VOLUNTEER-FIRST-NAME', 'volunteer-last-name',
-                'volunteer-email@systers.org', 'volunteer-address',
-                'volunteer-city', 'volunteer-state', 'volunteer-country',
-                '9999999999', 'volunteer-organization']
-
-        self.register_volunteer(credentials)
-
-        credentials = ['volunteer-usernameq', 'volunteer-passwordq',
-                'volunteer-first-name', 'volunteer-last-nameq',
-                'volunteer-email2@systers.orgq', 'volunteer-addressq',
-                'volunteer-cityq', 'volunteer-stateq', 'volunteer-countryq',
-                '9999999999', 'volunteer-organizationq']
-
-        self.register_volunteer(credentials)
-        self.login_admin()
-
-        #self.driver.find_element_by_link_text('Volunteer Search').click()
-        self.driver.get(self.live_server_url + '/volunteer/search/')
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                '/volunteer/search/')
-
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").send_keys('volunteer')
+    def submit_form(self):
         self.driver.find_element_by_class_name('btn').click()
 
+    def search_first_name_field(self, search_text):
+        self.driver.find_element_by_css_selector(self.first_name_field).clear()
+        self.driver.find_element_by_css_selector(self.first_name_field).send_keys(search_text)
+
+    def search_last_name_field(self, search_text):
+        self.driver.find_element_by_css_selector(self.last_name_field).clear()
+        self.driver.find_element_by_css_selector(self.last_name_field).send_keys(search_text)
+
+    def search_city_field(self, search_text):
+        self.driver.find_element_by_css_selector(self.city_field).clear()
+        self.driver.find_element_by_css_selector(self.city_field).send_keys(search_text)
+
+    def search_state_field(self, search_text):
+        self.driver.find_element_by_css_selector(self.state_field).clear()
+        self.driver.find_element_by_css_selector(self.state_field).send_keys(search_text)
+
+    def search_country_field(self, search_text):
+        self.driver.find_element_by_css_selector(self.country_field).clear()
+        self.driver.find_element_by_css_selector(self.country_field).send_keys(search_text)
+
+    def search_organization_field(self, search_text):
+        self.driver.find_element_by_css_selector(self.org_field).clear()
+        self.driver.find_element_by_css_selector(self.org_field).send_keys(search_text)
+
+    def get_search_results(self):
         search_results = self.driver.find_element_by_xpath('//table//tbody')
+        return search_results
+
+    def get_results_list(self, search_results):
 
         result = []
         for tr in search_results.find_elements_by_tag_name('tr'):
             row = tr.text.split()
             result.append(row)
+
+        return result
+
+    def test_volunteer_first_name_field(self):            
+        credentials_1 = ['volunteer-username', 'VOLUNTEER-FIRST-NAME', 'volunteer-last-name',
+                'volunteer-address', 'volunteer-city', 'volunteer-state',
+                'volunteer-country', '9999999999', 'volunteer-email@systers.org',
+                'volunteer-organization']
+
+        v1 = create_volunteer_with_details(credentials_1)
+
+        credentials_2 = ['volunteer-usernameq', 'volunteer-first-name', 'volunteer-last-nameq',
+                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq', 'volunteer-countryq',
+                '9999999999', 'volunteer-email2@systers.orgq', 'volunteer-organizationq']
+
+        v2 = create_volunteer_with_details(credentials_2)
+
+        self.login_admin()
+        self.driver.get(self.live_server_url + self.volunteer_search)
+
+        expected_result_one = credentials_1[1:-1]
+        expected_result_two = credentials_2[1:-1]
         
+        self.search_first_name_field('volunteer')
+        self.submit_form()
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
         self.assertEqual(len(result), 2)
 
-        expected_result = ['volunteer-first-name', 'volunteer-last-nameq',
-                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq',
-                'volunteer-countryq', 'volunteer-organizationq', '9999999999',
-                'volunteer-email2@systers.orgq']
-        
-        self.assertTrue(expected_result in result)
+        self.assertTrue(expected_result_two in result)
+        self.assertTrue(expected_result_one in result)
 
-        expected_result = ['VOLUNTEER-FIRST-NAME', 'volunteer-last-name',
-                'volunteer-address', 'volunteer-city', 'volunteer-state',
-                'volunteer-country', 'volunteer-organization', '9999999999',
-                'volunteer-email@systers.org']
-
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").send_keys('e')
-        self.driver.find_element_by_class_name('btn').click()
-
+        self.search_first_name_field('e')
+        self.submit_form()
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
         self.assertEqual(len(result), 2)
 
-        expected_result = ['volunteer-first-name', 'volunteer-last-nameq',
-                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq',
-                'volunteer-countryq', 'volunteer-organizationq', '9999999999',
-                'volunteer-email2@systers.orgq']
-        
-        self.assertTrue(expected_result in result)
+        self.assertTrue(expected_result_one in result)
+        self.assertTrue(expected_result_two in result)
 
-        expected_result = ['VOLUNTEER-FIRST-NAME', 'volunteer-last-name',
-                'volunteer-address', 'volunteer-city', 'volunteer-state',
-                'volunteer-country', 'volunteer-organization', '9999999999',
-                'volunteer-email@systers.org']
-
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").send_keys('vol-')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_first_name_field('vol-')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").send_keys('volunteer-fail-test')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_first_name_field('volunteer-fail-test')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").send_keys('!@#$%^&*()_')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_first_name_field('!@#$%^&*()_')
+        self.submit_form()
         self.assertNotEqual(self.driver.find_element_by_class_name('help-block'),
                 None)
 
     def test_volunteer_last_name_field(self):            
-        credentials = ['volunteer-username', 'volunteer-password',
-                'volunteer-first-name', 'VOLUNTEER-LAST-NAME',
-                'volunteer-email@systers.org', 'volunteer-address',
-                'volunteer-city', 'volunteer-state', 'volunteer-country',
-                '9999999999', 'volunteer-organization']
+        credentials_1 = ['volunteer-username', 'volunteer-first-name', 'VOLUNTEER-LAST-NAME',
+                'volunteer-address', 'volunteer-city', 'volunteer-state', 'volunteer-country',
+                '9999999999', 'volunteer-email@systers.org','volunteer-organization']
+        v1 = create_volunteer_with_details(credentials_1)
 
-        self.register_volunteer(credentials)
-
-        credentials = ['volunteer-usernameq', 'volunteer-passwordq',
-                'volunteer-first-nameq', 'volunteer-last-name',
-                'volunteer-email2@systers.orgq', 'volunteer-addressq',
-                'volunteer-cityq', 'volunteer-stateq', 'volunteer-countryq',
-                '9999999999', 'volunteer-organizationq']
-
-        self.register_volunteer(credentials)
+        credentials_2 = ['volunteer-usernameq', 'volunteer-first-nameq', 'volunteer-last-name',
+                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq', 'volunteer-countryq',
+                '9999999999', 'volunteer-email2@systers.orgq', 'volunteer-organizationq']
+        v2 = create_volunteer_with_details(credentials_2)
 
         self.login_admin()
-        self.driver.get(self.live_server_url + '/volunteer/search/')
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                '/volunteer/search/')
+        self.driver.get(self.live_server_url + self.volunteer_search)
 
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").send_keys('volunteer')
-        self.driver.find_element_by_class_name('btn').click()
+        expected_result_one = credentials_1[1:-1]
+        expected_result_two = credentials_2[1:-1]
 
-        search_results = self.driver.find_element_by_xpath('//table//tbody')
+        self.search_last_name_field('volunteer')
+        self.submit_form()
 
-        result = []
-        for tr in search_results.find_elements_by_tag_name('tr'):
-            row = tr.text.split()
-            result.append(row)
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
 
-        expected_result = ['volunteer-first-nameq', 'volunteer-last-name',
-                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq',
-                'volunteer-countryq', 'volunteer-organizationq', '9999999999',
-                'volunteer-email2@systers.orgq']
-        
-        self.assertTrue(expected_result in result)
+        self.assertTrue(expected_result_two in result)
+        self.assertTrue(expected_result_one in result)
 
-        expected_result = ['volunteer-first-name', 'VOLUNTEER-LAST-NAME',
-                'volunteer-address', 'volunteer-city', 'volunteer-state',
-                'volunteer-country', 'volunteer-organization', '9999999999',
-                'volunteer-email@systers.org']
-
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").send_keys('v')
-        self.driver.find_element_by_class_name('btn').click()
-
+        self.search_last_name_field('v')
+        self.submit_form()
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
         self.assertEqual(len(result), 2)
 
-        expected_result = ['volunteer-first-nameq', 'volunteer-last-name',
-                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq',
-                'volunteer-countryq', 'volunteer-organizationq', '9999999999',
-                'volunteer-email2@systers.orgq']
-        
-        self.assertTrue(expected_result in result)
+        self.assertTrue(expected_result_one in result)
+        self.assertTrue(expected_result_two in result)
 
-        expected_result = ['volunteer-first-name', 'VOLUNTEER-LAST-NAME',
-                'volunteer-address', 'volunteer-city', 'volunteer-state',
-                'volunteer-country', 'volunteer-organization', '9999999999',
-                'volunteer-email@systers.org']
-
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").send_keys('vol-')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_last_name_field('vol-')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").send_keys('volunteer-fail-test')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_last_name_field('volunteer-fail-test')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").send_keys('!@#$%^&*()_')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_last_name_field('!@#$%^&*()_')
+        self.submit_form()
         self.assertNotEqual(self.driver.find_element_by_class_name('help-block'),
                 None)
 
     def test_volunteer_city_field(self):            
-        credentials = ['volunteer-username', 'volunteer-password',
-                'volunteer-first-name', 'volunteer-last-name',
-                'volunteer-email@systers.org', 'volunteer-address',
-                'VOLUNTEER-CITY', 'volunteer-state', 'volunteer-country',
-                '9999999999', 'volunteer-organization']
+        credentials_1 = ['volunteer-username', 'volunteer-first-name', 'volunteer-last-name',
+                'volunteer-address', 'VOLUNTEER-CITY', 'volunteer-state', 'volunteer-country',
+                '9999999999', 'volunteer-email@systers.org', 'volunteer-organization']
 
-        self.register_volunteer(credentials)
+        v1 = create_volunteer_with_details(credentials_1)
 
-        credentials = ['volunteer-usernameq', 'volunteer-passwordq',
-                'volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-email2@systers.orgq', 'volunteer-addressq',
-                'volunteer-city', 'volunteer-stateq', 'volunteer-countryq',
-                '9999999999', 'volunteer-organizationq']
+        credentials_2 = ['volunteer-usernameq', 'volunteer-first-nameq', 'volunteer-last-nameq',
+                'volunteer-addressq', 'volunteer-city', 'volunteer-stateq', 'volunteer-countryq',
+                '9999999999', 'volunteer-email2@systers.orgq','volunteer-organizationq']
 
-        self.register_volunteer(credentials)
+        v2 = create_volunteer_with_details(credentials_2)
 
         self.login_admin()
-        self.driver.get(self.live_server_url + '/volunteer/search/')
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                '/volunteer/search/')
+        self.driver.get(self.live_server_url + self.volunteer_search)
 
-        self.driver.find_element_by_css_selector(".form-control[name='city']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='city']").send_keys('volunteer')
-        self.driver.find_element_by_class_name('btn').click()
+        expected_result_one = credentials_1[1:-1]
+        expected_result_two = credentials_2[1:-1]
 
-        search_results = self.driver.find_element_by_xpath('//table//tbody')
-
-        result = []
-        for tr in search_results.find_elements_by_tag_name('tr'):
-            row = tr.text.split()
-            result.append(row)
-
-        expected_result = ['volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-addressq', 'volunteer-city', 'volunteer-stateq',
-                'volunteer-countryq', 'volunteer-organizationq', '9999999999',
-                'volunteer-email2@systers.orgq']
+        self.search_city_field('volunteer')
+        self.submit_form()
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
+        self.assertEqual(len(result), 2)
         
-        self.assertTrue(expected_result in result)
+        self.assertTrue(expected_result_one in result)
+        self.assertTrue(expected_result_two in result)
 
-        expected_result = ['volunteer-first-name', 'volunteer-last-name',
-                'volunteer-address', 'VOLUNTEER-CITY', 'volunteer-state',
-                'volunteer-country', 'volunteer-organization', '9999999999',
-                'volunteer-email@systers.org']
-
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='city']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='city']").send_keys('v')
-        self.driver.find_element_by_class_name('btn').click()
-
+        self.search_city_field('v')
+        self.submit_form()
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
         self.assertEqual(len(result), 2)
 
-        expected_result = ['volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-addressq', 'volunteer-city', 'volunteer-stateq',
-                'volunteer-countryq', 'volunteer-organizationq', '9999999999',
-                'volunteer-email2@systers.orgq']
-        
-        self.assertTrue(expected_result in result)
+        self.assertTrue(expected_result_one in result)
+        self.assertTrue(expected_result_two in result)
 
-        expected_result = ['volunteer-first-name', 'volunteer-last-name',
-                'volunteer-address', 'VOLUNTEER-CITY', 'volunteer-state',
-                'volunteer-country', 'volunteer-organization', '9999999999',
-                'volunteer-email@systers.org']
-
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='city']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='city']").send_keys('vol-')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_city_field('vol-')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='city']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='city']").send_keys('volunteer-fail-test')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_city_field('volunteer-fail-test')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='city']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='city']").send_keys('!@#$%^&*()_')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_city_field('!@#$%^&*()_')
+        self.submit_form()
         self.assertNotEqual(self.driver.find_element_by_class_name('help-block'),
                 None)
 
     def test_volunteer_state_field(self):            
-        credentials = ['volunteer-username', 'volunteer-password',
-                'volunteer-first-name', 'volunteer-last-name',
-                'volunteer-email@systers.org', 'volunteer-address',
-                'volunteer-city', 'VOLUNTEER-STATE', 'volunteer-country',
-                '9999999999', 'volunteer-organization']
+        credentials_1 = ['volunteer-username', 'volunteer-first-name', 'volunteer-last-name',
+                'volunteer-address', 'volunteer-city', 'VOLUNTEER-STATE', 'volunteer-country',
+                '9999999999', 'volunteer-email@systers.org', 'volunteer-organization']
 
-        self.register_volunteer(credentials)
+        v1 = create_volunteer_with_details(credentials_1)
 
-        credentials = ['volunteer-usernameq', 'volunteer-passwordq',
-                'volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-email2@systers.orgq', 'volunteer-addressq',
-                'volunteer-cityq', 'volunteer-state', 'volunteer-countryq',
-                '9999999999', 'volunteer-organizationq']
+        credentials_2 = ['volunteer-usernameq', 'volunteer-first-nameq', 'volunteer-last-nameq',
+                'volunteer-addressq', 'volunteer-cityq', 'volunteer-state', 'volunteer-countryq',
+                '9999999999', 'volunteer-email2@systers.orgq', 'volunteer-organizationq']
 
-        self.register_volunteer(credentials)
+        v2 = create_volunteer_with_details(credentials_2)
 
         self.login_admin()
-        self.driver.get(self.live_server_url + '/volunteer/search/')
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                '/volunteer/search/')
+        self.driver.get(self.live_server_url + self.volunteer_search)
 
-        self.driver.find_element_by_css_selector(".form-control[name='state']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='state']").send_keys('volunteer')
-        self.driver.find_element_by_class_name('btn').click()
+        expected_result_one = credentials_1[1:-1]
+        expected_result_two = credentials_2[1:-1]
 
-        search_results = self.driver.find_element_by_xpath('//table//tbody')
-
-        result = []
-        for tr in search_results.find_elements_by_tag_name('tr'):
-            row = tr.text.split()
-            result.append(row)
-
-        expected_result = ['volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-addressq', 'volunteer-cityq', 'volunteer-state',
-                'volunteer-countryq', 'volunteer-organizationq', '9999999999',
-                'volunteer-email2@systers.orgq']
-        
-        self.assertTrue(expected_result in result)
-
-        expected_result = ['volunteer-first-name', 'volunteer-last-name',
-                'volunteer-address', 'volunteer-city', 'VOLUNTEER-STATE',
-                'volunteer-country', 'volunteer-organization', '9999999999',
-                'volunteer-email@systers.org']
-
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='state']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='state']").send_keys('v')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_state_field('volunteer')
+        self.submit_form()
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
 
         self.assertEqual(len(result), 2)
+        self.assertTrue(expected_result_two in result)
+        self.assertTrue(expected_result_one in result)
 
-        expected_result = ['volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-addressq', 'volunteer-cityq', 'volunteer-state',
-                'volunteer-countryq', 'volunteer-organizationq', '9999999999',
-                'volunteer-email2@systers.orgq']
+        self.search_state_field('v')
+        self.submit_form()
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
         
-        self.assertTrue(expected_result in result)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(expected_result_two in result)
+        self.assertTrue(expected_result_one in result)
 
-        expected_result = ['volunteer-first-name', 'volunteer-last-name',
-                'volunteer-address', 'volunteer-city', 'VOLUNTEER-STATE',
-                'volunteer-country', 'volunteer-organization', '9999999999',
-                'volunteer-email@systers.org']
-
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='state']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='state']").send_keys('vol-')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_state_field('vol-')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='state']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='state']").send_keys('volunteer-fail-test')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_state_field('volunteer-fail-test')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='state']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='state']").send_keys('!@#$%^&*()_')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_state_field('!@#$%^&*()_')
+        self.submit_form()
         self.assertNotEqual(self.driver.find_element_by_class_name('help-block'),
                 None)
 
     def test_volunteer_country_field(self):            
-        credentials = ['volunteer-username', 'volunteer-password',
-                'volunteer-first-name', 'volunteer-last-name',
-                'volunteer-email@systers.org', 'volunteer-address',
-                'volunteer-city', 'volunteer-state', 'VOLUNTEER-COUNTRY',
-                '9999999999', 'volunteer-organization']
+        credentials_1 = ['volunteer-username', 'volunteer-first-name', 'volunteer-last-name',
+                'volunteer-address', 'volunteer-city', 'volunteer-state', 'VOLUNTEER-COUNTRY',
+                '9999999999', 'volunteer-email@systers.org', 'volunteer-organization']
 
-        self.register_volunteer(credentials)
+        v1 = create_volunteer_with_details(credentials_1)
 
-        credentials = ['volunteer-usernameq', 'volunteer-passwordq',
-                'volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-email2@systers.orgq', 'volunteer-addressq',
-                'volunteer-cityq', 'volunteer-stateq', 'volunteer-country',
-                '9999999999', 'volunteer-organizationq']
+        credentials_2 = ['volunteer-usernameq', 'volunteer-first-nameq', 'volunteer-last-nameq',
+                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq', 'volunteer-country',
+                '9999999999', 'volunteer-email2@systers.orgq', 'volunteer-organizationq']
 
-        self.register_volunteer(credentials)
+        v2 = create_volunteer_with_details(credentials_2)
 
         self.login_admin()
-        self.driver.get(self.live_server_url + '/volunteer/search/')
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                '/volunteer/search/')
+        self.driver.get(self.live_server_url + self.volunteer_search)
 
-        self.driver.find_element_by_css_selector(".form-control[name='country']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='country']").send_keys('volunteer')
-        self.driver.find_element_by_class_name('btn').click()
+        expected_result_one = credentials_1[1:-1]
+        expected_result_two = credentials_2[1:-1]
 
-        search_results = self.driver.find_element_by_xpath('//table//tbody')
-
-        result = []
-        for tr in search_results.find_elements_by_tag_name('tr'):
-            row = tr.text.split()
-            result.append(row)
-
-        expected_result = ['volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq',
-                'volunteer-country', 'volunteer-organizationq', '9999999999',
-                'volunteer-email2@systers.orgq']
+        self.search_country_field('volunteer')
+        self.submit_form()
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
         
-        self.assertTrue(expected_result in result)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(expected_result_two in result)
+        self.assertTrue(expected_result_one in result)
 
-        expected_result = ['volunteer-first-name', 'volunteer-last-name',
-                'volunteer-address', 'volunteer-city', 'volunteer-state',
-                'VOLUNTEER-COUNTRY', 'volunteer-organization', '9999999999',
-                'volunteer-email@systers.org']
-
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='country']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='country']").send_keys('v')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_country_field('v')
+        self.submit_form()
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
 
         self.assertEqual(len(result), 2)
+        self.assertTrue(expected_result_two in result)
+        self.assertTrue(expected_result_one in result)
 
-        expected_result = ['volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq',
-                'volunteer-country', 'volunteer-organizationq', '9999999999',
-                'volunteer-email2@systers.orgq']
-        
-        self.assertTrue(expected_result in result)
-
-        expected_result = ['volunteer-first-name', 'volunteer-last-name',
-                'volunteer-address', 'volunteer-city', 'volunteer-state',
-                'VOLUNTEER-COUNTRY', 'volunteer-organization', '9999999999',
-                'volunteer-email@systers.org']
-
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='country']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='country']").send_keys('vol-')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_country_field('vol-')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='country']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='country']").send_keys('volunteer-fail-test')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_country_field('volunteer-fail-test')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='country']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='country']").send_keys('!@#$%^&*()_')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_country_field('!@#$%^&*()_')
+        self.submit_form()
         self.assertNotEqual(self.driver.find_element_by_class_name('help-block'),
                 None)
 
     def test_volunteer_organization_field(self):            
-        credentials = ['volunteer-username', 'volunteer-password',
-                'volunteer-first-name', 'volunteer-last-name',
-                'volunteer-email@systers.org', 'volunteer-address',
-                'volunteer-city', 'volunteer-state', 'volunteer-country',
-                '9999999999', 'VOLUNTEER-ORGANIZATION']
+        credentials_1 = ['volunteer-username', 'volunteer-first-name', 'volunteer-last-name',
+                'volunteer-address', 'volunteer-city', 'volunteer-state', 'volunteer-country',
+                '9999999999', 'volunteer-email@systers.org']
 
-        self.register_volunteer(credentials)
+        v1 = create_volunteer_with_details(credentials_1)
 
-        credentials = ['volunteer-usernameq', 'volunteer-passwordq',
-                'volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-email2@systers.orgq', 'volunteer-addressq',
-                'volunteer-cityq', 'volunteer-stateq', 'volunteer-countryq',
-                '9999999999', 'volunteer-organization']
+        credentials_2 = ['volunteer-usernameq', 'volunteer-first-nameq', 'volunteer-last-nameq',
+                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq', 'volunteer-countryq',
+                '9999999999', 'volunteer-email2@systers.orgq']
 
-        self.register_volunteer(credentials)
+        v2 = create_volunteer_with_details(credentials_2)
+
+        v2.unlisted_organization="volunteer-organization"
+        v1.unlisted_organization="VOLUNTEER-ORGANIZATION"
+        v1.save()
+        v2.save()
 
         self.login_admin()
-        self.driver.get(self.live_server_url + '/volunteer/search/')
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                '/volunteer/search/')
+        self.driver.get(self.live_server_url + self.volunteer_search)
 
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").send_keys('volunteer')
-        self.driver.find_element_by_class_name('btn').click()
-
-        search_results = self.driver.find_element_by_xpath('//table//tbody')
-
-        result = []
-        for tr in search_results.find_elements_by_tag_name('tr'):
-            row = tr.text.split()
-            result.append(row)
-
-        expected_result = ['volunteer-first-nameq', 'volunteer-last-nameq',
+        expected_result_one = ['volunteer-first-nameq', 'volunteer-last-nameq',
                 'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq',
                 'volunteer-countryq', 'volunteer-organization', '9999999999',
                 'volunteer-email2@systers.orgq']
-        
-        self.assertTrue(expected_result in result)
 
-        expected_result = ['volunteer-first-name', 'volunteer-last-name',
+        expected_result_two = ['volunteer-first-name', 'volunteer-last-name',
                 'volunteer-address', 'volunteer-city', 'volunteer-state',
                 'volunteer-country', 'VOLUNTEER-ORGANIZATION', '9999999999',
                 'volunteer-email@systers.org']
 
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").send_keys('v')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_organization_field('volunteer')
+        self.submit_form()
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
 
         self.assertEqual(len(result), 2)
+        self.assertTrue(expected_result_one in result)
+        self.assertTrue(expected_result_two in result)
 
-        expected_result = ['volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq',
-                'volunteer-countryq', 'volunteer-organization', '9999999999',
-                'volunteer-email2@systers.orgq']
-        
-        self.assertTrue(expected_result in result)
+        self.search_organization_field('v')
+        self.submit_form()
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
 
-        expected_result = ['volunteer-first-name', 'volunteer-last-name',
-                'volunteer-address', 'volunteer-city', 'volunteer-state',
-                'volunteer-country', 'VOLUNTEER-ORGANIZATION', '9999999999',
-                'volunteer-email@systers.org']
+        self.assertEqual(len(result), 2)
+        self.assertTrue(expected_result_one in result)
+        self.assertTrue(expected_result_two in result)
 
-        self.assertTrue(expected_result in result)
-
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").send_keys('vol-')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_organization_field('vol-')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").send_keys('volunteer-fail-test')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_organization_field('volunteer-fail-test')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
 
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").send_keys('!@#$%^&*()_')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_organization_field('!@#$%^&*()_')
+        self.submit_form()
         self.assertNotEqual(self.driver.find_element_by_class_name('help-block'),
                 None)
 
     def test_intersection_of_all_fields(self):            
-        credentials = ['volunteer-username', 'volunteer-password',
-                'volunteer-first-name', 'volunteer-last-name',
-                'volunteer-email@systers.org', 'volunteer-address',
-                'volunteer-city', 'volunteer-state', 'volunteer-country',
-                '9999999999', 'VOLUNTEER-ORGANIZATION']
+        credentials_1 = ['volunteer-username', 'volunteer-first-name', 'volunteer-last-name',
+                'volunteer-address', 'volunteer-city', 'volunteer-state', 'volunteer-country',
+                '9999999999', 'volunteer-email@systers.org']
 
-        self.register_volunteer(credentials)
+        v1 = create_volunteer_with_details(credentials_1)
 
-        credentials = ['volunteer-usernameq', 'volunteer-passwordq',
-                'volunteer-first-nameq', 'volunteer-last-nameq',
-                'volunteer-email2@systers.orgq', 'volunteer-addressq',
-                'volunteer-cityq', 'volunteer-stateq', 'volunteer-countryq',
-                '9999999999', 'volunteer-organization']
+        credentials_2 = ['volunteer-usernameq', 'volunteer-first-nameq', 'volunteer-last-nameq',
+                'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq', 'volunteer-countryq',
+                '9999999999', 'volunteer-email2@systers.orgq']
 
-        self.register_volunteer(credentials)
+        v2 = create_volunteer_with_details(credentials_2)
+
+        v2.unlisted_organization="volunteer-organization"
+        v1.unlisted_organization="VOLUNTEER-ORGANIZATION"
+        v1.save()
+        v2.save()
 
         self.login_admin()
-        self.driver.get(self.live_server_url + '/volunteer/search/')
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                '/volunteer/search/')
+        self.driver.get(self.live_server_url + self.volunteer_search)
 
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").send_keys('volunteer')
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").send_keys('volunteer')
-        self.driver.find_element_by_css_selector(".form-control[name='city']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='city']").send_keys('volunteer')
-        self.driver.find_element_by_css_selector(".form-control[name='state']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='state']").send_keys('volunteer')
-        self.driver.find_element_by_css_selector(".form-control[name='country']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='country']").send_keys('volunteer')
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").send_keys('volunteer')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_first_name_field('volunteer')
+        self.search_last_name_field('volunteer')
+        self.search_city_field('volunteer')
+        self.search_state_field('volunteer')
+        self.search_country_field('volunteer')
+        self.search_organization_field('volunteer')
+        self.submit_form()
 
-        search_results = self.driver.find_element_by_xpath('//table//tbody')
+        search_results = self.get_search_results()
+        result = self.get_results_list(search_results)
 
-        result = []
-        for tr in search_results.find_elements_by_tag_name('tr'):
-            row = tr.text.split()
-            result.append(row)
-
-        expected_result = ['volunteer-first-nameq', 'volunteer-last-nameq',
+        expected_result_one = ['volunteer-first-nameq', 'volunteer-last-nameq',
                 'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq',
                 'volunteer-countryq', 'volunteer-organization', '9999999999',
                 'volunteer-email2@systers.orgq']
-        
-        self.assertTrue(expected_result in result)
 
-        expected_result = ['volunteer-first-name', 'volunteer-last-name',
+        expected_result_two = ['volunteer-first-name', 'volunteer-last-name',
                 'volunteer-address', 'volunteer-city', 'volunteer-state',
                 'volunteer-country', 'VOLUNTEER-ORGANIZATION', '9999999999',
                 'volunteer-email@systers.org']
 
-        self.assertTrue(expected_result in result)
+        self.assertTrue(expected_result_one in result)
+        self.assertTrue(expected_result_two in result)
 
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='first_name']").send_keys('volunteer')
-        self.driver.find_element_by_css_selector(".form-control[name='country']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='country']").send_keys('wrong-country')
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='organization']").send_keys('org')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_first_name_field('volunteer')
+        self.search_country_field('wrong-country')
+        self.search_organization_field('org')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()
         
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='last_name']").send_keys('volunteer')
-        self.driver.find_element_by_css_selector(".form-control[name='city']").clear()
-        self.driver.find_element_by_css_selector(".form-control[name='city']").send_keys('wrong-city')
-        self.driver.find_element_by_class_name('btn').click()
+        self.search_last_name_field('volunteer')
+        self.search_city_field('wrong-city')
+        self.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            search_results = self.driver.find_element_by_xpath('//table//tbody')
+            search_results = self.get_search_results()

--- a/vms/volunteer/tests/test_volunteerReport.py
+++ b/vms/volunteer/tests/test_volunteerReport.py
@@ -1,53 +1,44 @@
-from django.test import TestCase
 from django.contrib.staticfiles.testing import LiveServerTestCase
-
-from django.contrib.auth.models import User
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import Select
 
-from volunteer.models import Volunteer
-from organization.models import Organization #hack to pass travis,Bug in Code
-from event.models import Event
-from job.models import Job
-from shift.models import Shift, VolunteerShift
-
+from shift.utils import (
+    create_volunteer,
+    register_event_utility,
+    register_job_utility,
+    register_shift_utility
+    )
 
 class VolunteerReport(LiveServerTestCase):
     '''
     '''
+    @classmethod
+    def setUpClass(cls):
+        cls.homepage = '/'
+        cls.authentication_page = '/authentication/login/'
+        cls.report_start_date = '//input[@name = "start_date"]'
+        cls.report_end_date = '//input[@name = "end_date"]'
+        cls.report_event_selector = '//select[@name = "event_name"]'
+        cls.report_job_selector = '//select[@name = "job_name"]'
+        cls.report_shift_summary_path = '//div[2]/div[4]'
+
+        cls.driver = webdriver.Firefox()
+        cls.driver.implicitly_wait(5)
+        cls.driver.maximize_window()
+        super(VolunteerReport, cls).setUpClass()
+
     def setUp(self):
-        volunteer_user = User.objects.create_user(
-                username = 'volunteer',
-                password = 'volunteer',
-                email = 'volunteer@volunteer.com')
-
-        Volunteer.objects.create(
-                user = volunteer_user,
-                address = 'address',
-                city = 'city',
-                state = 'state',
-                country = 'country',
-                phone_number = '9999999999',
-                unlisted_organization = 'organization')
-
-        # create an org prior to registration. Bug in Code
-        # added to pass CI
-        Organization.objects.create(
-                name = 'DummyOrg')
-
-        self.homepage = '/'
-        self.registration_page = '/registration/signup_volunteer/'
-        self.authentication_page = '/authentication/login/'
-        self.driver = webdriver.Firefox()
-        self.driver.implicitly_wait(5)
-        self.driver.maximize_window()
-        super(VolunteerReport, self).setUp()
+        create_volunteer()
 
     def tearDown(self):
-        self.driver.quit()
-        super(VolunteerReport, self).tearDown()
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        super(VolunteerReport, cls).tearDownClass()
 
     def login(self, credentials):
         self.driver.get(self.live_server_url + self.authentication_page)
@@ -55,40 +46,38 @@ class VolunteerReport(LiveServerTestCase):
         self.driver.find_element_by_id('id_password').send_keys(credentials['password'])
         self.driver.find_element_by_xpath('//form[1]').submit()
 
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url + self.homepage)
-
-    def register_event_utility(self):
-        Event.objects.create(
-                name = 'event',
-                start_date = '2015-06-11',
-                end_date = '2015-06-25')
-
-    def register_job_utility(self):
-        Job.objects.create(
-                name = 'job',
-                start_date = '2015-06-15',
-                end_date = '2015-06-18',
-                event = Event.objects.get(name = 'event'))
-
-    def register_shift_utility(self):
-        Shift.objects.create(
-                date = '2015-06-15',
-                start_time = '09:00',
-                end_time = '15:00',
-                max_volunteers ='6',
-                job = Job.objects.get(name = 'job'))
-
-    def log_hours_utility(self):
-        VolunteerShift.objects.create(
-                shift = Shift.objects.get(job__name = 'job'),
-                volunteer = Volunteer.objects.get(user__username = 'volunteer'),
-                start_time = '09:00',
-                end_time = '12:00')
-
-    def test_report_without_any_created_shifts(self):
+    def login_and_navigate_to_report_page(self):
         self.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
         self.driver.find_element_by_link_text('Report').send_keys("\n")
+
+    def get_event_job_selectors(self):
+        select1 = Select(self.driver.find_element_by_xpath(self.report_event_selector))
+        select2 = Select(self.driver.find_element_by_xpath(self.report_job_selector))
+        return (select1, select2)
+
+    def fill_report_form(self, dates):
+        self.driver.find_element_by_xpath(
+                self.report_start_date).clear()
+        self.driver.find_element_by_xpath(
+                self.report_end_date).clear()
+        self.driver.find_element_by_xpath(
+                self.report_start_date).send_keys(dates['start'])
+        self.driver.find_element_by_xpath(
+                self.report_end_date).send_keys(dates['end'])
+        self.driver.find_element_by_xpath('//form').submit()
+
+    def verify_shift_details(self, total_shifts, hours):
+        total_no_of_shifts =  self.driver.find_element_by_xpath(
+                self.report_shift_summary_path).text.split(' ')[10].strip('\nTotal')
+
+        total_no_of_hours =  self.driver.find_element_by_xpath(
+                self.report_shift_summary_path).text.split(' ')[-1].strip('\n')
+        
+        self.assertEqual(total_no_of_shifts, total_shifts)
+        self.assertEqual(total_no_of_hours, hours)
+
+    def test_report_without_any_created_shifts(self):
+        self.login_and_navigate_to_report_page()
         self.driver.find_element_by_xpath('//form').submit()
         self.assertEqual(self.driver.find_element_by_class_name(
             'alert-danger').text, 'Your criteria did not return any results.')
@@ -97,31 +86,21 @@ class VolunteerReport(LiveServerTestCase):
 #Test commented out to prevent travis build failure
 
     """def test_report_with_empty_fields(self):
-        self.register_event_utility()
-        self.register_job_utility()
-        self.register_shift_utility()
-        self.log_hours_utility()
+        register_event_utility()
+        register_job_utility()
+        register_shift_utility()
+        log_hours_utility()
 
-        self.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
-        self.driver.find_element_by_link_text('Report').send_keys("\n")
+        self.login_and_navigate_to_report_page()
         self.driver.find_element_by_xpath('//form').submit()
-
-        total_no_of_shifts =  self.driver.find_element_by_xpath(
-                '//div[2]/div[4]').text.split(' ')[10].strip('\nTotal')
-
-        total_no_of_hours =  self.driver.find_element_by_xpath(
-                '//div[2]/div[4]').text.split(' ')[-1].strip('\n')
-
-        self.assertEqual(total_no_of_shifts, '1')
-        self.assertEqual(total_no_of_hours, '3.0')"""
+        self.verify_shift_details('1','3.0')"""
 
     def test_only_logged_shifts_appear_in_report(self):
-        self.register_event_utility()
-        self.register_job_utility()
-        self.register_shift_utility()
+        register_event_utility()
+        register_job_utility()
+        register_shift_utility()
 
-        self.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
-        self.driver.find_element_by_link_text('Report').send_keys("\n")
+        self.login_and_navigate_to_report_page()
         self.driver.find_element_by_xpath('//form').submit()
         self.assertEqual(self.driver.find_element_by_class_name(
             'alert-danger').text, 'Your criteria did not return any results.')
@@ -130,129 +109,62 @@ class VolunteerReport(LiveServerTestCase):
 #Tests commented out to prevent travis build failure
 
     """def test_date_field(self):
-        self.register_event_utility()
-        self.register_job_utility()
-        self.register_shift_utility()
-        self.log_hours_utility()
+        register_event_utility()
+        register_job_utility()
+        register_shift_utility()
+        log_hours_utility()
 
-        self.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
-        self.driver.find_element_by_link_text('Report').send_keys("\n")
-        self.driver.find_element_by_xpath(
-                '//input[@name = "start_date"]').send_keys('2015-06-11')
-        self.driver.find_element_by_xpath(
-                '//input[@name = "end_date"]').send_keys('2015-07-30')
-        self.driver.find_element_by_xpath('//form').submit()
-
-        total_no_of_shifts =  self.driver.find_element_by_xpath(
-                '//div[2]/div[4]').text.split(' ')[10].strip('\nTotal')
-
-        total_no_of_hours =  self.driver.find_element_by_xpath(
-                '//div[2]/div[4]').text.split(' ')[-1].strip('\n')
-
-        self.assertEqual(total_no_of_shifts, '1')
-        self.assertEqual(total_no_of_hours, '3.0')
+        self.login_and_navigate_to_report_page()
+        self.fill_report_form({ 'start' : '2015-06-11', 'end' : '2017-06-16'})
+        self.verify_shift_details('1','3.0')
 
         #incorrect date
-        self.driver.find_element_by_xpath(
-                '//input[@name = "start_date"]').clear()
-        self.driver.find_element_by_xpath(
-                '//input[@name = "end_date"]').clear()
-        self.driver.find_element_by_xpath(
-                '//input[@name = "start_date"]').send_keys('2015-05-10')
-        self.driver.find_element_by_xpath(
-                '//input[@name = "end_date"]').send_keys('2015-06-01')
-        self.driver.find_element_by_xpath('//form').submit()
+        self.fill_report_form({ 'start' : '2015-05-10', 'end' : '2015-06-01'})
         self.assertEqual(self.driver.find_element_by_class_name(
             'alert-danger').text, 'Your criteria did not return any results.')
 
     def test_event_field(self):
-        self.register_event_utility()
-        self.register_job_utility()
-        self.register_shift_utility()
-        self.log_hours_utility()
+        register_event_utility()
+        register_job_utility()
+        register_shift_utility()
+        log_hours_utility()
 
-        self.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
-        self.driver.find_element_by_link_text('Report').send_keys("\n")
-        select = Select(self.driver.find_element_by_xpath('//select[@name = "event_name"]'))
-        select.select_by_visible_text('event')
+        self.login_and_navigate_to_report_page()
+        [select1, select2] = self.get_event_job_selectors()
+        select1.select_by_visible_text('event')
 
         self.driver.find_element_by_xpath('//form').submit()
-
-        total_no_of_shifts =  self.driver.find_element_by_xpath(
-                '//div[2]/div[4]').text.split(' ')[10].strip('\nTotal')
-
-        total_no_of_hours =  self.driver.find_element_by_xpath(
-                '//div[2]/div[4]').text.split(' ')[-1].strip('\n')
-
-        self.assertEqual(total_no_of_shifts, '1')
-        self.assertEqual(total_no_of_hours, '3.0')
+        self.verify_shift_details('1','3.0')
 
     def test_job_field(self):
-        self.register_event_utility()
-        self.register_job_utility()
-        self.register_shift_utility()
-        self.log_hours_utility()
+        register_event_utility()
+        register_job_utility()
+        register_shift_utility()
+        log_hours_utility()
 
-        self.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
-        self.driver.find_element_by_link_text('Report').send_keys("\n")
-        select = Select(self.driver.find_element_by_xpath('//select[@name = "job_name"]'))
-        select.select_by_visible_text('job')
+        self.login_and_navigate_to_report_page()
+        [select1, select2] = self.get_event_job_selectors()
+        select2.select_by_visible_text('job')
         self.driver.find_element_by_xpath('//form').submit()
-
-        total_no_of_shifts =  self.driver.find_element_by_xpath(
-                '//div[2]/div[4]').text.split(' ')[10].strip('\nTotal')
-
-        total_no_of_hours =  self.driver.find_element_by_xpath(
-                '//div[2]/div[4]').text.split(' ')[-1].strip('\n')
-
-        self.assertEqual(total_no_of_shifts, '1')
-        self.assertEqual(total_no_of_hours, '3.0')
+        self.verify_shift_details('1','3.0')
 
     def test_intersection_of_fields(self):
-        self.register_event_utility()
-        self.register_job_utility()
-        self.register_shift_utility()
-        self.log_hours_utility()
+        register_event_utility()
+        register_job_utility()
+        register_shift_utility()
+        log_hours_utility()
 
-        self.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
-        self.driver.find_element_by_link_text('Report').send_keys("\n")
-        select1 = Select(self.driver.find_element_by_xpath('//select[@name = "event_name"]'))
+        self.login_and_navigate_to_report_page()
+        [select1, select2] = self.get_event_job_selectors()
         select1.select_by_visible_text('event')
-        select2 = Select(self.driver.find_element_by_xpath('//select[@name = "job_name"]'))
         select2.select_by_visible_text('job')
-        self.driver.find_element_by_xpath(
-                '//input[@name = "start_date"]').clear()
-        self.driver.find_element_by_xpath(
-                '//input[@name = "end_date"]').clear()
-        self.driver.find_element_by_xpath(
-                '//input[@name = "start_date"]').send_keys('2015-06-11')
-        self.driver.find_element_by_xpath(
-                '//input[@name = "end_date"]').send_keys('2015-07-30')
-        self.driver.find_element_by_xpath('//form').submit()
-
-        total_no_of_shifts =  self.driver.find_element_by_xpath(
-                '//div[2]/div[4]').text.split(' ')[10].strip('\nTotal')
-
-        total_no_of_hours =  self.driver.find_element_by_xpath(
-                '//div[2]/div[4]').text.split(' ')[-1].strip('\n')
-
-        self.assertEqual(total_no_of_shifts, '1')
-        self.assertEqual(total_no_of_hours, '3.0')
+        self.fill_report_form({ 'start' : '2015-06-11', 'end' : '2017-06-16'})
+        self.verify_shift_details('1','3.0')
 
         # event, job correct and date incorrect
-        select1 = Select(self.driver.find_element_by_xpath('//select[@name = "event_name"]'))
+        [select1, select2] = self.get_event_job_selectors()
         select1.select_by_visible_text('event')
-        select2 = Select(self.driver.find_element_by_xpath('//select[@name = "job_name"]'))
         select2.select_by_visible_text('job')
-        self.driver.find_element_by_xpath(
-                '//input[@name = "start_date"]').clear()
-        self.driver.find_element_by_xpath(
-                '//input[@name = "end_date"]').clear()
-        self.driver.find_element_by_xpath(
-                '//input[@name = "start_date"]').send_keys('2015-05-10')
-        self.driver.find_element_by_xpath(
-                '//input[@name = "end_date"]').send_keys('2015-06-01')
-
-        self.driver.find_element_by_xpath('//form').submit()
+        self.fill_report_form({ 'start' : '2015-05-10', 'end' : '2015-06-01'})
         self.assertEqual(self.driver.find_element_by_class_name(
             'alert-danger').text, 'Your criteria did not return any results.')"""


### PR DESCRIPTION
All selenium tests have been restructured to share code in this PR. Functions which could be possibly reused have been identified and created for the tests. In most tests, constants have also been isolated at the top so that any change in UI only requires a change at the beginning of the file.
There is reduction in both test times and lines  as follows -
Time (approx. ) - 75 min to 43 min (41-42% reduction)
Lines - 

Number of tests have also increased from 164 to 168 but these are not new tests. I have broken subparts of a few tests into separate ones as they were repeatedly testing the same thing

Travis build timings - 
Related to #369 