### PR TITLE
Added database checks

### DIFF
--- a/vms/administrator/tests/test_formFields.py
+++ b/vms/administrator/tests/test_formFields.py
@@ -207,6 +207,9 @@ class FormFields(LiveServerTestCase):
         self.assertEqual(settings.get_shift_end_time_error(), 'This field is required.')
         self.assertEqual(settings.get_shift_max_volunteer_error(), 'This field is required.')
 
+        # database check to ensure that shift was not created
+        self.assertEqual(len(Shift.objects.all()), 0)
+
     def test_null_values_in_edit_shift(self):
         # register event to create job
         event = ['event-name', '2017-08-21', '2017-09-28']
@@ -237,6 +240,10 @@ class FormFields(LiveServerTestCase):
         self.assertEqual(settings.get_shift_start_time_error(), 'This field is required.')
         self.assertEqual(settings.get_shift_end_time_error(), 'This field is required.')
         self.assertEqual(settings.get_shift_max_volunteer_error(), 'This field is required.')
+
+        # database check to ensure that shift was not edited
+        self.assertEqual(len(Shift.objects.all()), 1)
+        self.assertNotEqual(len(Shift.objects.filter(date=created_shift.date)), 0)
 
     def test_field_value_retention_for_event(self):
         settings = self.settings
@@ -335,6 +342,9 @@ class FormFields(LiveServerTestCase):
         # erased
         # self.check_shift_form_values(invalid_shift)
 
+        # database check to ensure that shift was not created
+        self.assertEqual(len(Shift.objects.all()), 0)
+
         # now create shift and edit it
         # verify that shift was not edited and that field values are not
         # erased
@@ -347,6 +357,10 @@ class FormFields(LiveServerTestCase):
         # verify that shift was not created and that field values are not
         # erased
         # self.check_shift_form_values(invalid_shift)
+
+        # database check to ensure that shift was not edited
+        self.assertEqual(len(Shift.objects.all()), 1)
+        self.assertNotEqual(len(Shift.objects.filter(date=created_shift.date)), 0)
 
     def test_max_volunteer_field(self):
         event = ['event-name', '2017-08-21', '2017-09-28']

--- a/vms/administrator/tests/test_formFields.py
+++ b/vms/administrator/tests/test_formFields.py
@@ -1,5 +1,9 @@
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
+from pom.pages.eventsPage import EventsPage
+from pom.pages.authenticationPage import AuthenticationPage
+from pom.locators.eventsPageLocators import *
+
 from shift.utils import (
     create_admin,
     create_event_with_details,
@@ -22,38 +26,17 @@ class FormFields(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.homepage = '/'
-        cls.authentication_page = '/authentication/login/'
-        cls.event_list_page = '/event/list/'
-        cls.job_list_page = '/job/list/'
-        cls.shift_list_page = '/shift/list_jobs/'
-        cls.login_id = 'id_login'
-        cls.login_password = 'id_password'
-
-        cls.create_event_name ='//input[@placeholder = "Event Name"]'
-        cls.create_event_start_date = '//input[@name = "start_date"]'
-        cls.create_event_end_date = '//input[@name = "end_date"]'
-        cls.create_event_id = '//select[@name = "event_id"]'
-        cls.create_job_name = '//input[@placeholder = "Job Name"]'
-        cls.create_job_description = '//textarea[@name = "description"]'
-        cls.create_job_start_date = '//input[@name = "start_date"]'
-        cls.create_job_end_date = '//input[@name = "end_date"]'
-        cls.create_shift_date = '//input[@name = "date"]'
-        cls.create_shift_start_time = '//input[@name = "start_time"]'
-        cls.create_shift_end_time = '//input[@name = "end_time"]'
-        cls.create_shift_max_volunteer = '//input[@name = "max_volunteers"]'
-
-        cls.create_event_url = '/event/create/'
-
         cls.driver = webdriver.Firefox()
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
+        cls.settings = EventsPage(cls.driver)
+        cls.authentication_page = AuthenticationPage(cls.driver)
         super(FormFields, cls).setUpClass()
 
     def setUp(self):
         create_admin()
         self.login_admin()
-        self.go_to_events_page()
+        self.settings.go_to_events_page()
 
     def tearDown(self):
         pass
@@ -63,207 +46,67 @@ class FormFields(LiveServerTestCase):
         cls.driver.quit()
         super(FormFields, cls).tearDownClass()
 
-    def login(self, credentials):
-        self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id(self.login_id).send_keys(credentials['username'])
-        self.driver.find_element_by_id(self.login_password).send_keys(
-            credentials['password'])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
     def check_event_form_values(self, event):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@placeholder = "Event Name"]').get_attribute('value'),
-            event[0])
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "start_date"]').get_attribute('value'),
-            event[1])
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "end_date"]').get_attribute('value'),
-            event[2])
+        settings = self.settings
+        self.assertEqual(settings.get_event_name_value(),event[0])
+        self.assertEqual(settings.get_event_start_date_value(),event[1])
+        self.assertEqual(settings.get_event_end_date_value(),event[2])
 
     def check_job_form_values(self, job):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@placeholder = "Job Name"]').get_attribute('value'),
-            job[1])
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//textarea[@name = "description"]').get_attribute(
-            'value'), job[2])
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "start_date"]').get_attribute(
-            'value'), job[3])
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "end_date"]').get_attribute(
-            'value'), job[4])
+        settings = self.settings
+        self.assertEqual(settings.get_job_name_value(),job[1])
+        self.assertEqual(settings.get_job_description_value(), job[2])
+        self.assertEqual(settings.get_job_start_date_value(), job[3])
+        self.assertEqual(settings.get_job_end_date_value(), job[4])
 
     def check_shift_form_values(self, shift):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "date"]').get_attribute('value'), shift[0])
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "start_time"]').get_attribute('value'), shift[1])
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "end_time"]').get_attribute(
-            'value'), shift[2])
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//input[@name = "max_volunteers"]').get_attribute(
-            'value'), shift[3])
-
-    def navigate_to_event_list_view(self):
-        self.driver.get(self.live_server_url + self.event_list_page)
-
-    def navigate_to_job_list_view(self):
-        self.driver.get(self.live_server_url + self.job_list_page)
-
-    def navigate_to_shift_list_view(self):
-        self.driver.get(self.live_server_url + self.shift_list_page)
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]/td[5]//a').click()
-
-    def go_to_events_page(self):
-        self.driver.find_element_by_link_text('Events').send_keys("\n")
-
-    def go_to_create_event_page(self):
-        self.driver.find_element_by_link_text('Create Event').click()
-        self.assertEqual(self.driver.current_url,self.live_server_url +
-            '/event/create/')
-
-    def go_to_edit_event_page(self):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]').text, 'Edit')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]//a').click()
-
-    def go_to_create_job_page(self):
-        self.driver.get(self.live_server_url +'/job/create/')
-
-    def go_to_edit_job_page(self):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[6]').text, 'Edit')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[6]//a').click()
-
-    def go_to_create_shift_page(self):
-        self.driver.find_element_by_link_text('Create Shift').click()
-
-    def go_to_edit_shift_page(self):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]').text, 'Edit')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]//a').click()
+        settings = self.settings
+        self.assertEqual(settings.get_shift_date_value(), shift[0])
+        self.assertEqual(settings.get_shift_start_time_value(), shift[1])
+        self.assertEqual(settings.get_shift_end_time_value(), shift[2])
+        self.assertEqual(settings.get_shift_max_volunteers(), shift[3])
 
     def login_admin(self):
-        self.login({'username': 'admin', 'password': 'admin'})
-
-    def fill_event_form(self, event):
-        self.driver.find_element_by_xpath(
-            self.create_event_name).clear()
-        self.driver.find_element_by_xpath(
-            self.create_event_start_date).clear()
-        self.driver.find_element_by_xpath(
-            self.create_event_end_date).clear()
-        self.driver.find_element_by_xpath(
-            self.create_event_name).send_keys(
-            event[0])
-        self.driver.find_element_by_xpath(
-            self.create_event_start_date).send_keys(
-            event[1])
-        self.driver.find_element_by_xpath(
-            self.create_event_end_date).send_keys(
-            event[2])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def fill_job_form(self, job):
-        self.driver.find_element_by_xpath(
-            self.create_job_name).clear()
-        self.driver.find_element_by_xpath(
-            self.create_job_description).clear()
-        self.driver.find_element_by_xpath(
-            self.create_job_start_date).clear()
-        self.driver.find_element_by_xpath(
-            self.create_job_end_date).clear()
-
-        self.driver.find_element_by_xpath(
-            self.create_event_id).send_keys(
-            job[0])
-        self.driver.find_element_by_xpath(
-            self.create_job_name).send_keys(
-            job[1])
-        self.driver.find_element_by_xpath(
-            self.create_job_description).send_keys(
-            job[2])
-        self.driver.find_element_by_xpath(
-            self.create_job_start_date).send_keys(
-            job[3])
-        self.driver.find_element_by_xpath(
-            self.create_job_end_date).send_keys(
-            job[4])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def fill_shift_form(self, shift):
-        self.driver.find_element_by_xpath(
-            self.create_shift_date).clear()
-        self.driver.find_element_by_xpath(
-            self.create_shift_start_time).clear()
-        self.driver.find_element_by_xpath(
-            self.create_shift_end_time).clear()
-        self.driver.find_element_by_xpath(
-            self.create_shift_max_volunteer).clear()
-
-        self.driver.find_element_by_xpath(
-            self.create_shift_date).send_keys(
-            shift[0])
-        self.driver.find_element_by_xpath(
-            self.create_shift_start_time).send_keys(
-            shift[1])
-        self.driver.find_element_by_xpath(
-            self.create_shift_end_time).send_keys(
-            shift[2])
-        self.driver.find_element_by_xpath(
-            self.create_shift_max_volunteer).send_keys(
-            shift[3])
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        self.authentication_page.server_url = self.live_server_url
+        self.authentication_page.login({'username': 'admin', 'password': 'admin'})
 
     def test_null_values_in_create_event(self):
         event = ['', '', '']
-        self.go_to_create_event_page()
-        self.fill_event_form(event)
+        settings = self.settings
+        settings.go_to_create_event_page()
+        settings.fill_event_form(event)
 
         # check that event was not created and that error messages appear as
         # expected
         self.assertEqual(self.driver.current_url,self.live_server_url +
-            self.create_event_url)
-        self.assertEqual(
-            len(self.driver.find_elements_by_class_name('help-block')), 3)
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[1]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[2]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[3]/div/p/strong").text, 'This field is required.')
+            settings.create_event_page)
+        self.assertEqual(len(settings.get_help_blocks()), 3)
+        self.assertEqual(settings.get_event_name_error(), 'This field is required.')
+        self.assertEqual(settings.get_event_start_date_error(), 'This field is required.')
+        self.assertEqual(settings.get_event_end_date_error(), 'This field is required.')
 
     # Parts of test commented out, as they are throwing server error
     def test_null_values_in_edit_event(self):
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, created_event.name)
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
 
-        self.go_to_edit_event_page()
+        self.assertEqual(settings.get_event_name(), created_event.name)
+        settings.go_to_edit_event_page()
         edited_event = ['', '', '']
-        self.fill_event_form(edited_event)
+        settings.fill_event_form(edited_event)
 
         # check that event was not edited and that error messages appear as
         # expected
         self.assertNotEqual(self.driver.current_url,self.live_server_url +
-            self.event_list_page)
-        """self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),3)
+            settings.event_list_page)
+        """self.assertEqual(len(settings.get_help_blocks()),3)
 
-        self.assertEqual(self.driver.find_element_by_xpath("//form//div[1]/div/p/strong").text,
-                'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath("//form//div[2]/div/p/strong").text,
-                'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath("//form//div[3]/div/p/strong").text,
-                'This field is required.')"""
+        self.assertEqual(settings.get_event_name_error(),'This field is required.')
+        self.assertEqual(settings.get_event_start_date_error(),'This field is required.')
+        self.assertEqual(settings.get_event_end_date_error(),'This field is required.')"""
 
     def test_null_values_in_create_job(self):
 
@@ -273,22 +116,21 @@ class FormFields(LiveServerTestCase):
 
         # create job with null values
         job = [created_event.id, '', '', '', '']
-        self.go_to_create_job_page()
-        self.fill_job_form(job)
+
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.go_to_create_job_page()
+        settings.fill_job_form(job)
 
         # check that job was not created and that error messages appear as
         # expected
         self.assertEqual(self.driver.current_url,self.live_server_url +
-            '/job/create/')
-        self.assertEqual(
-            len(self.driver.find_elements_by_class_name('help-block')), 3)
+            settings.create_job_page)
+        self.assertEqual(len(settings.get_help_blocks()), 3)
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[3]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[5]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[6]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(settings.get_job_name_error(), 'This field is required.')
+        self.assertEqual(settings.get_job_start_date_error(), 'This field is required.')
+        self.assertEqual(settings.get_job_end_date_error(), 'This field is required.')
 
     def test_null_values_in_edit_job(self):
 
@@ -301,25 +143,23 @@ class FormFields(LiveServerTestCase):
         created_job = create_job_with_details(job)
 
         # verify the job was created and proceed to edit it
-        self.navigate_to_job_list_view()
-        self.go_to_edit_job_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_job_list_view()
+        settings.go_to_edit_job_page()
 
         # send null values to fields
-        self.fill_job_form([created_event.id,'','','',''])
+        settings.fill_job_form([created_event.id,'','','',''])
 
         # check that job was not edited and that error messages appear as
         # expected
         self.assertNotEqual(self.driver.current_url, 
-            self.live_server_url + '/job/list/')
-        self.assertEqual(
-            len(self.driver.find_elements_by_class_name('help-block')), 3)
+            self.live_server_url + settings.job_list_page)
+        self.assertEqual(len(settings.get_help_blocks()), 3)
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[3]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[5]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[6]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(settings.get_job_name_error(), 'This field is required.')
+        self.assertEqual(settings.get_job_start_date_error(), 'This field is required.')
+        self.assertEqual(settings.get_job_end_date_error(), 'This field is required.')
 
     def test_null_values_in_create_shift(self):
 
@@ -331,26 +171,23 @@ class FormFields(LiveServerTestCase):
         job = ['job', '2017-08-21', '2017-08-21', '',created_event]
         created_job = create_job_with_details(job)
 
-        self.navigate_to_shift_list_view()
-        self.go_to_create_shift_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_shift_list_view()
+        settings.go_to_create_shift_page()
 
         # create shift
         shift = ['', '', '', '']
-        self.fill_shift_form(shift)
+        settings.fill_shift_form(shift)
 
         # verify that shift was not created and error messages appear as
         # expected
-        self.assertEqual(
-            len(self.driver.find_elements_by_class_name('help-block')), 4)
+        self.assertEqual(len(settings.get_help_blocks()), 4)
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[4]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[5]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[6]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[7]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(settings.get_shift_date_error(), 'This field is required.')
+        self.assertEqual(settings.get_shift_start_time_error(), 'This field is required.')
+        self.assertEqual(settings.get_shift_end_time_error(), 'This field is required.')
+        self.assertEqual(settings.get_shift_max_volunteer_error(), 'This field is required.')
 
     def test_null_values_in_edit_shift(self):
         # register event to create job
@@ -365,38 +202,38 @@ class FormFields(LiveServerTestCase):
         shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
         created_shift = create_shift_with_details(shift)
 
-        self.navigate_to_shift_list_view()
-        self.go_to_edit_shift_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_shift_list_view()
+        settings.go_to_edit_shift_page()
 
         # edit shift with null values
         shift = ['', '', '', '']
-        self.fill_shift_form(shift)
+        settings.fill_shift_form(shift)
 
         # verify that shift was not edited and error messages appear as
         # expected
-        self.assertEqual(
-            len(self.driver.find_elements_by_class_name('help-block')), 4)
+        self.assertEqual(len(settings.get_help_blocks()), 4)
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[4]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[5]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[6]/div/p/strong").text, 'This field is required.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[7]/div/p/strong").text, 'This field is required.')
+        self.assertEqual(settings.get_shift_date_error(), 'This field is required.')
+        self.assertEqual(settings.get_shift_start_time_error(), 'This field is required.')
+        self.assertEqual(settings.get_shift_end_time_error(), 'This field is required.')
+        self.assertEqual(settings.get_shift_max_volunteer_error(), 'This field is required.')
 
     def test_field_value_retention_for_event(self):
-        self.navigate_to_event_list_view()
-        self.go_to_create_event_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_event_list_view()
+        settings.go_to_create_event_page()
 
         invalid_event = ['event-name!@', '07/21/2016', '09/28/2017']
-        self.fill_event_form(invalid_event)
+
+        settings.fill_event_form(invalid_event)
 
         # verify that event was not created and that field values are not
         # erased
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                         '/event/create/')
+            settings.create_event_page)
         self.check_event_form_values(invalid_event)
 
         # now create an event and edit it
@@ -404,18 +241,21 @@ class FormFields(LiveServerTestCase):
         # erased
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
-        self.navigate_to_event_list_view()
-        self.go_to_edit_event_page()
-        self.fill_event_form(invalid_event)
+        settings.navigate_to_event_list_view()
+        settings.go_to_edit_event_page()
+        settings.fill_event_form(invalid_event)
         self.assertNotEqual(self.driver.current_url, self.live_server_url +
-                            '/event/create/')
+            settings.create_event_page)
         # self.check_event_form_values(invalid_event)
 
     def test_field_value_retention_for_job(self):
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
-        self.navigate_to_job_list_view()
-        self.go_to_create_job_page()
+
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_job_list_view()
+        settings.go_to_create_job_page()
 
         invalid_job = [
             created_event.id,
@@ -423,12 +263,12 @@ class FormFields(LiveServerTestCase):
             'job description',
             '27/05/2016',
             '09/11/2017']
-        self.fill_job_form(invalid_job)
+        settings.fill_job_form(invalid_job)
 
         # verify that job was not created and that field values are not
         # erased
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                         '/job/create/')
+            settings.create_job_page)
         self.check_job_form_values(invalid_job)
 
         # now create job and edit it
@@ -436,14 +276,14 @@ class FormFields(LiveServerTestCase):
         # erased
         job = ['job', '2017-08-21', '2017-08-21', '',created_event]
         created_job = create_job_with_details(job)
-        self.navigate_to_job_list_view()
+        settings.navigate_to_job_list_view()
 
-        self.go_to_edit_job_page()
-        self.fill_job_form(invalid_job)
+        settings.go_to_edit_job_page()
+        settings.fill_job_form(invalid_job)
         # verify that job was not created and that field values are not
         # erased
         self.assertNotEqual(self.driver.current_url, self.live_server_url +
-                            self.job_list_page)
+                            settings.job_list_page)
         #self.check_job_form_values(invalid_job)
 
     def test_field_value_retention_for_shift(self):
@@ -452,11 +292,13 @@ class FormFields(LiveServerTestCase):
         job = ['job', '2017-08-21', '2017-08-21', '',created_event]
         created_job = create_job_with_details(job)
 
-        self.navigate_to_shift_list_view()
-        self.go_to_create_shift_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_shift_list_view()
+        settings.go_to_create_shift_page()
 
         invalid_shift = ['01/01/2016', '12:00', '11:00', '10']
-        self.fill_shift_form(invalid_shift)
+        settings.fill_shift_form(invalid_shift)
 
         # verify that shift was not created and that field values are not
         # erased
@@ -467,10 +309,10 @@ class FormFields(LiveServerTestCase):
         # erased
         shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
         created_shift = create_shift_with_details(shift)
-        self.navigate_to_shift_list_view()
-        self.go_to_edit_shift_page()
+        settings.navigate_to_shift_list_view()
+        settings.go_to_edit_shift_page()
 
-        self.fill_shift_form(invalid_shift)
+        settings.fill_shift_form(invalid_shift)
         # verify that shift was not created and that field values are not
         # erased
         # self.check_shift_form_values(invalid_shift)
@@ -481,28 +323,28 @@ class FormFields(LiveServerTestCase):
         job = ['job', '2017-08-21', '2017-08-21', '',created_event]
         created_job = create_job_with_details(job)
 
-        self.navigate_to_shift_list_view()
-        self.go_to_create_shift_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_shift_list_view()
+        settings.go_to_create_shift_page()
 
         invalid_shift = ['01/01/2016','12:00','11:00','0']
-        self.fill_shift_form(invalid_shift)
+        settings.fill_shift_form(invalid_shift)
 
         # verify that error message displayed
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[7]/div/p/strong").text,
+        self.assertEqual(settings.get_shift_max_volunteer_error(),
             'Ensure this value is greater than or equal to 1.')
 
         # Create shift and try editing it with 0 value
         shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
         created_shift = create_shift_with_details(shift)
 
-        self.navigate_to_shift_list_view()
-        self.go_to_edit_shift_page()
-        self.fill_shift_form(invalid_shift)
+        settings.navigate_to_shift_list_view()
+        settings.go_to_edit_shift_page()
+        settings.fill_shift_form(invalid_shift)
 
         # verify that error message displayed
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//form//div[7]/div/p/strong").text,
+        self.assertEqual(settings.get_shift_max_volunteer_error(),
             'Ensure this value is greater than or equal to 1.')
 
     def test_simplify_shift(self):
@@ -511,58 +353,50 @@ class FormFields(LiveServerTestCase):
         job = ['job', '2017-08-21', '2017-08-21', '',created_event]
         created_job = create_job_with_details(job)
 
-        self.navigate_to_shift_list_view()
-        self.go_to_create_shift_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_shift_list_view()
+        settings.go_to_create_shift_page()
 
         # verify that the correct job name and date are displayed
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//div[2]//div[1]/p").text, 'job')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//div[2]//div[2]/p").text, 'Aug. 21, 2017')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//div[2]//div[3]/p").text, 'Aug. 21, 2017')
+        self.assertEqual(settings.get_shift_job(), 'job')
+        self.assertEqual(settings.get_shift_job_start_date(), 'Aug. 21, 2017')
+        self.assertEqual(settings.get_shift_job_end_date(), 'Aug. 21, 2017')
 
         # Create shift and check job details in edit form
         shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
         created_shift = create_shift_with_details(shift)
-        self.navigate_to_shift_list_view()
-        self.go_to_edit_shift_page()
+        settings.navigate_to_shift_list_view()
+        settings.go_to_edit_shift_page()
 
         # verify that the correct job name and date are displayed
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//div[2]//div[1]/p").text, 'job')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//div[2]//div[2]/p").text, 'Aug. 21, 2017')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            "//div[2]//div[3]/p").text, 'Aug. 21, 2017')
+        self.assertEqual(settings.get_shift_job(), 'job')
+        self.assertEqual(settings.get_shift_job_start_date(), 'Aug. 21, 2017')
+        self.assertEqual(settings.get_shift_job_end_date(), 'Aug. 21, 2017')
 
     """def test_simplify_job(self):
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
 
-        self.navigate_to_job_list_view()
-        self.go_to_create_job_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_job_list_view()
+        settings.go_to_create_job_page()
 
         # verify that the correct event name and date are displayed
-        select = Select(self.driver.find_element_by_id(
-            'events'))
+        select = settings.get_job_event()
         select.select_by_visible_text('event')
-        self.assertEqual(self.driver.find_element_by_id(
-            'start_date_here').text, 'June 15, 2017')
-        self.assertEqual(self.driver.find_element_by_id(
-            'end_date_here').text, 'June 17, 2017')
+        self.assertEqual(settings.get_job_event_start_date(), 'June 15, 2017')
+        self.assertEqual(settings.get_job_event_end_date(), 'June 17, 2017')
 
         # Create job and check event details in edit form
         job_1 = self.register_job_utility(event_1)
-        self.navigate_to_job_list_view()
-        self.go_to_edit_job_page()
+        settings.navigate_to_job_list_view()
+        settings.go_to_edit_job_page()
 
         # verify that the correct event name and date are displayed
-        select = Select(self.driver.find_element_by_id(
-            'events'))
+        select = settings.get_job_event()
         select.select_by_visible_text('event')
-        self.assertEqual(self.driver.find_element_by_id(
-            'start_date_here').text, 'June 15, 2017')
-        self.assertEqual(self.driver.find_element_by_id(
-            'end_date_here').text, 'June 17, 2017')"""
+        self.assertEqual(settings.get_job_event_start_date(), 'June 15, 2017')
+        self.assertEqual(settings.get_job_event_end_date(), 'June 17, 2017')"""
     

--- a/vms/administrator/tests/test_formFields.py
+++ b/vms/administrator/tests/test_formFields.py
@@ -5,6 +5,8 @@ from pom.pages.authenticationPage import AuthenticationPage
 from pom.locators.eventsPageLocators import *
 
 from event.models import Event
+from job.models import Job
+from shift.models import Shift
 
 from shift.utils import (
     create_admin,
@@ -16,7 +18,6 @@ from shift.utils import (
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import Select
-
 
 class FormFields(LiveServerTestCase):
     '''
@@ -107,6 +108,7 @@ class FormFields(LiveServerTestCase):
         # expected
         self.assertNotEqual(self.driver.current_url,self.live_server_url +
             settings.event_list_page)
+
         """self.assertEqual(len(settings.get_help_blocks()),3)
 
         self.assertEqual(settings.get_event_name_error(),'This field is required.')
@@ -141,6 +143,9 @@ class FormFields(LiveServerTestCase):
         self.assertEqual(settings.get_job_start_date_error(), 'This field is required.')
         self.assertEqual(settings.get_job_end_date_error(), 'This field is required.')
 
+        # database check to ensure that job not created
+        self.assertEqual(len(Job.objects.all()), 0)
+
     def test_null_values_in_edit_job(self):
 
         # register event first to create job
@@ -169,6 +174,10 @@ class FormFields(LiveServerTestCase):
         self.assertEqual(settings.get_job_name_error(), 'This field is required.')
         self.assertEqual(settings.get_job_start_date_error(), 'This field is required.')
         self.assertEqual(settings.get_job_end_date_error(), 'This field is required.')
+
+        # database check to ensure that job not edited
+        self.assertEqual(len(Job.objects.all()), 1)
+        self.assertNotEqual(len(Job.objects.filter(name=created_job.name)), 0)
 
     def test_null_values_in_create_shift(self):
 
@@ -286,6 +295,9 @@ class FormFields(LiveServerTestCase):
             settings.create_job_page)
         self.check_job_form_values(invalid_job)
 
+        # database check to ensure that job not created
+        self.assertEqual(len(Job.objects.all()), 0)
+
         # now create job and edit it
         # verify that job was not edited and that field values are not
         # erased
@@ -300,6 +312,10 @@ class FormFields(LiveServerTestCase):
         self.assertNotEqual(self.driver.current_url, self.live_server_url +
                             settings.job_list_page)
         #self.check_job_form_values(invalid_job)
+
+        # database check to ensure that job not edited
+        self.assertEqual(len(Job.objects.all()), 1)
+        self.assertEqual(len(Job.objects.filter(name=invalid_job[0])), 0)
 
     def test_field_value_retention_for_shift(self):
         event = ['event-name', '2017-08-21', '2017-09-28']

--- a/vms/administrator/tests/test_formFields.py
+++ b/vms/administrator/tests/test_formFields.py
@@ -4,6 +4,8 @@ from pom.pages.eventsPage import EventsPage
 from pom.pages.authenticationPage import AuthenticationPage
 from pom.locators.eventsPageLocators import *
 
+from event.models import Event
+
 from shift.utils import (
     create_admin,
     create_event_with_details,
@@ -85,6 +87,9 @@ class FormFields(LiveServerTestCase):
         self.assertEqual(settings.get_event_start_date_error(), 'This field is required.')
         self.assertEqual(settings.get_event_end_date_error(), 'This field is required.')
 
+        # database check to ensure that event not created
+        self.assertEqual(len(Event.objects.all()), 0)
+
     # Parts of test commented out, as they are throwing server error
     def test_null_values_in_edit_event(self):
         event = ['event-name', '2017-08-21', '2017-09-28']
@@ -107,6 +112,10 @@ class FormFields(LiveServerTestCase):
         self.assertEqual(settings.get_event_name_error(),'This field is required.')
         self.assertEqual(settings.get_event_start_date_error(),'This field is required.')
         self.assertEqual(settings.get_event_end_date_error(),'This field is required.')"""
+
+        # database check to ensure that event not edited
+        self.assertEqual(len(Event.objects.all()), 1)
+        self.assertEqual(len(Event.objects.filter(name=edited_event[0])), 0)
 
     def test_null_values_in_create_job(self):
 
@@ -227,7 +236,6 @@ class FormFields(LiveServerTestCase):
         settings.go_to_create_event_page()
 
         invalid_event = ['event-name!@', '07/21/2016', '09/28/2017']
-
         settings.fill_event_form(invalid_event)
 
         # verify that event was not created and that field values are not
@@ -235,6 +243,9 @@ class FormFields(LiveServerTestCase):
         self.assertEqual(self.driver.current_url, self.live_server_url +
             settings.create_event_page)
         self.check_event_form_values(invalid_event)
+
+        # database check to ensure that event not created
+        self.assertEqual(len(Event.objects.all()), 0)
 
         # now create an event and edit it
         # verify that event was not edited and that field values are not
@@ -247,6 +258,10 @@ class FormFields(LiveServerTestCase):
         self.assertNotEqual(self.driver.current_url, self.live_server_url +
             settings.create_event_page)
         # self.check_event_form_values(invalid_event)
+
+        # database check to ensure that event not edited
+        self.assertEqual(len(Event.objects.all()), 1)
+        self.assertEqual(len(Event.objects.filter(name=invalid_event[0])), 0)
 
     def test_field_value_retention_for_job(self):
         event = ['event-name', '2017-08-21', '2017-09-28']

--- a/vms/administrator/tests/test_report.py
+++ b/vms/administrator/tests/test_report.py
@@ -1,7 +1,10 @@
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
 from django.db import IntegrityError
-from selenium.webdriver.support.ui import Select
+
+from pom.locators.administratorReportPageLocators import *
+from pom.pages.administratorReportPage import AdministratorReportPage
+from pom.pages.authenticationPage import AuthenticationPage
 
 from shift.utils import (
     create_admin,
@@ -24,19 +27,18 @@ class Report(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.homepage = '/'
-        cls.authentication_page = '/authentication/login/'
-        cls.report_page = '/administrator/report/'
-        cls.report_shift_summary_path = '//div[2]/div[4]'
-
         cls.driver = webdriver.Firefox()
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
+        cls.authentication_page = AuthenticationPage(cls.driver)
+        cls.report_page = AdministratorReportPage(cls.driver)
+        cls.elements = AdministratorReportPageLocators()
         super(Report, cls).setUpClass()
 
     def setUp(self):
         create_admin()
         self.login_admin()
+        self.report_page.go_to_admin_report()
 
     def tearDown(self):
         pass
@@ -47,56 +49,17 @@ class Report(LiveServerTestCase):
         super(Report, cls).tearDownClass()
 
     def login_admin(self):
-        self.login('admin', 'admin')
-
-    def login(self, username, password):
-        self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id('id_login').send_keys(username)
-        self.driver.find_element_by_id('id_password').send_keys(password)
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def logout(self):
-        self.driver.find_element_by_link_text('Log Out').click()
-
-    def go_to_admin_report(self):
-        self.driver.find_element_by_link_text('Report').click()
-
-    def fill_report_form(self, info):
-        self.driver.find_element_by_xpath(
-                '//input[@name = "first_name"]').clear()
-        self.driver.find_element_by_xpath(
-                '//input[@name = "last_name"]').clear()
-        [select1, select2, select3] = self.get_event_job_organization_selectors()
-
-        self.driver.find_element_by_xpath(
-                '//input[@name = "first_name"]').send_keys(info[0])
-        self.driver.find_element_by_xpath(
-                '//input[@name = "last_name"]').send_keys(info[1])
-
-        """select1.select_by_visible_text(info[2])
-        select2.select_by_visible_text(info[3])
-        select3.select_by_visible_text(info[4])"""
-
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def get_event_job_organization_selectors(self):
-        select1 = Select(self.driver.find_element_by_xpath('//select[@name = "event_name"]'))
-        select2 = Select(self.driver.find_element_by_xpath('//select[@name = "job_name"]'))
-        select3 = Select(self.driver.find_element_by_xpath('//select[@name = "organization"]'))
-        return (select1, select2, select3)
+        self.authentication_page.server_url = self.live_server_url
+        self.authentication_page.login({ 'username' : 'admin', 'password' : 'admin'})
 
     def verify_shift_details(self, total_shifts, hours):
-        total_no_of_shifts =  self.driver.find_element_by_xpath(
-                self.report_shift_summary_path).text.split(' ')[10].strip('\nTotal')
-
-        total_no_of_hours =  self.driver.find_element_by_xpath(
-                self.report_shift_summary_path).text.split(' ')[-1].strip('\n')
-        
+        total_no_of_shifts = self.report_page.get_shift_summary().split(' ')[10].strip('\nTotal')
+        total_no_of_hours = self.report_page.get_shift_summary().split(' ')[-1].strip('\n')
         self.assertEqual(total_no_of_shifts, total_shifts)
         self.assertEqual(total_no_of_hours, hours)
 
 #Failing test case which has been documented
-#Test commented out to prevent travis build failure
+#Test commented out to prevent travis build failure - bug #327
 
     """def test_null_values_with_dataset(self):
         # register dataset
@@ -120,28 +83,28 @@ class Report(LiveServerTestCase):
 
         logged_shift = log_hours_with_details(volunteer, created_shift, "09:00", "12:00")
 
+        report_page = self.report_page
+
         # check admin report with null fields, should return the above shift
-        self.driver.get(self.live_server_url + self.report_page)
-        self.fill_report_form(['','','','',''])
+        report_page.fill_report_form(['','','','',''])
         self.verify_shift_details('1','3.0')
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, created_event.name)
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[6]').text, 'Aug. 21, 2016')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[7]').text, '9 a.m.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[8]').text, '12 p.m.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[9]').text, '3.0')"""
+        self.assertEqual(report_page.element_by_xpath(
+            self.elements.NAME).text, created_event.name)
+        self.assertEqual(report_page.element_by_xpath(
+            self.elements.DATE).text, 'Aug. 21, 2016')
+        self.assertEqual(report_page.element_by_xpath(
+            self.elements.START_TIME).text, '9 a.m.')
+        self.assertEqual(report_page.element_by_xpath(
+            self.elements.END_TIME).text, '12 p.m.')
+        self.assertEqual(report_page.element_by_xpath(
+            self.elements.HOURS).text, '3.0')"""
 
     def test_null_values_with_empty_dataset(self):
         # should return no entries
-        self.go_to_admin_report()
-        self.fill_report_form(['','','','',''])
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-danger').text, 'Your criteria did not return any results.')
+        report_page = self.report_page
+        report_page.fill_report_form(['','','','',''])
+        self.assertEqual(report_page.get_alert_box_text(),report_page.no_results_message)
 
     def test_only_logged_shifts_are_reported(self):
         # register dataset
@@ -165,47 +128,45 @@ class Report(LiveServerTestCase):
         # shift is assigned to volunteer-one, but hours have not been logged
         volunteer_shift = register_volunteer_for_shift_utility(created_shift, volunteer)
 
+        report_page = self.report_page
         # check admin report with null fields, should not return the above shift
-        self.driver.get(self.live_server_url + self.report_page)
-        self.fill_report_form(['','','','',''])
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-danger').text, 'Your criteria did not return any results.')
+        report_page.fill_report_form(['','','','',''])
+        self.assertEqual(report_page.get_alert_box_text(),report_page.no_results_message)
 
-#Failing test case which has been documented
+#Failing test case which has been documented - bug #327
 #Test commented out to prevent travis build failure
 
     """def test_check_intersection_of_fields(self):
 
         self.create_dataset()
 
-        self.login_admin()
-        self.go_to_admin_report()
+        report_page = self.report_page
 
         search_parameters_1 = ['tom','','','','']
-        self.fill_report_form(search_parameters_1)
+        report_page.fill_report_form(search_parameters_1)
 
         self.verify_shift_details('2','2.0')
 
         search_parameters_2 = ['','','','','org-one']
-        self.fill_report_form(search_parameters_2)
+        report_page.fill_report_form(search_parameters_2)
 
         self.verify_shift_details('3','3.0')
 
         search_parameters_3 = ['','','event-four','Two','']
-        self.fill_report_form(search_parameters_3)
+        report_page.fill_report_form(search_parameters_3)
 
         # 1 shift of 1:30 hrs
         self.verify_shift_details('1','1.5')
 
         search_parameters_4 = ['','','one','','']
-        self.fill_report_form(search_parameters_4)
+        report_page.fill_report_form(search_parameters_4)
 
         # 3 shifts of 0:30 hrs, 1:00 hrs, 1:00 hrs
         self.verify_shift_details('3','2.5')
 
         # check case-insensitive
         search_parameters_5 = ['','sherlock','two','','']
-        self.fill_report_form(search_parameters_5)
+        report_page.fill_report_form(search_parameters_5)
 
         self.verify_shift_details('1','2.0')
 

--- a/vms/administrator/tests/test_settings.py
+++ b/vms/administrator/tests/test_settings.py
@@ -5,6 +5,9 @@ from pom.pages.authenticationPage import AuthenticationPage
 from pom.locators.eventsPageLocators import *
 
 from event.models import Event
+from job.models import Job
+from shift.models import Shift
+from organization.models import Organization
 
 from shift.utils import (
     create_admin,
@@ -382,7 +385,11 @@ class Settings(LiveServerTestCase):
         # check job created
         settings.navigate_to_job_list_view()
         self.assertEqual(settings.get_job_name(), 'job name')
-        self.assertEqual(settings.get_job_event(), created_event.name)"""
+        self.assertEqual(settings.get_job_event(), created_event.name)
+
+        # database check to ensure that correct job created
+        self.assertEqual(len(Job.objects.all()), 1)
+        self.assertNotEqual(len(Job.objects.filter(name=job[1])), 0)
 
     # - commented out due to bug - desirable feature not yet implemented
     """def test_duplicate_job(self):
@@ -406,12 +413,15 @@ class Settings(LiveServerTestCase):
         settings.go_to_create_job_page()
         settings.fill_job_form(job)
 
+        # database check to ensure that job not created
+        self.assertEqual(len(Job.objects.all()), 1)
+
         # TBA here - more checks depending on logic that should be reflected
         # check job not created - commented out due to bug
         self.assertNotEqual(self.driver.current_url,
                             self.live_server_url + settings.job_list_page)"""
 
-    """def test_edit_job(self):
+    def test_edit_job(self):
         # register event first to create job
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
@@ -434,6 +444,10 @@ class Settings(LiveServerTestCase):
                          self.live_server_url + settings.job_list_page)
         self.assertEqual(settings.get_job_name(), 'changed job name')
 
+        # database check to ensure that job edited correctly
+        self.assertEqual(len(Job.objects.all()), 1)
+        self.assertNotEqual(len(Job.objects.filter(name=edit_job[1])), 0)
+
     def test_create_job_with_invalid_event_date(self):
 
         # register event first to create job
@@ -454,6 +468,9 @@ class Settings(LiveServerTestCase):
             self.live_server_url + settings.job_list_page)
         self.assertEqual(settings.get_warning_context(), 'Job dates should lie within Event dates')
 
+        # database check to ensure that job not created
+        self.assertEqual(len(Job.objects.all()), 0)
+
         # create job with end date outside range
         job = [
             'event-name',
@@ -468,6 +485,9 @@ class Settings(LiveServerTestCase):
         self.assertNotEqual(self.driver.current_url,self.live_server_url +
             settings.job_list_page)
         self.assertEqual(settings.get_warning_context(), 'Job dates should lie within Event dates')
+
+        # database check to ensure that job not created
+        self.assertEqual(len(Job.objects.all()), 0)
 
     def test_edit_job_with_invalid_event_date(self):
 
@@ -496,6 +516,10 @@ class Settings(LiveServerTestCase):
         self.assertEqual(settings.get_warning_context(),
             'Job dates should lie within Event dates')
 
+        # database check to ensure that job not edited
+        self.assertEqual(len(Job.objects.all()), 1)
+        self.assertEqual(len(Job.objects.filter(name=invalid_job_one[1])), 0)
+
         invalid_job_two = ['event-name','changed job name','job description',
             '2017-09-14', '2017-12-31']
         settings.navigate_to_job_list_view()
@@ -507,6 +531,10 @@ class Settings(LiveServerTestCase):
             self.live_server_url +settings.job_list_page)
         self.assertEqual(settings.get_warning_context(),
             'Job dates should lie within Event dates')
+
+        # database check to ensure that job not edited
+        self.assertEqual(len(Job.objects.all()), 1)
+        self.assertEqual(len(Job.objects.filter(name=invalid_job_two[1])), 0)
 
     def test_edit_job_with_invalid_shift_date(self):
         # register event first to create job
@@ -538,6 +566,10 @@ class Settings(LiveServerTestCase):
             self.live_server_url +settings.job_list_page)
         self.assertEqual(settings.get_template_error_message(),
             'You cannot edit this job as 1 associated shift no longer lies within the new date range')
+
+        # database check to ensure that job not edited
+        self.assertEqual(len(Job.objects.all()), 1)
+        self.assertNotEqual(len(Job.objects.filter(name=created_job.name)), 0)
 
     def test_delete_job_without_associated_shift(self):
         # register event first to create job

--- a/vms/administrator/tests/test_settings.py
+++ b/vms/administrator/tests/test_settings.py
@@ -867,6 +867,10 @@ class Settings(LiveServerTestCase):
         settings.fill_organization_form('Org-name 92:4 CA')
         self.assertEqual(settings.get_org_name(), 'Org-name 92:4 CA')
 
+        # database check to ensure that organization is created
+        self.assertEqual(len(Organization.objects.all()), 1)
+        self.assertNotEqual(len(Organization.objects.filter(name='Org-name 92:4 CA')), 0)
+
     def test_replication_of_organization(self):
         settings = self.settings
         settings.live_server_url = self.live_server_url
@@ -882,6 +886,9 @@ class Settings(LiveServerTestCase):
 
         self.assertEqual(settings.get_help_block().text,
             'Organization with this Name already exists.')
+        
+        # database check to ensure that duplicate organization is created
+        self.assertEqual(len(Organization.objects.all()), 1)
 
     def test_edit_org(self):
         # create org
@@ -902,6 +909,10 @@ class Settings(LiveServerTestCase):
 
         self.assertTrue('changed-organization' in org_list)
 
+        # database check to ensure that organization is edited
+        self.assertEqual(len(Organization.objects.all()), 1)
+        self.assertNotEqual(len(Organization.objects.filter(name='changed-organization')), 0)
+
     def test_delete_org_without_associated_users(self):
         # create org
         org = create_organization()
@@ -915,6 +926,9 @@ class Settings(LiveServerTestCase):
         # check org deleted
         with self.assertRaises(NoSuchElementException):
             settings.element_by_xpath('//table//tbody//tr[1]')
+
+        # database check to ensure that organization is deleted
+        self.assertEqual(len(Organization.objects.all()), 0)
 
     def test_delete_org_with_associated_users(self):
         # create org
@@ -934,3 +948,7 @@ class Settings(LiveServerTestCase):
         self.assertNotEqual(settings.get_danger_message(), None)
         self.assertEqual(settings.get_template_error_message(),
             'You cannot delete an organization that users are currently associated with.')
+
+        # database check to ensure that organization is not deleted
+        self.assertEqual(len(Organization.objects.all()), 1)
+        self.assertNotEqual(len(Organization.objects.filter(name=org.name)), 0)

--- a/vms/administrator/tests/test_settings.py
+++ b/vms/administrator/tests/test_settings.py
@@ -341,6 +341,9 @@ class Settings(LiveServerTestCase):
         with self.assertRaises(NoSuchElementException):
             settings.get_results()
 
+        # database check to ensure that event is deleted
+        self.assertEqual(len(Event.objects.all()), 0)
+
     def test_delete_event_with_associated_job(self):
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
@@ -366,6 +369,10 @@ class Settings(LiveServerTestCase):
         # check event NOT deleted
         settings.navigate_to_event_list_view()
         self.assertEqual(settings.get_event_name(), 'event-name')
+
+        # database check to ensure that event is not deleted
+        self.assertEqual(len(Event.objects.all()), 1)
+        self.assertNotEqual(len(Event.objects.filter(name = created_event.name)), 0)
 
     def test_create_job(self):
 
@@ -595,6 +602,9 @@ class Settings(LiveServerTestCase):
         with self.assertRaises(NoSuchElementException):
             settings.get_results()
 
+        # database check to ensure that job is deleted
+        self.assertEqual(len(Job.objects.all()), 0)
+
     def test_delete_job_with_associated_shifts(self):
 
         # register event first to create job
@@ -623,6 +633,10 @@ class Settings(LiveServerTestCase):
         # check job NOT deleted
         settings.navigate_to_job_list_view()
         self.assertEqual(settings.get_job_name(), 'job')
+
+        # database check to ensure that job is not deleted
+        self.assertEqual(len(Job.objects.all()), 1)
+        self.assertNotEqual(len(Job.objects.filter(name = created_job.name)), 0)
 
     def test_create_shift(self):
         # register event first to create job
@@ -821,6 +835,9 @@ class Settings(LiveServerTestCase):
         self.assertEqual(settings.get_message_context(),
             'There are currently no shifts. Please create shifts first.')
 
+        # database check to ensure that shift is deleted
+        self.assertEqual(len(Shift.objects.all()), 0)
+
     def test_delete_shift_with_volunteer(self):
         # register event first to create job
         event = ['event-name', '2017-08-21', '2017-09-28']
@@ -849,6 +866,10 @@ class Settings(LiveServerTestCase):
         # check error message displayed and shift not deleted
         self.assertEqual(settings.get_template_error_message(),
             'You cannot delete a shift that a volunteer has signed up for.')
+
+        # database check to ensure that shift is not deleted
+        self.assertEqual(len(Shift.objects.all()), 1)
+        self.assertNotEqual(len(Shift.objects.filter(date = created_shift.date)), 0)
 
     def test_organization(self):
 

--- a/vms/administrator/tests/test_settings.py
+++ b/vms/administrator/tests/test_settings.py
@@ -648,6 +648,10 @@ class Settings(LiveServerTestCase):
         with self.assertRaises(NoSuchElementException):
             settings.get_help_block()
 
+        # database check to ensure that shift created with proper job
+        self.assertEqual(len(Shift.objects.all()), 1)
+        self.assertNotEqual(len(Shift.objects.filter(job=created_job)), 0)
+
     def test_create_shift_with_invalid_timings(self):
         # register event first to create job
         event = ['event-name', '2017-08-21', '2017-09-28']
@@ -670,6 +674,9 @@ class Settings(LiveServerTestCase):
         # verify that shift was not created and error message displayed
         self.assertEqual(settings.get_warning_context(),
             'Shift end time should be greater than start time')
+
+        # database check to ensure that shift is not created
+        self.assertEqual(len(Shift.objects.all()), 0)
 
     def test_edit_shift_with_invalid_timings(self):
         # register event first to create job
@@ -697,6 +704,10 @@ class Settings(LiveServerTestCase):
         self.assertEqual(settings.get_warning_context(),
             'Shift end time should be greater than start time')
 
+        # database check to ensure that shift was not edited
+        self.assertEqual(len(Shift.objects.all()), 1)
+        self.assertNotEqual(len(Shift.objects.filter(date=created_shift.date)), 0)
+
     def test_create_shift_with_invalid_date(self):
         # register event first to create job
         event = ['event-name', '2017-08-21', '2017-09-28']
@@ -719,6 +730,9 @@ class Settings(LiveServerTestCase):
         # verify that shift was not created and error message displayed
         self.assertEqual(settings.get_warning_context(),
             'Shift date should lie within Job dates')
+
+        # database check to ensure that shift was not created
+        self.assertEqual(len(Shift.objects.all()), 0)
 
     def test_edit_shift_with_invalid_date(self):
         # register event first to create job
@@ -746,6 +760,10 @@ class Settings(LiveServerTestCase):
         self.assertEqual(settings.get_warning_context(),
             'Shift date should lie within Job dates')
 
+        # database check to ensure that shift was not edited
+        self.assertEqual(len(Shift.objects.all()), 1)
+        self.assertNotEqual(len(Shift.objects.filter(date=created_shift.date)), 0)
+
     def test_edit_shift(self):
         # register event first to create job
         event = ['event-name', '2017-08-21', '2017-09-28']
@@ -764,7 +782,7 @@ class Settings(LiveServerTestCase):
         settings.navigate_to_shift_list_view()
         settings.go_to_edit_shift_page()
 
-        # edit shift with date not between job dates
+        # edit shift with date between job dates
         shift = ['08/25/2017', '10:00', '13:00', '2']
         settings.fill_shift_form(shift)
 
@@ -772,6 +790,10 @@ class Settings(LiveServerTestCase):
             settings.get_help_block()
 
         self.assertEqual(settings.get_shift_date(), 'Aug. 25, 2017')
+
+        # database check to ensure that shift was edited
+        self.assertEqual(len(Shift.objects.all()), 1)
+        self.assertEqual(len(Shift.objects.filter(date=created_shift.date)), 0)
 
     def test_delete_shift(self):
         # register event first to create job

--- a/vms/administrator/tests/test_settings.py
+++ b/vms/administrator/tests/test_settings.py
@@ -4,6 +4,8 @@ from pom.pages.eventsPage import EventsPage
 from pom.pages.authenticationPage import AuthenticationPage
 from pom.locators.eventsPageLocators import *
 
+from event.models import Event
+
 from shift.utils import (
     create_admin,
     create_event_with_details,
@@ -172,6 +174,10 @@ class Settings(LiveServerTestCase):
             self.live_server_url + settings.event_list_page)
         self.assertEqual(settings.get_event_name(), 'event-name')
 
+        # database check to see if correct event created
+        self.assertEqual(len(Event.objects.all()), 1)
+        self.assertNotEqual(len(Event.objects.filter(name=event[0])), 0)
+
     # - commented out due to bug - desirable feature not yet implemented
     """def test_duplicate_event(self):
         event = ['event-name', '2017-08-21', '2017-09-28']
@@ -186,8 +192,10 @@ class Settings(LiveServerTestCase):
         settings.go_to_create_event_page()
         settings.fill_event_form(event)
 
+        # database check to verify that event is not created
+        self.assertEqual(len(Event.objects.all()), 1)
+
         # TBA here - more checks depending on behaviour that should be reflected
-        # check event not created 
         self.assertNotEqual(self.driver.current_url,
                             self.live_server_url + settings.event_list_page)"""
 
@@ -211,12 +219,16 @@ class Settings(LiveServerTestCase):
                          self.live_server_url + settings.event_list_page)
         self.assertEqual(settings.get_event_name(), 'new-event-name')
 
+        # database check to see if event edited with correct details
+        self.assertEqual(len(Event.objects.all()), 1)
+        self.assertNotEqual(len(Event.objects.filter(name=edited_event[0])), 0)
+
     def test_create_and_edit_event_with_invalid_start_date(self):
         
         settings = self.settings
         settings.live_server_url = self.live_server_url
         settings.go_to_create_event_page()
-        invalid_event = ['event-name', '05/17/2016', '09/28/2016']
+        invalid_event = ['event-name-invalid', '05/17/2016', '09/28/2016']
         settings.fill_event_form(invalid_event)
 
         # check event not created and error message displayed
@@ -224,6 +236,9 @@ class Settings(LiveServerTestCase):
             self.live_server_url + settings.event_list_page)
         self.assertEqual(settings.get_warning_context(),
             "Start date should be today's date or later.")
+
+        # database check to see that no event created
+        self.assertEqual(len(Event.objects.all()), 0)
 
         settings.navigate_to_event_list_view()
         settings.go_to_create_event_page()
@@ -241,6 +256,10 @@ class Settings(LiveServerTestCase):
             self.live_server_url +settings.event_list_page)
         self.assertEqual(settings.get_warning_context(),
             "Start date should be today's date or later.")
+
+        # database check to ensure that event not edited
+        self.assertEqual(len(Event.objects.all()), 1)
+        self.assertEqual(len(Event.objects.filter(name=invalid_event[0])), 0)
 
     def test_edit_event_with_elapsed_start_date(self):
         elapsed_event = ['event-name', '2016-05-21', '2017-08-09']
@@ -267,6 +286,10 @@ class Settings(LiveServerTestCase):
 
         # Test for proper msg TBA later once it is implemented
 
+        # database check to ensure that event not edited
+        self.assertEqual(len(Event.objects.all()), 1)
+        self.assertNotEqual(len(Event.objects.filter(name=elapsed_event[0])), 0)
+
     def test_edit_event_with_invalid_job_date(self):
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
@@ -283,7 +306,7 @@ class Settings(LiveServerTestCase):
         settings.go_to_edit_event_page()
 
         # Edit event such that job is no longer in the new date range
-        new_event = ['event-name', '2017-08-30', '2017-09-21']
+        new_event = ['new-event-name', '2017-08-30', '2017-09-21']
         settings.fill_event_form(new_event)
 
         # check event not edited and error message displayed
@@ -292,6 +315,10 @@ class Settings(LiveServerTestCase):
         self.assertEqual(
             settings.element_by_xpath(self.elements.TEMPLATE_ERROR_MESSAGE).text,
             'You cannot edit this event as the following associated job no longer lies within the new date range :')
+
+        # database check to ensure that event not edited
+        self.assertEqual(len(Event.objects.all()), 1)
+        self.assertEqual(len(Event.objects.filter(name=new_event[0])), 0)
 
     def test_delete_event_with_no_associated_job(self):
         event = ['event-name', '2017-08-21', '2017-09-28']
@@ -355,7 +382,7 @@ class Settings(LiveServerTestCase):
         # check job created
         settings.navigate_to_job_list_view()
         self.assertEqual(settings.get_job_name(), 'job name')
-        self.assertEqual(settings.get_job_event(), created_event.name)
+        self.assertEqual(settings.get_job_event(), created_event.name)"""
 
     # - commented out due to bug - desirable feature not yet implemented
     """def test_duplicate_job(self):
@@ -384,7 +411,7 @@ class Settings(LiveServerTestCase):
         self.assertNotEqual(self.driver.current_url,
                             self.live_server_url + settings.job_list_page)"""
 
-    def test_edit_job(self):
+    """def test_edit_job(self):
         # register event first to create job
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)

--- a/vms/administrator/tests/test_settings.py
+++ b/vms/administrator/tests/test_settings.py
@@ -1,5 +1,9 @@
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
+from pom.pages.eventsPage import EventsPage
+from pom.pages.authenticationPage import AuthenticationPage
+from pom.locators.eventsPageLocators import *
+
 from shift.utils import (
     create_admin,
     create_event_with_details,
@@ -60,39 +64,18 @@ class Settings(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.homepage = '/'
-        cls.authentication_page = '/authentication/login/'
-        cls.event_list_page = '/event/list/'
-
-        cls.job_list_page = '/job/list/'
-        cls.shift_list_page = '/shift/list_jobs/'
-        cls.login_id = 'id_login'
-        cls.login_password = 'id_password'
-
-        cls.create_event_name ='//input[@placeholder = "Event Name"]'
-        cls.create_event_start_date = '//input[@name = "start_date"]'
-        cls.create_event_end_date = '//input[@name = "end_date"]'
-        cls.create_event_id = '//select[@name = "event_id"]'
-        cls.create_job_name = '//input[@placeholder = "Job Name"]'
-        cls.create_job_description = '//textarea[@name = "description"]'
-        cls.create_job_start_date = '//input[@name = "start_date"]'
-        cls.create_job_end_date = '//input[@name = "end_date"]'
-        cls.create_shift_date = '//input[@name = "date"]'
-        cls.create_shift_start_time = '//input[@name = "start_time"]'
-        cls.create_shift_end_time = '//input[@name = "end_time"]'
-        cls.create_shift_max_volunteer = '//input[@name = "max_volunteers"]'
-
-        cls.create_event_url = '/event/create/'
-
         cls.driver = webdriver.Firefox()
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
+        cls.settings = EventsPage(cls.driver)
+        cls.authentication_page = AuthenticationPage(cls.driver)
+        cls.elements = EventsPageLocators()
         super(Settings, cls).setUpClass()
 
     def setUp(self):
         create_admin()
         self.login_admin()
-        self.go_to_events_page()
+        self.settings.go_to_events_page()
 
     def tearDown(self):
         pass
@@ -103,295 +86,160 @@ class Settings(LiveServerTestCase):
         super(Settings, cls).tearDownClass()
 
     def login_admin(self):
-        self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id('id_login').send_keys('admin')
-        self.driver.find_element_by_id('id_password').send_keys('admin')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        self.authentication_page.server_url = self.live_server_url
+        self.authentication_page.login({'username' : 'admin', 'password' : 'admin'})
 
     def delete_event_from_list(self):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[6]').text, 'Delete')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[6]//a').click()
-        self.assertNotEqual(self.driver.find_element_by_class_name(
-            'panel-danger'), None)
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'panel-heading').text, 'Delete Event')
-        self.driver.find_element_by_xpath('//form').submit()
+        settings = self.settings
+        self.assertEqual(settings.element_by_xpath(
+            self.elements.DELETE_EVENT).text, 'Delete')
+        settings.element_by_xpath(
+            self.elements.DELETE_EVENT+'//a').click()
+        self.assertNotEqual(settings.get_deletion_box(), None)
+        self.assertEqual(settings.get_deletion_context(), 'Delete Event')
+        settings.submit_form()
 
     def delete_job_from_list(self):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[7]').text, 'Delete')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[7]//a').click()
+        settings = self.settings
+        self.assertEqual(settings.element_by_xpath(
+            self.elements.DELETE_JOB).text, 'Delete')
+        settings.element_by_xpath(
+            self.elements.DELETE_JOB+'//a').click()
 
-        self.assertNotEqual(self.driver.find_element_by_class_name(
-            'panel-danger'), None)
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'panel-heading').text, 'Delete Job')
-        self.driver.find_element_by_xpath('//form').submit()
+        self.assertNotEqual(settings.get_deletion_box(), None)
+        self.assertEqual(settings.get_deletion_context(), 'Delete Job')
+        settings.submit_form()
 
     def delete_shift_from_list(self):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[6]').text, 'Delete')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[6]//a').click()
+        settings = self.settings
+        self.assertEqual(settings.element_by_xpath(
+            self.elements.DELETE_SHIFT).text, 'Delete')
+        settings.element_by_xpath(
+            self.elements.DELETE_SHIFT+'//a').click()
 
         # confirm on delete
-        self.assertNotEqual(
-            self.driver.find_element_by_class_name('panel-danger'), None)
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'panel-heading').text, 'Delete Shift')
-        self.driver.find_element_by_xpath('//form').submit()
+        self.assertNotEqual(settings.get_deletion_box(), None)
+        self.assertEqual(settings.get_deletion_context(), 'Delete Shift')
+        settings.submit_form()
 
     def delete_organization_from_list(self):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[3]').text, 'Delete')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[3]//a').click()
+        settings = self.settings
+        self.assertEqual(settings.element_by_xpath(
+            self.elements.DELETE_ORG).text, 'Delete')
+        settings.element_by_xpath(
+            self.elements.DELETE_ORG+'//a').click()
 
         # confirm on delete
-        self.assertNotEqual(self.driver.find_element_by_class_name(
-            'panel-danger'), None)
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'panel-heading').text, 'Delete Organization')
-        self.driver.find_element_by_xpath('//form').submit()
-
-    def fill_event_form(self, event):
-        self.driver.find_element_by_xpath(
-            self.create_event_name).clear()
-        self.driver.find_element_by_xpath(
-            self.create_event_start_date).clear()
-        self.driver.find_element_by_xpath(
-            self.create_event_end_date).clear()
-        self.driver.find_element_by_xpath(
-            self.create_event_name).send_keys(
-            event[0])
-        self.driver.find_element_by_xpath(
-            self.create_event_start_date).send_keys(
-            event[1])
-        self.driver.find_element_by_xpath(
-            self.create_event_end_date).send_keys(
-            event[2])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def fill_job_form(self, job):
-        self.driver.find_element_by_xpath(
-            self.create_job_name).clear()
-        self.driver.find_element_by_xpath(
-            self.create_job_description).clear()
-        self.driver.find_element_by_xpath(
-            self.create_job_start_date).clear()
-        self.driver.find_element_by_xpath(
-            self.create_job_end_date).clear()
-
-        self.driver.find_element_by_xpath(
-            self.create_event_id).send_keys(
-            job[0])
-        self.driver.find_element_by_xpath(
-            self.create_job_name).send_keys(
-            job[1])
-        self.driver.find_element_by_xpath(
-            self.create_job_description).send_keys(
-            job[2])
-        self.driver.find_element_by_xpath(
-            self.create_job_start_date).send_keys(
-            job[3])
-        self.driver.find_element_by_xpath(
-            self.create_job_end_date).send_keys(
-            job[4])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def fill_shift_form(self, shift):
-        self.driver.find_element_by_xpath(
-            self.create_shift_date).clear()
-        self.driver.find_element_by_xpath(
-            self.create_shift_start_time).clear()
-        self.driver.find_element_by_xpath(
-            self.create_shift_end_time).clear()
-        self.driver.find_element_by_xpath(
-            self.create_shift_max_volunteer).clear()
-
-        self.driver.find_element_by_xpath(
-            self.create_shift_date).send_keys(
-            shift[0])
-        self.driver.find_element_by_xpath(
-            self.create_shift_start_time).send_keys(
-            shift[1])
-        self.driver.find_element_by_xpath(
-            self.create_shift_end_time).send_keys(
-            shift[2])
-        self.driver.find_element_by_xpath(
-            self.create_shift_max_volunteer).send_keys(
-            shift[3])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def fill_organization_form(self, org):
-        self.driver.find_element_by_xpath(
-            '//input[@name = "name"]').clear()
-        self.driver.find_element_by_xpath('//input[@name = "name"]').send_keys(
-            org)
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def go_to_events_page(self):
-        self.driver.find_element_by_link_text('Events').send_keys("\n")
-
-    def navigate_to_event_list_view(self):
-        self.driver.get(self.live_server_url + self.event_list_page)
-
-    def navigate_to_job_list_view(self):
-        self.driver.get(self.live_server_url + self.job_list_page)
-
-    def navigate_to_shift_list_view(self):
-        self.driver.get(self.live_server_url + self.shift_list_page)
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]/td[5]//a').click()
-
-    def navigate_to_organization_view(self):
-        self.driver.get(self.live_server_url +'/organization/list/')
-
-    def go_to_create_event_page(self):
-        self.driver.find_element_by_link_text('Create Event').click()
-        self.assertEqual(self.driver.current_url,self.live_server_url +
-            '/event/create/')
-
-    def go_to_edit_event_page(self):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]').text, 'Edit')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]//a').click()
-
-    def go_to_create_job_page(self):
-        self.driver.get(self.live_server_url +'/job/create/')
-
-    def go_to_edit_job_page(self):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[6]').text, 'Edit')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[6]//a').click()
-
-    def go_to_create_shift_page(self):
-        self.driver.find_element_by_link_text('Create Shift').click()
-
-    def go_to_edit_shift_page(self):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]').text, 'Edit')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[5]//a').click()
-
-    def go_to_create_organization_page(self):
-        self.driver.get(self.live_server_url + '/organization/create/')
+        self.assertNotEqual(settings.get_deletion_box(), None)
+        self.assertEqual(settings.get_deletion_context(), 'Delete Organization')
+        settings.submit_form()
 
     def test_event_tab(self):
-        self.assertNotEqual(
-            self.driver.find_element_by_link_text('Events'), None)
-        self.assertEqual(
-            self.driver.find_element_by_class_name('alert-success').text,
+        settings = self.settings
+        self.assertEqual(settings.get_message_context(),
             'There are currently no events. Please create events first.')
 
     def test_job_tab_and_create_job_without_event(self):
-        self.driver.find_element_by_link_text('Jobs').click()
+        settings = self.settings
+        settings.click_link(settings.jobs_tab)
         self.assertEqual(self.driver.current_url,
-                         self.live_server_url + '/job/list/')
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-success').text,
+                         self.live_server_url + settings.job_list_page)
+        self.assertEqual(settings.get_message_context(),
             'There are currently no jobs. Please create jobs first.')
 
-        self.driver.find_element_by_link_text('Create Job').click()
+        settings.click_link('Create Job')
         self.assertEqual(self.driver.current_url,
-                         self.live_server_url + '/job/create/')
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-success').text,
+                         self.live_server_url + settings.create_job_page)
+        self.assertEqual(settings.get_message_context(),
             'Please add events to associate with jobs first.')
 
     def test_shift_tab_and_create_shift_without_job(self):
-        self.driver.find_element_by_link_text('Shifts').click()
+        settings = self.settings
+        settings.click_link(settings.shift_tab)
         self.assertEqual(self.driver.current_url,
-                         self.live_server_url + '/shift/list_jobs/')
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-success').text,
+                         self.live_server_url + settings.shift_list_page)
+        self.assertEqual(settings.get_message_context(),
             'There are currently no jobs. Please create jobs first.')
 
     def test_create_event(self):
+        settings = self.settings
         event = ['event-name', '2017-08-21', '2017-09-28']
-        self.go_to_create_event_page()
-        self.fill_event_form(event)
+        settings.go_to_create_event_page()
+        settings.fill_event_form(event)
 
         # check event created
         self.assertEqual(self.driver.current_url,
-            self.live_server_url + self.event_list_page)
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'event-name')
+            self.live_server_url + settings.event_list_page)
+        self.assertEqual(settings.get_event_name(), 'event-name')
 
     # - commented out due to bug - desirable feature not yet implemented
     """def test_duplicate_event(self):
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
 
+        settings = self.settings
         # check event created
         self.assertEqual(self.driver.current_url,
-                         self.live_server_url + self.settings_page)
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'event-name')
+                         self.live_server_url + settings.event_list_page)
+        self.assertEqual(settings.get_event_name(), 'event-name')
 
-        self.go_to_create_event_page()
-        self.fill_event_form(event)
+        settings.go_to_create_event_page()
+        settings.fill_event_form(event)
 
         # TBA here - more checks depending on behaviour that should be reflected
         # check event not created 
         self.assertNotEqual(self.driver.current_url,
-                            self.live_server_url + self.settings_page)"""
+                            self.live_server_url + settings.event_list_page)"""
 
     def test_edit_event(self):
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
 
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+
         # create event
-        self.navigate_to_event_list_view()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, created_event.name)
+        settings.navigate_to_event_list_view()
+        self.assertEqual(settings.get_event_name(), created_event.name)
 
-        self.go_to_edit_event_page()
-
+        settings.go_to_edit_event_page()
         edited_event = ['new-event-name', '2017-09-21', '2017-09-28']
-        self.fill_event_form(edited_event)
+        settings.fill_event_form(edited_event)
 
         # check event edited
         self.assertEqual(self.driver.current_url,
-                         self.live_server_url + self.event_list_page)
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'new-event-name')
+                         self.live_server_url + settings.event_list_page)
+        self.assertEqual(settings.get_event_name(), 'new-event-name')
 
     def test_create_and_edit_event_with_invalid_start_date(self):
         
-        self.go_to_create_event_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.go_to_create_event_page()
         invalid_event = ['event-name', '05/17/2016', '09/28/2016']
-        self.fill_event_form(invalid_event)
+        settings.fill_event_form(invalid_event)
 
         # check event not created and error message displayed
         self.assertNotEqual(self.driver.current_url,
-            self.live_server_url + self.event_list_page)
-        self.assertEqual(
-            self.driver.find_element_by_class_name('messages').text,
+            self.live_server_url + settings.event_list_page)
+        self.assertEqual(settings.get_warning_context(),
             "Start date should be today's date or later.")
 
-        self.navigate_to_event_list_view()
-        self.go_to_create_event_page()
+        settings.navigate_to_event_list_view()
+        settings.go_to_create_event_page()
         valid_event = ['event-name', '2017-05-21', '2017-09-28']
         valid_event_created = create_event_with_details(valid_event)
 
-        self.navigate_to_event_list_view()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, valid_event_created.name)
+        settings.navigate_to_event_list_view()
+        self.assertEqual(settings.get_event_name(), valid_event_created.name)
 
-        self.go_to_edit_event_page()
-        self.fill_event_form(invalid_event)
+        settings.go_to_edit_event_page()
+        settings.fill_event_form(invalid_event)
 
         # check event not edited and error message displayed
         self.assertNotEqual(self.driver.current_url,
-            self.live_server_url +self.event_list_page)
-        self.assertEqual(
-            self.driver.find_element_by_class_name('messages').text,
+            self.live_server_url +settings.event_list_page)
+        self.assertEqual(settings.get_warning_context(),
             "Start date should be today's date or later.")
 
     def test_edit_event_with_elapsed_start_date(self):
@@ -400,24 +248,22 @@ class Settings(LiveServerTestCase):
         # Create an event with elapsed start date
         created_event = create_event_with_details(elapsed_event)
 
-        self.navigate_to_event_list_view()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, created_event.name)
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_event_list_view()
+        self.assertEqual(settings.get_event_name(), created_event.name)
 
-        self.go_to_edit_event_page()
+        settings.go_to_edit_event_page()
 
         # Try editing any one field - (event name in this case)
-        self.driver.find_element_by_xpath(
-            '//input[@placeholder = "Event Name"]').clear()
-        self.driver.find_element_by_xpath(
-            '//input[@placeholder = "Event Name"]').send_keys(
+        settings.element_by_xpath(self.elements.CREATE_EVENT_NAME).clear()
+        settings.send_value_to_xpath(self.elements.CREATE_EVENT_NAME,
             'changed-event-name')
-
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        settings.submit_form()
 
         # check event not edited
         self.assertNotEqual(self.driver.current_url,
-            self.live_server_url + self.event_list_page)
+            self.live_server_url + settings.event_list_page)
 
         # Test for proper msg TBA later once it is implemented
 
@@ -429,21 +275,22 @@ class Settings(LiveServerTestCase):
         job = ['job', '2017-08-21', '2017-08-21', '',created_event]
         created_job = create_job_with_details(job)
 
-        self.navigate_to_event_list_view()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_event_list_view()
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, created_event.name)
-        self.go_to_edit_event_page()
+        self.assertEqual(settings.get_event_name(), created_event.name)
+        settings.go_to_edit_event_page()
 
         # Edit event such that job is no longer in the new date range
         new_event = ['event-name', '2017-08-30', '2017-09-21']
-        self.fill_event_form(new_event)
+        settings.fill_event_form(new_event)
 
         # check event not edited and error message displayed
         self.assertNotEqual(self.driver.current_url,
-            self.live_server_url + self.event_list_page)
+            self.live_server_url + settings.event_list_page)
         self.assertEqual(
-            self.driver.find_element_by_xpath('//div[2]/div[3]/p').text,
+            settings.element_by_xpath(self.elements.TEMPLATE_ERROR_MESSAGE).text,
             'You cannot edit this event as the following associated job no longer lies within the new date range :')
 
     def test_delete_event_with_no_associated_job(self):
@@ -451,17 +298,18 @@ class Settings(LiveServerTestCase):
         created_event = create_event_with_details(event)
 
         # create event
-        self.navigate_to_event_list_view()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, created_event.name)
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_event_list_view()
+        self.assertEqual(settings.get_event_name(), created_event.name)
 
         self.delete_event_from_list()
 
         # check event deleted
         self.assertEqual(self.driver.current_url,
-                         self.live_server_url + self.event_list_page)
+                         self.live_server_url + settings.event_list_page)
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_xpath('//table//tbody')
+            settings.get_results()
 
     def test_delete_event_with_associated_job(self):
         event = ['event-name', '2017-08-21', '2017-09-28']
@@ -471,24 +319,23 @@ class Settings(LiveServerTestCase):
         job = ['job', '2017-08-21', '2017-08-21', '',created_event]
         created_job = create_job_with_details(job)
 
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+
         # check event created
-        self.navigate_to_event_list_view()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, created_event.name)
+        settings.navigate_to_event_list_view()
+        self.assertEqual(settings.get_event_name(), created_event.name)
 
         # delete event
         self.delete_event_from_list()
 
-        self.assertNotEqual(self.driver.find_element_by_class_name(
-            'alert-danger'), None)
-        self.assertEqual(
-            self.driver.find_element_by_xpath('//div[2]/div[3]/p').text,
+        self.assertNotEqual(settings.get_danger_message(), None)
+        self.assertEqual(settings.get_template_error_message(),
             'You cannot delete an event that a job is currently associated with.')
 
         # check event NOT deleted
-        self.driver.get(self.live_server_url + self.event_list_page)
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'event-name')
+        settings.navigate_to_event_list_view()
+        self.assertEqual(settings.get_event_name(), 'event-name')
 
     def test_create_job(self):
 
@@ -496,18 +343,19 @@ class Settings(LiveServerTestCase):
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
 
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+
         # create job
         job = ['event-name','job name','job description',
             '2017-08-21', '2017-08-28']
-        self.go_to_create_job_page()
-        self.fill_job_form(job)
+        settings.go_to_create_job_page()
+        settings.fill_job_form(job)
 
         # check job created
-        self.navigate_to_job_list_view()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'job name')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[2]').text, created_event.name)
+        settings.navigate_to_job_list_view()
+        self.assertEqual(settings.get_job_name(), 'job name')
+        self.assertEqual(settings.get_job_event(), created_event.name)
 
     # - commented out due to bug - desirable feature not yet implemented
     """def test_duplicate_job(self):
@@ -520,21 +368,21 @@ class Settings(LiveServerTestCase):
             '2017-08-21', '2017-08-28']
         create_job_with_details(job))
 
+        settings = self.settings
+
         # check job created
-        self.navigate_to_job_list_view()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'job name')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[2]').text, 'event-name')
+        settings.navigate_to_job_list_view(self.live_server_url)
+        self.assertEqual(settings.get_job_name(), 'job name')
+        self.assertEqual(settings.get_job_event(), 'event-name')
 
         # Create another job with same details within the same event
-        self.go_to_create_job_page()
-        self.fill_job_form(job)
+        settings.go_to_create_job_page()
+        settings.fill_job_form(job)
 
         # TBA here - more checks depending on logic that should be reflected
         # check job not created - commented out due to bug
         self.assertNotEqual(self.driver.current_url,
-                            self.live_server_url + '/job/list/')"""
+                            self.live_server_url + settings.job_list_page)"""
 
     def test_edit_job(self):
         # register event first to create job
@@ -545,38 +393,39 @@ class Settings(LiveServerTestCase):
         job = ['job', '2017-08-21', '2017-08-21', '',created_event]
         created_job = create_job_with_details(job)
 
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+
         edit_job = ['event-name','changed job name','job description',
             '2017-08-25', '2017-08-25']
-        self.navigate_to_job_list_view()
-        self.go_to_edit_job_page()
-        self.fill_job_form(edit_job)
+        settings.navigate_to_job_list_view()
+        settings.go_to_edit_job_page()
+        settings.fill_job_form(edit_job)
 
         # check job edited
         self.assertEqual(self.driver.current_url,
-                         self.live_server_url + '/job/list/')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'changed job name')
+                         self.live_server_url + settings.job_list_page)
+        self.assertEqual(settings.get_job_name(), 'changed job name')
 
     def test_create_job_with_invalid_event_date(self):
 
         # register event first to create job
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
 
         # create job with start date outside range
         job = ['event-name','job name',
             'job description','08/10/2017',
             '09/11/2017']
-        self.go_to_create_job_page()
-        self.fill_job_form(job)
+        settings.go_to_create_job_page()
+        settings.fill_job_form(job)
 
         # check job not created and proper error message displayed
         self.assertNotEqual(self.driver.current_url,
-            self.live_server_url + '/job/list/')
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'messages').text, 'Job dates should lie within Event dates')
-
-        self.navigate_to_event_list_view()
+            self.live_server_url + settings.job_list_page)
+        self.assertEqual(settings.get_warning_context(), 'Job dates should lie within Event dates')
 
         # create job with end date outside range
         job = [
@@ -585,14 +434,13 @@ class Settings(LiveServerTestCase):
             'job description',
             '08/30/2017',
             '09/11/2018']
-        self.go_to_create_job_page()
-        self.fill_job_form(job)
+        settings.go_to_create_job_page()
+        settings.fill_job_form(job)
 
         # check job not created and proper error message displayed
         self.assertNotEqual(self.driver.current_url,self.live_server_url +
-            '/job/list/')
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'messages').text, 'Job dates should lie within Event dates')
+            settings.job_list_page)
+        self.assertEqual(settings.get_warning_context(), 'Job dates should lie within Event dates')
 
     def test_edit_job_with_invalid_event_date(self):
 
@@ -607,28 +455,31 @@ class Settings(LiveServerTestCase):
         invalid_job_one = ['event-name','changed job name','job description',
             '2017-05-03', '2017-11-09']
 
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+
         # edit job with start date outside event start date
-        self.navigate_to_job_list_view()
-        self.go_to_edit_job_page()
-        self.fill_job_form(invalid_job_one)
+        settings.navigate_to_job_list_view()
+        settings.go_to_edit_job_page()
+        settings.fill_job_form(invalid_job_one)
 
         # check job not edited and proper error message displayed
         self.assertNotEqual(self.driver.current_url,
-            self.live_server_url +'/job/list/')
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'messages').text, 'Job dates should lie within Event dates')
+            self.live_server_url +settings.job_list_page)
+        self.assertEqual(settings.get_warning_context(),
+            'Job dates should lie within Event dates')
 
         invalid_job_two = ['event-name','changed job name','job description',
             '2017-09-14', '2017-12-31']
-        self.navigate_to_job_list_view()
-        self.go_to_edit_job_page()
-        self.fill_job_form(invalid_job_two)
+        settings.navigate_to_job_list_view()
+        settings.go_to_edit_job_page()
+        settings.fill_job_form(invalid_job_two)
 
         # check job not edited and proper error message displayed
         self.assertNotEqual(self.driver.current_url,
-            self.live_server_url +'/job/list/')
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'messages').text, 'Job dates should lie within Event dates')
+            self.live_server_url +settings.job_list_page)
+        self.assertEqual(settings.get_warning_context(),
+            'Job dates should lie within Event dates')
 
     def test_edit_job_with_invalid_shift_date(self):
         # register event first to create job
@@ -643,21 +494,22 @@ class Settings(LiveServerTestCase):
         shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
         created_shift = create_shift_with_details(shift)
 
-        self.navigate_to_job_list_view()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_job_list_view()
 
         invalid_job_one = ['event-name','changed job name','job description',
             '2017-09-01', '2017-09-11']
 
         # edit job with date range such that the shift start date no longer
         # falls in the range
-        self.go_to_edit_job_page()
-        self.fill_job_form(invalid_job_one)
+        settings.go_to_edit_job_page()
+        settings.fill_job_form(invalid_job_one)
 
         # check job not edited and proper error message displayed
         self.assertNotEqual(self.driver.current_url,
-            self.live_server_url +'/job/list/')
-        self.assertEqual(
-            self.driver.find_element_by_xpath('//div[2]/div[3]/p').text,
+            self.live_server_url +settings.job_list_page)
+        self.assertEqual(settings.get_template_error_message(),
             'You cannot edit this job as 1 associated shift no longer lies within the new date range')
 
     def test_delete_job_without_associated_shift(self):
@@ -669,21 +521,20 @@ class Settings(LiveServerTestCase):
         job = ['job', '2017-08-21', '2017-08-21', '',created_event]
         created_job = create_job_with_details(job)
 
-        # check job created
-        self.navigate_to_job_list_view()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'job')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[2]').text, 'event-name')
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_job_list_view()
+        self.assertEqual(settings.get_job_name(), 'job')
+        self.assertEqual(settings.get_job_event(), 'event-name')
 
         # delete job
         self.delete_job_from_list()
 
         # check event deleted
         self.assertEqual(self.driver.current_url,
-                         self.live_server_url + '/job/list/')
+                         self.live_server_url + settings.job_list_page)
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_xpath('//table//tbody')
+            settings.get_results()
 
     def test_delete_job_with_associated_shifts(self):
 
@@ -699,20 +550,20 @@ class Settings(LiveServerTestCase):
         shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
         created_shift = create_shift_with_details(shift)
 
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+
         # delete job
-        self.navigate_to_job_list_view()
+        settings.navigate_to_job_list_view()
         self.delete_job_from_list()
 
-        self.assertNotEqual(self.driver.find_element_by_class_name(
-            'alert-danger'), None)
-        self.assertEqual(
-            self.driver.find_element_by_xpath('//div[2]/div[3]/p').text,
+        self.assertNotEqual(settings.get_danger_message(), None)
+        self.assertEqual(settings.get_template_error_message(),
             'You cannot delete a job that a shift is currently associated with.')
 
         # check job NOT deleted
-        self.navigate_to_job_list_view()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'job')
+        settings.navigate_to_job_list_view()
+        self.assertEqual(settings.get_job_name(), 'job')
 
     def test_create_shift(self):
         # register event first to create job
@@ -723,38 +574,42 @@ class Settings(LiveServerTestCase):
         job = ['job', '2017-08-21', '2017-08-30', '',created_event]
         created_job = create_job_with_details(job)
 
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+
         # create shift
-        self.navigate_to_shift_list_view()
-        self.go_to_create_shift_page()
+        settings.navigate_to_shift_list_view()
+        settings.go_to_create_shift_page()
 
         shift = ['08/30/2017', '09:00', '12:00', '10']
-        self.fill_shift_form(shift)
+        settings.fill_shift_form(shift)
 
         # verify that shift was created
-        self.assertNotEqual(
-            self.driver.find_elements_by_xpath('//table//tbody'), None)
+        self.assertNotEqual(settings.get_results(), None)
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('help-block')
+            settings.get_help_block()
 
     def test_create_shift_with_invalid_timings(self):
         # register event first to create job
         event = ['event-name', '2017-08-21', '2017-09-28']
         created_event = create_event_with_details(event)
 
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+
         # create job
         job = ['job', '2017-08-21', '2017-08-30', '',created_event]
         created_job = create_job_with_details(job)
 
-        self.navigate_to_shift_list_view()
-        self.go_to_create_shift_page()
+        settings.navigate_to_shift_list_view()
+        settings.go_to_create_shift_page()
 
         # create shift where end hours is less than start hours
         shift = ['08/30/2017', '14:00', '12:00', '5']
-        self.fill_shift_form(shift)
+        settings.fill_shift_form(shift)
 
         # verify that shift was not created and error message displayed
-        self.assertEqual(
-            self.driver.find_element_by_class_name('messages').text,
+        self.assertEqual(settings.get_warning_context(),
             'Shift end time should be greater than start time')
 
     def test_edit_shift_with_invalid_timings(self):
@@ -770,16 +625,17 @@ class Settings(LiveServerTestCase):
         shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
         created_shift = create_shift_with_details(shift)
 
-        self.navigate_to_shift_list_view()
-        self.go_to_edit_shift_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_shift_list_view()
+        settings.go_to_edit_shift_page()
 
         # edit shift with end hours less than start hours
         invalid_shift = ['08/30/2017', '18:00', '13:00', '5']
-        self.fill_shift_form(invalid_shift)
+        settings.fill_shift_form(invalid_shift)
 
         # verify that shift was not edited and error message displayed
-        self.assertEqual(
-            self.driver.find_element_by_class_name('messages').text,
+        self.assertEqual(settings.get_warning_context(),
             'Shift end time should be greater than start time')
 
     def test_create_shift_with_invalid_date(self):
@@ -791,16 +647,19 @@ class Settings(LiveServerTestCase):
         job = ['job', '2017-08-21', '2017-08-30', '',created_event]
         created_job = create_job_with_details(job)
 
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+
         # create shift
-        self.navigate_to_shift_list_view()
-        self.go_to_create_shift_page()
+        settings.navigate_to_shift_list_view()
+        settings.go_to_create_shift_page()
 
         shift = ['06/30/2017', '14:00', '18:00', '5']
-        self.fill_shift_form(shift)
+        settings.fill_shift_form(shift)
 
         # verify that shift was not created and error message displayed
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'messages').text, 'Shift date should lie within Job dates')
+        self.assertEqual(settings.get_warning_context(),
+            'Shift date should lie within Job dates')
 
     def test_edit_shift_with_invalid_date(self):
         # register event first to create job
@@ -815,16 +674,18 @@ class Settings(LiveServerTestCase):
         shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
         created_shift = create_shift_with_details(shift)
 
-        self.navigate_to_shift_list_view()
-        self.go_to_edit_shift_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_shift_list_view()
+        settings.go_to_edit_shift_page()
 
         # edit shift with date not between job dates
         invalid_shift = ['02/05/2017', '04:00', '13:00', '2']
-        self.fill_shift_form(invalid_shift)
+        settings.fill_shift_form(invalid_shift)
 
         # verify that shift was not edited and error message displayed
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'messages').text, 'Shift date should lie within Job dates')
+        self.assertEqual(settings.get_warning_context(),
+            'Shift date should lie within Job dates')
 
     def test_edit_shift(self):
         # register event first to create job
@@ -839,18 +700,19 @@ class Settings(LiveServerTestCase):
         shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
         created_shift = create_shift_with_details(shift)
 
-        self.navigate_to_shift_list_view()
-        self.go_to_edit_shift_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_shift_list_view()
+        settings.go_to_edit_shift_page()
 
         # edit shift with date not between job dates
         shift = ['08/25/2017', '10:00', '13:00', '2']
-        self.fill_shift_form(shift)
+        settings.fill_shift_form(shift)
 
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('help-block')
+            settings.get_help_block()
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'Aug. 25, 2017')
+        self.assertEqual(settings.get_shift_date(), 'Aug. 25, 2017')
 
     def test_delete_shift(self):
         # register event first to create job
@@ -865,17 +727,17 @@ class Settings(LiveServerTestCase):
         shift = ['2017-08-21', '09:00', '12:00', '10', created_job]
         created_shift = create_shift_with_details(shift)
 
-        self.navigate_to_shift_list_view()
-        self.assertNotEqual(
-            self.driver.find_elements_by_xpath('//table//tbody'), None)
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_shift_list_view()
+        self.assertNotEqual(settings.get_results(), None)
 
         # delete shift
         self.delete_shift_from_list()
 
         # check deletion of shift
-        self.navigate_to_shift_list_view()
-        self.assertEqual(
-            self.driver.find_element_by_class_name('alert-success').text,
+        settings.navigate_to_shift_list_view()
+        self.assertEqual(settings.get_message_context(),
             'There are currently no shifts. Please create shifts first.')
 
     def test_delete_shift_with_volunteer(self):
@@ -896,82 +758,82 @@ class Settings(LiveServerTestCase):
         shift_volunteer = register_volunteer_for_shift_utility(
             created_shift, volunteer)
 
-        self.navigate_to_shift_list_view()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_shift_list_view()
 
         # delete shift
         self.delete_shift_from_list()
 
         # check error message displayed and shift not deleted
-        self.assertEqual(
-            self.driver.find_element_by_xpath("//div[2]/div[3]/p").text,
+        self.assertEqual(settings.get_template_error_message(),
             'You cannot delete a shift that a volunteer has signed up for.')
 
     def test_organization(self):
 
-        self.driver.find_element_by_link_text('Organizations').click()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.click_link(settings.organization_tab)
         self.assertEqual(self.driver.current_url,
-            self.live_server_url +'/organization/list/')
+            self.live_server_url +settings.organization_list_page)
 
-        self.driver.find_element_by_link_text('Create Organization').click()
+        settings.click_link('Create Organization')
         self.assertEqual(self.driver.current_url,
-            self.live_server_url +'/organization/create/')
+            self.live_server_url +settings.create_organization_page)
 
         # Test all valid characters for organization
         # [(A-Z)|(a-z)|(0-9)|(\s)|(\-)|(:)]
-        self.fill_organization_form('Org-name 92:4 CA')
-        # tr[2] since one dummy org already created in Setup, due to code-bug
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'Org-name 92:4 CA')
+        settings.fill_organization_form('Org-name 92:4 CA')
+        self.assertEqual(settings.get_org_name(), 'Org-name 92:4 CA')
 
     def test_replication_of_organization(self):
-        self.navigate_to_organization_view()
-        self.go_to_create_organization_page()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_organization_view()
+        settings.go_to_create_organization_page()
 
-        self.fill_organization_form('Organization')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text, 'Organization')
+        settings.fill_organization_form('Organization')
+        self.assertEqual(settings.get_org_name(), 'Organization')
 
         # Create same orgnization again
-        self.go_to_create_organization_page()
-        self.fill_organization_form('Organization')
+        settings.go_to_create_organization_page()
+        settings.fill_organization_form('Organization')
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//p[@class = "help-block"]').text,
+        self.assertEqual(settings.get_help_block().text,
             'Organization with this Name already exists.')
 
     def test_edit_org(self):
         # create org
         org = create_organization()
-        self.navigate_to_organization_view()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_organization_view()
 
         # edit org
-        self.assertEqual(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[2]').text, 'Edit')
-        self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[2]//a').click()
+        self.assertEqual(settings.element_by_xpath(self.elements.EDIT_ORG).text, 'Edit')
+        settings.element_by_xpath(self.elements.EDIT_ORG+'//a').click()
 
-        self.fill_organization_form('changed-organization')
+        settings.fill_organization_form('changed-organization')
 
         # check edited org
         org_list = []
-        org_list.append(self.driver.find_element_by_xpath(
-            '//table//tbody//tr[1]//td[1]').text)
+        org_list.append(settings.get_org_name())
 
         self.assertTrue('changed-organization' in org_list)
 
     def test_delete_org_without_associated_users(self):
         # create org
         org = create_organization()
-        self.navigate_to_organization_view()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_organization_view()
 
         # delete org
         self.delete_organization_from_list()
 
         # check org deleted
-        # There should only be one org entry in the table shown.
-        # One, because of dummy-org inserted in setUp and not zero
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_xpath('//table//tbody//tr[1]')
+            settings.element_by_xpath('//table//tbody//tr[1]')
 
     def test_delete_org_with_associated_users(self):
         # create org
@@ -982,12 +844,12 @@ class Settings(LiveServerTestCase):
         volunteer.save()
 
         # delete org
-        self.navigate_to_organization_view()
+        settings = self.settings
+        settings.live_server_url = self.live_server_url
+        settings.navigate_to_organization_view()
         self.delete_organization_from_list()
 
         # check org not deleted message received
-        self.assertNotEqual(self.driver.find_element_by_class_name(
-            'alert-danger'), None)
-        self.assertEqual(
-            self.driver.find_element_by_xpath('//div[2]/div[3]/p').text,
+        self.assertNotEqual(settings.get_danger_message(), None)
+        self.assertEqual(settings.get_template_error_message(),
             'You cannot delete an organization that users are currently associated with.')

--- a/vms/event/tests/test_shiftSignUp.py
+++ b/vms/event/tests/test_shiftSignUp.py
@@ -1,19 +1,21 @@
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
 from job.models import Job
-from shift.models import VolunteerShift
+
+from pom.pages.eventSignUpPage import EventSignUpPage
+from pom.pages.authenticationPage import AuthenticationPage
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
 from shift.utils import (
-    create_organization,
     create_volunteer,
     register_event_utility,
     register_job_utility,
     register_shift_utility,
     create_volunteer_with_details,
-    create_shift_with_details
+    create_shift_with_details,
+    register_volunteer_for_shift_utility
     )
 
 class ShiftSignUp(LiveServerTestCase):
@@ -21,26 +23,16 @@ class ShiftSignUp(LiveServerTestCase):
     '''
     @classmethod
     def setUpClass(cls):
-        cls.homepage = '/'
-        cls.authentication_page = '/authentication/login/'
-        cls.login_id = 'id_login'
-        cls.login_password = 'id_password'
-        cls.view_jobs_path = '//table//tbody//tr[1]//td[4]'
-        cls.view_shifts_path = '//table//tbody//tr[1]//td[4]'
-        cls.event_signup_path = '//table//tbody//tr[1]//td[4]'
-        cls.shift_job_path = '//table//tbody//tr[1]//td[1]'
-        cls.shift_date_path = '//table//tbody//tr[1]//td[2]'
-        cls.shift_stime_path = '//table//tbody//tr[1]//td[3]'
-        cls.shift_etime_path = '//table//tbody//tr[1]//td[4]'
-        cls.event_list = '//table//tbody//tr[1]//td[1]'
-
         cls.driver = webdriver.Firefox()
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
+        cls.sign_up_page = EventSignUpPage(cls.driver)
+        cls.authentication_page = AuthenticationPage(cls.driver)
         super(ShiftSignUp, cls).setUpClass()
 
     def setUp(self):
         create_volunteer()
+        self.login_volunteer()
 
     def tearDown(self):
         pass
@@ -50,41 +42,14 @@ class ShiftSignUp(LiveServerTestCase):
         cls.driver.quit()
         super(ShiftSignUp, cls).tearDownClass()
 
-    def click_to_view_jobs(self):
-        self.driver.find_element_by_xpath(
-                self.view_jobs_path + "//a").click()
-
-    def click_to_view_shifts(self):
-        self.driver.find_element_by_xpath(
-                self.view_shifts_path + "//a").click()
-
-    def click_to_sign_up(self):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.event_signup_path).text, 'Sign Up')
-        self.driver.find_element_by_xpath(
-            self.event_signup_path + "//a").click()
-
-    def login(self, credentials):
-        self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id(self.login_id).send_keys(credentials['username'])
-        self.driver.find_element_by_id(self.login_password).send_keys(credentials['password'])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def login_volunteer_and_navigate_to_sign_up(self):
-        self.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
-        self.driver.find_element_by_link_text('Shift Sign Up').click()
-
-    def fill_search_form(self, date):
-        self.driver.find_element_by_id('from').clear()
-        self.driver.find_element_by_id('to').clear()
-        self.driver.find_element_by_id('from').send_keys(date[0])
-        self.driver.find_element_by_id('to').send_keys(date[1])
-        self.driver.find_element_by_xpath('//form[1]').submit()
+    def login_volunteer(self):
+        self.authentication_page.server_url = self.live_server_url
+        self.authentication_page.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
 
     def test_events_page_with_no_events(self):
-        self.login_volunteer_and_navigate_to_sign_up()
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
-               'There are no events.')
+        sign_up_page = self.sign_up_page
+        sign_up_page.navigate_to_sign_up()
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
 
     def test_signup_shifts_with_registered_shifts(self):
 
@@ -92,39 +57,31 @@ class ShiftSignUp(LiveServerTestCase):
         register_job_utility()
         register_shift_utility()
 
-        # login and open Shift Sign Up
-        self.login_volunteer_and_navigate_to_sign_up()
+        sign_up_page = self.sign_up_page
+
+        # open Shift Sign Up
+        sign_up_page.navigate_to_sign_up()
 
         # on event page
-        self.click_to_view_jobs()
+        sign_up_page.click_to_view_jobs()
 
         # on jobs page
-        self.click_to_view_shifts()
+        sign_up_page.click_to_view_shifts()
 
         # on shifts page
-        self.click_to_sign_up()
+        sign_up_page.click_to_sign_up()
 
         # confirm shift assignment
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        sign_up_page.submit_form()
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-danger')
+            sign_up_page.get_danger_box()
 
         # check shift signed up
-        self.assertEqual(self.driver.find_element_by_xpath(
-            'html/body/div[2]/h3').text,
-            'Upcoming Shifts')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_job_path).text,
-            'job')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_date_path).text,
-            'June 15, 2017')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_stime_path).text,
-            '9 a.m.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_etime_path).text,
-            '3 p.m.')
+        self.assertEqual(sign_up_page.get_signed_up_shift_text(),'Upcoming Shifts')
+        self.assertEqual(sign_up_page.get_shift_job(),'job')
+        self.assertEqual(sign_up_page.get_shift_date(),'June 15, 2017')
+        self.assertEqual(sign_up_page.get_shift_start_time(),'9 a.m.')
+        self.assertEqual(sign_up_page.get_shift_end_time(),'3 p.m.')
 
     def test_signup_for_same_shift_again(self):
 
@@ -132,81 +89,83 @@ class ShiftSignUp(LiveServerTestCase):
         register_job_utility()
         register_shift_utility()
 
-        # login and open Shift Sign Up
-        self.login_volunteer_and_navigate_to_sign_up()
+        sign_up_page = self.sign_up_page
+        # open Shift Sign Up
+        sign_up_page.navigate_to_sign_up()
 
         # events shown in table
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-info')
-        self.click_to_view_jobs()
+            sign_up_page.get_info_box()
+        sign_up_page.click_to_view_jobs()
 
         # on jobs page
-        self.click_to_view_shifts()
+        sign_up_page.click_to_view_shifts()
 
         # on shifts page, Sign up this shift !
-        self.click_to_sign_up()
+        sign_up_page.click_to_sign_up()
 
         # confirm on shift sign up
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        sign_up_page.submit_form()
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-danger')
+            sign_up_page.get_danger_box()
 
         # sign up same shift again
         # open Shift Sign Up
-        self.driver.find_element_by_link_text('Shift Sign Up').click()
+        sign_up_page.navigate_to_sign_up()
 
         # events page
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
-               'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
+
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_tag_name('table')
-            self.assertEqual(self.driver.find_element_by_xpath(
-            self.view_jobs_path).text, 'View Jobs')
+            sign_up_page.find_table_tag()
 
     def test_empty_events(self):
         
         register_event_utility()
-        self.login_volunteer_and_navigate_to_sign_up()
+        sign_up_page = self.sign_up_page
+        # open Shift Sign Up
+        sign_up_page.navigate_to_sign_up()
 
         # on event page
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
-               'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
+
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_tag_name('table')
-            self.click_to_view_jobs()
+            sign_up_page.find_table_tag()
+            sign_up_page.click_to_view_jobs()
 
         register_job_utility()
 
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
-               'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
+
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_tag_name('table')
-            self.assertEqual(self.driver.find_element_by_xpath(
-            self.view_jobs_path).text, 'View Jobs')
+            sign_up_page.find_table_tag()
 
     def test_shift_sign_up_with_outdated_shifts(self):
 
         register_event_utility()
         register_job_utility()
+        sign_up_page = self.sign_up_page
 
         # create outdated shift
         shift_1 = ["2016-05-11","9:00","15:00",6,Job.objects.get(name = 'job')]
         s1 = create_shift_with_details(shift_1)
 
         # open Shift Sign Up
-        self.login_volunteer_and_navigate_to_sign_up()
+        sign_up_page.navigate_to_sign_up()
 
         # on event page
-        self.click_to_view_jobs()
+        sign_up_page.click_to_view_jobs()
 
         # on jobs page
-        self.click_to_view_shifts()
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are currently no shifts for the job job.')
+        sign_up_page.click_to_view_shifts()
+        self.assertEqual(sign_up_page.get_info_box().text,'There are currently no shifts for the job job.')
 
     def test_shift_sign_up_with_no_slots(self):
 
         register_event_utility()
         register_job_utility()
+
+        sign_up_page = self.sign_up_page
 
         # create shift with no slot
         shift_2 = ["2016-05-11","9:00","15:00",1,Job.objects.get(name = 'job')]
@@ -217,15 +176,13 @@ class ShiftSignUp(LiveServerTestCase):
         v2 = create_volunteer_with_details(volunteer_2)
 
         # Assign shift to the volunteer
-        VolunteerShift.objects.create(
-                shift = s2,
-                volunteer = v2)
+        vol_shift = register_volunteer_for_shift_utility(s2, v2)
 
-        # Login as volunteer 1 and open Shift Sign Up
-        self.login_volunteer_and_navigate_to_sign_up()
+        # open Shift Sign Up
+        sign_up_page.navigate_to_sign_up()
 
         # on event page
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
 
     def test_search_event(self):
 
@@ -233,41 +190,43 @@ class ShiftSignUp(LiveServerTestCase):
         register_job_utility()
         register_shift_utility()
 
-        # Login as volunteer 1 and open Shift Sign Up
-        self.login_volunteer_and_navigate_to_sign_up()
+        sign_up_page = self.sign_up_page
+
+        # open Shift Sign Up
+        sign_up_page.navigate_to_sign_up()
 
         # enter date range in which an event starts
         date = ['05/08/2016', '08/31/2017']
-        self.fill_search_form(date)
+        sign_up_page.fill_search_form(date)
         # verify that the event shows up
-        self.assertEqual(self.driver.find_element_by_xpath(self.event_list).text, 'event')
+        self.assertEqual(sign_up_page.get_event_name(), 'event')
 
         # enter date range in which no event starts
         date = ['10/08/2016', '08/31/2017']
-        self.fill_search_form(date)
+        sign_up_page.fill_search_form(date)
         # verify that no event shows up on event page
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
 
         """# enter only incorrect starting date
         date = ['10/08/2016', '']
-        self.fill_search_form(date)
+        sign_up_page.fill_search_form(date)
         # verify that no event shows up on event page
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
 
         # enter only correct starting date
         date = ['05/10/2016', '']
-        self.fill_search_form(date)
+        sign_up_page.fill_search_form(date)
         # verify that the event shows up
-        self.assertEqual(self.driver.find_element_by_xpath(self.event_list).text, 'event')
+        self.assertEqual(sign_up_page.get_event_name() 'event')
 
         # enter only incorrect ending date
         date = ['', '10/08/2015']
-        self.fill_search_form(date)
+        sign_up_page.fill_search_form(date)
         # verify that no event shows up on event page
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
 
         # enter correct ending date
         date = ['', '06/15/2017']
-        self.fill_search_form(date)
+        sign_up_page.fill_search_form(date)
         # verify that the event shows up
-        self.assertEqual(self.driver.find_element_by_xpath(self.event_list).text, 'event')"""
+        self.assertEqual(sign_up_page.get_event_name(), 'event')"""

--- a/vms/event/tests/test_shiftSignUp.py
+++ b/vms/event/tests/test_shiftSignUp.py
@@ -1,6 +1,7 @@
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
 from job.models import Job
+from shift.models import VolunteerShift
 
 from pom.pages.eventSignUpPage import EventSignUpPage
 from pom.pages.authenticationPage import AuthenticationPage
@@ -31,7 +32,7 @@ class ShiftSignUp(LiveServerTestCase):
         super(ShiftSignUp, cls).setUpClass()
 
     def setUp(self):
-        create_volunteer()
+        self.volunteer = create_volunteer()
         self.login_volunteer()
 
     def tearDown(self):
@@ -53,9 +54,9 @@ class ShiftSignUp(LiveServerTestCase):
 
     def test_signup_shifts_with_registered_shifts(self):
 
-        register_event_utility()
-        register_job_utility()
-        register_shift_utility()
+        created_event = register_event_utility()
+        created_job = register_job_utility()
+        created_shift = register_shift_utility()
 
         sign_up_page = self.sign_up_page
 
@@ -83,7 +84,12 @@ class ShiftSignUp(LiveServerTestCase):
         self.assertEqual(sign_up_page.get_shift_start_time(),'9 a.m.')
         self.assertEqual(sign_up_page.get_shift_end_time(),'3 p.m.')
 
-    def test_signup_for_same_shift_again(self):
+        # database check to ensure volunteer has signed up for the shift
+        self.assertEqual(len(VolunteerShift.objects.all()), 1)
+        self.assertNotEqual(len(VolunteerShift.objects.filter(
+            volunteer_id=self.volunteer.id, shift_id = created_shift.id)), 0)
+
+    """def test_signup_for_same_shift_again(self):
 
         register_event_utility()
         register_job_utility()
@@ -207,7 +213,8 @@ class ShiftSignUp(LiveServerTestCase):
         # verify that no event shows up on event page
         self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
 
-        """# enter only incorrect starting date
+        # comm
+        # enter only incorrect starting date
         date = ['10/08/2016', '']
         sign_up_page.fill_search_form(date)
         # verify that no event shows up on event page

--- a/vms/job/tests/test_jobDetails.py
+++ b/vms/job/tests/test_jobDetails.py
@@ -1,5 +1,8 @@
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
+from pom.pages.jobDetailsPage import JobDetailsPage
+from pom.pages.authenticationPage import AuthenticationPage
+
 from shift.utils import (
     create_admin,
     create_event_with_details,
@@ -15,56 +18,39 @@ class JobDetails(LiveServerTestCase):
     '''
     def setUp(self):
         create_admin()
-        self.homepage = '/'
-        self.authentication_page = '/authentication/login/'
         self.job_list_page = '/job/list/'
-        self.job_name_path = '//table[1]//tr//td[1]'
-        self.job_event_path = '//table[1]//tr//td[2]'
-        self.job_start_date_path = '//table[1]//tr//td[3]'
-        self.job_end_date_path = '//table[1]//tr//td[4]'
 
         self.driver = webdriver.Firefox()
         self.driver.implicitly_wait(5)
         self.driver.maximize_window()
         super(JobDetails, self).setUp()
+        self.job_details_page = JobDetailsPage(self.driver)
+        self.authentication_page = AuthenticationPage(self.driver)
 
     def tearDown(self):
         self.driver.quit()
         super(JobDetails, self).tearDown()
 
-    def login(self, credentials):
-        self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id(
-            'id_login').send_keys(credentials['username'])
-        self.driver.find_element_by_id(
-            'id_password').send_keys(credentials['password'])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
     def register_job(self):
-
         # create shift and log hours
         created_event = create_event_with_details(['event', '2017-06-15', '2017-06-17'])
         created_job = create_job_with_details(['job', '2017-06-15', '2017-06-18', '', created_event])
-
         return created_job
 
     def login_admin(self):
-        self.login({'username': 'admin', 'password': 'admin'})
-
-    def navigate_to_job_details_view(self):
-        self.driver.get(self.live_server_url + self.job_list_page)
+        authentication_page = self.authentication_page
+        authentication_page.server_url = self.live_server_url
+        authentication_page.login({'username': 'admin', 'password': 'admin'})
 
     def test_job_details_view(self):
         self.login_admin()
         job = self.register_job()
-        self.navigate_to_job_details_view()
+        job_details_page = self.job_details_page
+        job_details_page.live_server_url = self.live_server_url
+        job_details_page.navigate_to_job_details_view()
 
         # verify details
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.job_name_path).text, job.name)
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.job_start_date_path).text, 'June 15, 2017')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.job_end_date_path).text, 'June 18, 2017')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.job_event_path).text, job.event.name)
+        self.assertEqual(job_details_page.get_name(), job.name)
+        self.assertEqual(job_details_page.get_start_date(), 'June 15, 2017')
+        self.assertEqual(job_details_page.get_end_date(), 'June 18, 2017')
+        self.assertEqual(job_details_page.get_event_name(), job.event.name)

--- a/vms/pom/admin.py
+++ b/vms/pom/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/vms/pom/locators/adminRegistrationPageLocators.py
+++ b/vms/pom/locators/adminRegistrationPageLocators.py
@@ -1,0 +1,29 @@
+
+class AdminRegistrationPageLocators(object):
+
+	USERNAME = 'id_username'
+	PASSWORD = 'id_password'
+	FIRST_NAME = 'id_first_name'
+	LAST_NAME = 'id_last_name'
+	EMAIL = 'id_email'
+	ADDRESS = 'id_address'
+	CITY = 'id_city'
+	STATE = 'id_state'
+	COUNTRY = 'id_country'
+	PHONE = 'id_phone_number'
+	ORGANIZATION = 'id_unlisted_organization'
+
+	USERNAME_ERROR = "id('div_id_username')/div/p/strong"
+	FIRST_NAME_ERROR = "id('div_id_first_name')/div/p/strong"
+	LAST_NAME_ERROR = "id('div_id_last_name')/div/p/strong"
+	EMAIL_ERROR = "id('div_id_email')/div/p/strong"
+	ADDRESS_ERROR = "id('div_id_address')/div/p/strong"
+	CITY_ERROR = "id('div_id_city')/div/p/strong"
+	STATE_ERROR = "id('div_id_state')/div/p/strong"
+	COUNTRY_ERROR = "id('div_id_country')/div/p/strong"
+	PHONE_ERROR = "id('div_id_phone_number')/div/p/strong"
+	ORGANIZATION_ERROR = "id('div_id_unlisted_organization')/div/p/strong"
+
+	HELP_BLOCK = 'help-block'
+	MESSAGES = 'messages'
+	SUBMIT_PATH = '//form[1]'

--- a/vms/pom/locators/administratorReportPageLocators.py
+++ b/vms/pom/locators/administratorReportPageLocators.py
@@ -1,0 +1,20 @@
+
+class AdministratorReportPageLocators(object):
+
+	REPORT_SHIFT_SUMMARY_PATH = '//div[2]/div[4]'
+	REPORT_START_DATE = '//input[@name = "start_date"]'
+	REPORT_END_DATE = '//input[@name = "end_date"]'
+	REPORT_EVENT_SELECTOR = '//select[@name = "event_name"]'
+	REPORT_JOB_SELECTOR = '//select[@name = "job_name"]'
+	REPORT_ORG_SELECTOR = '//select[@name = "organization"]'
+	FIRST_NAME_SELECTOR = '//input[@name = "first_name"]'
+	LAST_NAME_SELECTOR = '//input[@name = "last_name"]'
+
+	NAME = '//table//tbody//tr[1]//td[1]'
+	DATE = '//table//tbody//tr[1]//td[6]'
+	START_TIME = '//table//tbody//tr[1]//td[7]'
+	END_TIME = '//table//tbody//tr[1]//td[8]'
+	HOURS = '//table//tbody//tr[1]//td[9]'
+
+	SUBMIT_PATH = '//form[1]'
+	NO_RESULT_BOX = 'alert-danger'

--- a/vms/pom/locators/authenticationPageLocators.py
+++ b/vms/pom/locators/authenticationPageLocators.py
@@ -1,0 +1,8 @@
+
+class AuthenticationPageLocators(object):
+
+	LOGIN_ID = 'id_login'
+	LOGIN_PASSWORD = 'id_password'
+	INCORRECT_LOGIN_ERROR = 'alert-danger'
+	SUBMIT_PATH = '//form[1]'
+	

--- a/vms/pom/locators/completedShiftsPageLocators.py
+++ b/vms/pom/locators/completedShiftsPageLocators.py
@@ -1,0 +1,16 @@
+
+class CompletedShiftsPageLocators(object):
+
+    SHIFT_JOB_PATH = '//table//tbody//tr[1]//td[1]'
+    SHIFT_DATE_PATH = '//table//tbody//tr[1]//td[2]'
+    SHIFT_STIME_PATH = '//table//tbody//tr[1]//td[3]'
+    SHIFT_ETIME_PATH = '//table//tbody//tr[1]//td[4]'
+    SHIFT_EDIT_PATH = '//table//tbody//tr[1]//td[5]'
+    SHIFT_CLEAR_PATH = '//table//tbody//tr[1]//td[6]'
+    START_TIME_FORM = '//input[@name = "start_time"]'
+    END_TIME_FORM = '//input[@name = "end_time"]'
+    CLEAR_SHIFT_HOURS_TEXT = 'html/body/div[2]/form/div/div[1]/h3'
+
+    INFO_BOX = 'alert-info'
+    DANGER_BOX = 'alert-danger'
+    SUBMIT_PATH = '//form[1]'

--- a/vms/pom/locators/eventSignUpPageLocators.py
+++ b/vms/pom/locators/eventSignUpPageLocators.py
@@ -1,0 +1,24 @@
+
+class EventSignUpPageLocators(object):
+
+	SHIFT_JOB_PATH = '//table//tbody//tr[1]//td[1]'
+	SHIFT_DATE_PATH = '//table//tbody//tr[1]//td[2]'
+	SHIFT_STIME_PATH = '//table//tbody//tr[1]//td[3]'
+	SHIFT_ETIME_PATH = '//table//tbody//tr[1]//td[4]'
+	VIEW_JOBS_PATH = '//table//tbody//tr[1]//td[4]'
+	VIEW_SHIFTS_PATH = '//table//tbody//tr[1]//td[4]'
+	EVENT_NAME = '//table//tbody//tr[1]//td[1]'
+	UPCOMING_SHIFT_SECTION = 'html/body/div[2]/h3'
+	SLOTS_REMAINING_PATH = '//table//tbody//tr[1]//td[5]'
+
+	# search form locators
+	START_DATE_FROM = 'from'
+	START_DATE_TO = 'to'
+
+	# Two choices depending on whether volunteer or admin
+	ASSIGN_SHIFTS_PATH = '//table//tbody//tr[1]//td[4]'
+	SHIFT_SIGNUP_PATH = '//table//tbody//tr[1]//td[4]'
+
+	INFO_BOX = 'alert-info'
+	DANGER_BOX = 'alert-danger'
+	SUBMIT_PATH = '//form[1]'

--- a/vms/pom/locators/eventsPageLocators.py
+++ b/vms/pom/locators/eventsPageLocators.py
@@ -1,0 +1,62 @@
+
+class EventsPageLocators(object):
+
+	# locators for events, jobs, shifts  listed
+	EVENT_NAME = '//table//tbody//tr[1]//td[1]'
+	JOB_NAME = '//table//tbody//tr[1]//td[1]'
+	JOB_EVENT = '//table//tbody//tr[1]//td[2]'
+	SHIFT_DATE = '//table//tbody//tr[1]//td[1]'
+	CREATED_ORG_NAME = '//table//tbody//tr[1]//td[1]'
+	MESSAGE_BOX = 'alert-success'
+	HELP_BLOCK = 'help-block'
+
+	VIEW_SHIFT = '//table//tbody//tr[1]/td[5]//a'
+	EDIT_EVENT = '//table//tbody//tr[1]//td[5]//a'
+	EDIT_JOB = '//table//tbody//tr[1]//td[6]//a'
+	EDIT_SHIFT = '//table//tbody//tr[1]//td[5]//a'
+	EDIT_ORG = '//table//tbody//tr[1]//td[2]'
+	DELETE_ORG = '//table//tbody//tr[1]//td[3]'
+	DELETE_SHIFT = '//table//tbody//tr[1]//td[6]'
+	DELETE_JOB = '//table//tbody//tr[1]//td[7]'
+	DELETE_EVENT = '//table//tbody//tr[1]//td[6]'
+	DELETION_BOX = 'panel-danger'
+	DELETION_TOPIC = 'panel-heading'
+	WARNING_CONTEXT = 'messages'
+	TEMPLATE_ERROR_MESSAGE = '//div[2]/div[3]/p'
+	DANGER_BOX = 'alert-danger'
+	RESULTS = '//table//tbody'
+
+	# locators for event, job and shift form
+	JOB_EVENT_NAME = 'events'
+	SHIFT_JOB = "//div[2]//div[1]/p"
+	SHIFT_JOB_START_DATE = "//div[2]//div[2]/p"
+	SHIFT_JOB_END_DATE = "//div[2]//div[3]/p"
+	JOB_EVENT_START_DATE = 'start_date_here'
+	JOB_EVENT_END_DATE = 'end_date_here'
+
+	CREATE_EVENT_NAME ='//input[@placeholder = "Event Name"]'
+	CREATE_EVENT_START_DATE = '//input[@name = "start_date"]'
+	CREATE_EVENT_END_DATE = '//input[@name = "end_date"]'
+	CREATE_EVENT_ID = '//select[@name = "event_id"]'
+	CREATE_JOB_NAME = '//input[@placeholder = "Job Name"]'
+	CREATE_JOB_DESCRIPTION = '//textarea[@name = "description"]'
+	CREATE_JOB_START_DATE = '//input[@name = "start_date"]'
+	CREATE_JOB_END_DATE = '//input[@name = "end_date"]'
+	CREATE_SHIFT_DATE = '//input[@name = "date"]'
+	CREATE_SHIFT_START_TIME = '//input[@name = "start_time"]'
+	CREATE_SHIFT_END_TIME = '//input[@name = "end_time"]'
+	CREATE_SHIFT_MAX_VOLUNTEER = '//input[@name = "max_volunteers"]'
+	ORG_NAME = '//input[@name = "name"]'
+
+	EVENT_NAME_ERROR = "//form//div[1]/div/p/strong"
+	EVENT_START_DATE_ERROR = "//form//div[2]/div/p/strong"
+	EVENT_END_DATE_ERROR = "//form//div[3]/div/p/strong"
+	JOB_NAME_ERROR = "//form//div[3]/div/p/strong"
+	JOB_START_DATE_ERROR = "//form//div[5]/div/p/strong"
+	JOB_END_DATE_ERROR = "//form//div[6]/div/p/strong"
+	SHIFT_DATE_ERROR = "//form//div[4]/div/p/strong"
+	SHIFT_START_TIME_ERROR = "//form//div[5]/div/p/strong"
+	SHIFT_END_TIME_ERROR = "//form//div[6]/div/p/strong"
+	SHIFT_MAX_VOLUNTEER_ERROR = "//form//div[7]/div/p/strong"
+
+	GENERAL_SUBMIT_PATH = '//form[1]'

--- a/vms/pom/locators/homePageLocators.py
+++ b/vms/pom/locators/homePageLocators.py
@@ -1,0 +1,19 @@
+
+class HomePageLocators(object):
+
+	ADMIN_REPORT_TEXT = 'Report'
+	VOLUNTEER_REPORT_TEXT = 'Report'
+	MANAGE_SHIFT_TEXT = 'Manage Volunteer Shifts'
+	UPCOMING_SHIFT_TEXT = 'Upcoming Shifts'
+	COMPLETED_SHIFT_TEXT = 'Completed Shifts'
+	LOGIN_TEXT = 'Log In'
+	LOGOUT_TEXT = 'Log Out'
+	ADMIN_EVENTS_TEXT = 'Events'
+	SHIFT_SIGN_UP_TEXT = 'Shift Sign Up'
+	VOLUNTEER_SEARCH_TEXT = 'Volunteer Search'
+	VOLUNTEER_PROFILE_TEXT = 'Profile'
+	CREATE_ADMIN_TEXT = 'Create Admin Account'
+
+	NO_ADMIN_RIGHT_HEAD = 'panel-heading'
+	NO_ADMIN_RIGHT_CONTENT = 'panel-body'
+	

--- a/vms/pom/locators/jobDetailsPageLocators.py
+++ b/vms/pom/locators/jobDetailsPageLocators.py
@@ -1,0 +1,9 @@
+
+class JobDetailsPageLocators(object):
+
+	JOB_NAME = '//table[1]//tr//td[1]'
+	JOB_EVENT = '//table[1]//tr//td[2]'
+	JOB_START_DATE = '//table[1]//tr//td[3]'
+	JOB_END_DATE = '//table[1]//tr//td[4]'
+	VIEW_DETAILS = '//table[1]//tr//td[5]'
+	

--- a/vms/pom/locators/manageShiftPageLocators.py
+++ b/vms/pom/locators/manageShiftPageLocators.py
@@ -1,0 +1,9 @@
+
+class ManageShiftPageLocators(object):
+
+    CANCEL_SHIFT_PATH = '//table//tbody//tr[1]//td[5]'
+    INFO_BOX = 'alert-info'
+    CANCELLATION_PANEL = 'panel-danger'
+    CANCELLATION_CONFIRMATION = 'btn-danger'
+    CANCELLATION_HEAD = 'panel-title'
+    SUBMIT_PATH = '//form[1]'

--- a/vms/pom/locators/shiftDetailsPageLocators.py
+++ b/vms/pom/locators/shiftDetailsPageLocators.py
@@ -1,0 +1,18 @@
+
+class ShiftDetailsPageLocators(object):
+	VOL_EMAIL = '//table[2]//tr//td[9]'
+	MAX_VOL = '//table[1]//tr//td[9]'
+	JOB = '//table[1]//tr//td[1]'
+	DATE = '//table[1]//tr//td[3]'
+	START_TIME = '//table[1]//tr//td[4]'
+	END_TIME = '//table[1]//tr//td[5]'
+	VIEW_DETAILS = '//table//tbody//tr[1]//td[7]'
+	
+	LOGGED_VOLUNTEER = '//table[3]//tr//td[1]'
+	LOGGED_START_TIME = '//table[3]//tr//td[4]'
+	LOGGED_END_TIME = '//table[3]//tr//td[5]'
+	LOGGED_VOLUNTEER_LIST = '//table[3]//tbody//tr'
+
+	REGISTERED_VOLUNTEER_NAME = '//table[2]//tr//td[1]'
+	REGISTERED_VOLUNTEER_LIST = '//table[2]//tbody//tr'
+	ALERT_BOX = 'alert-success'

--- a/vms/pom/locators/upcomingShiftsPageLocators.py
+++ b/vms/pom/locators/upcomingShiftsPageLocators.py
@@ -1,0 +1,13 @@
+
+class UpcomingShiftsPageLocators(object):
+
+	SHIFT_JOB_PATH = '//table//tbody//tr[1]//td[1]'
+	SHIFT_DATE_PATH = '//table//tbody//tr[1]//td[2]'
+	SHIFT_STIME_PATH = '//table//tbody//tr[1]//td[3]'
+	SHIFT_ETIME_PATH = '//table//tbody//tr[1]//td[4]'
+	SHIFT_CANCEL_PATH = '//table//tbody//tr[1]//td[6]'
+	LOG_SHIFT_HOURS_PATH = '//table//tbody//tr[1]//td[5]'
+
+	INFO_BOX = 'alert-info'
+	CONTAINER = '//table'
+	SUBMIT_PATH = '//form[1]'

--- a/vms/pom/locators/volunteerProfilePageLocators.py
+++ b/vms/pom/locators/volunteerProfilePageLocators.py
@@ -1,0 +1,18 @@
+
+class VolunteerProfilePageLocators(object):
+
+	PROFILE_FIRST_NAME = '//input[@name = "first_name"]'
+	PROFILE_LAST_NAME = '//input[@name = "last_name"]'
+	PROFILE_EMAIL = '//input[@name = "email"]'
+	PROFILE_ADDRESS = '//input[@name = "address"]'
+	PROFILE_CITY = '//input[@name = "city"]'
+	PROFILE_STATE = '//input[@name = "state"]'
+	PROFILE_COUNTRY = '//input[@name = "country"]'
+	PROFILE_PHONE = '//input[@name = "phone_number"]'
+	SELECT_ORGANIZATION = '//select[@name = "organization_name"]'
+	UNLISTED_ORGANIZATION = '//input[@name = "unlisted_organization"]'
+	RESUME_FILE = '//input[@name = "resume_file"]'
+	DOWNLOAD_RESUME = './/*[@id="collapseResumeFile"]/div/form/button'
+	EDIT_PROFILE_TEXT = 'Edit Profile'
+	INVALID_FORMAT_MESSAGE = 'html/body/div[2]/div[2]/form/fieldset/div[13]/div/p/strong'
+	SUBMIT_PATH = '//form[1]'

--- a/vms/pom/locators/volunteerRegistrationPageLocators.py
+++ b/vms/pom/locators/volunteerRegistrationPageLocators.py
@@ -1,0 +1,29 @@
+
+class VolunteerRegistrationPageLocators(object):
+
+	USERNAME = 'id_username'
+	PASSWORD = 'id_password'
+	FIRST_NAME = 'id_first_name'
+	LAST_NAME = 'id_last_name'
+	EMAIL = 'id_email'
+	ADDRESS = 'id_address'
+	CITY = 'id_city'
+	STATE = 'id_state'
+	COUNTRY = 'id_country'
+	PHONE = 'id_phone_number'
+	ORGANIZATION = 'id_unlisted_organization'
+
+	USERNAME_ERROR = "id('div_id_username')/div/p/strong"
+	FIRST_NAME_ERROR = "id('div_id_first_name')/div/p/strong"
+	LAST_NAME_ERROR = "id('div_id_last_name')/div/p/strong"
+	EMAIL_ERROR = "id('div_id_email')/div/p/strong"
+	ADDRESS_ERROR = "id('div_id_address')/div/p/strong"
+	CITY_ERROR = "id('div_id_city')/div/p/strong"
+	STATE_ERROR = "id('div_id_state')/div/p/strong"
+	COUNTRY_ERROR = "id('div_id_country')/div/p/strong"
+	PHONE_ERROR = "id('div_id_phone_number')/div/p/strong"
+	ORGANIZATION_ERROR = "id('div_id_unlisted_organization')/div/p/strong"
+
+	HELP_BLOCK = 'help-block'
+	MESSAGES = 'messages'
+	SUBMIT_PATH = '//form[1]'

--- a/vms/pom/locators/volunteerReportPageLocators.py
+++ b/vms/pom/locators/volunteerReportPageLocators.py
@@ -1,0 +1,10 @@
+
+class VolunteerReportPageLocators(object):
+
+	REPORT_START_DATE = '//input[@name = "start_date"]'
+	REPORT_END_DATE = '//input[@name = "end_date"]'
+	REPORT_EVENT_SELECTOR = '//select[@name = "event_name"]'
+	REPORT_JOB_SELECTOR = '//select[@name = "job_name"]'
+	REPORT_SHIFT_SUMMARY_PATH = '//div[2]/div[4]'
+	NO_RESULT_BOX = 'alert-danger'
+	SUBMIT_PATH = '//form[1]'

--- a/vms/pom/locators/volunteerSearchPageLocators.py
+++ b/vms/pom/locators/volunteerSearchPageLocators.py
@@ -1,0 +1,12 @@
+
+class VolunteerSearchPageLocators(object):
+
+	FIRST_NAME_FIELD = ".form-control[name='first_name']"
+	LAST_NAME_FIELD = ".form-control[name='last_name']"
+	CITY_FIELD = ".form-control[name='city']"
+	STATE_FIELD = ".form-control[name='state']"
+	COUNTRY_FIELD = ".form-control[name='country']"
+	ORG_FIELD = ".form-control[name='organization']"
+	RESULT_BODY = '//table//tbody'
+	HELP_BLOCK = 'help-block'
+	SUBMIT_PATH = 'btn'

--- a/vms/pom/models.py
+++ b/vms/pom/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/vms/pom/pageUrls.py
+++ b/vms/pom/pageUrls.py
@@ -1,0 +1,21 @@
+
+class PageUrls(object):
+
+	homepage = '/'
+	authentication_page = '/authentication/login/'
+	logout_page = '/authentication/logout/'
+	shift_list_page = '/shift/list_jobs/'
+	job_list_page = '/job/list/'
+
+	administrator_report_page = '/administrator/report/'
+	admin_registration_page = '/registration/signup_administrator/'
+	admin_settings_page = '/administrator/settings/'
+
+	volunteer_report_page = '/volunteer/report/'
+	volunteer_registration_page = '/registration/signup_volunteer/'
+	volunteer_search_page = '/volunteer/search/'
+	manage_volunteer_shift_page = '/shift/volunteer_search/'
+	upcoming_shifts_page = '/shift/view_volunteer_shifts/'
+	completed_shifts_page = '/shift/view_hours/'
+	shift_sign_up_page = '/event/list_sign_up/'
+	volunteer_profile_page = '/volunteer/profile/'

--- a/vms/pom/pageUrls.py
+++ b/vms/pom/pageUrls.py
@@ -6,6 +6,8 @@ class PageUrls(object):
 	logout_page = '/authentication/logout/'
 	shift_list_page = '/shift/list_jobs/'
 	job_list_page = '/job/list/'
+	event_list_page = '/event/list/'
+	organization_list_page = '/organization/list/'
 
 	administrator_report_page = '/administrator/report/'
 	admin_registration_page = '/registration/signup_administrator/'

--- a/vms/pom/pages/adminRegistrationPage.py
+++ b/vms/pom/pages/adminRegistrationPage.py
@@ -5,6 +5,7 @@ from pom.pageUrls import PageUrls
 class AdminRegistrationPage(BasePage):
     """Admin Registration page action methods here"""
 
+    live_server_url = ''
     admin_registration_page = PageUrls.admin_registration_page
     success_message = "You have successfully registered!"
 
@@ -45,8 +46,8 @@ class AdminRegistrationPage(BasePage):
     def submit_form(self):
         self.element_by_xpath(self.elements.SUBMIT_PATH).submit()   
 
-    def get_admin_registration_page(self, base_url):
-        self.get_page(base_url, self.admin_registration_page)
+    def get_admin_registration_page(self):
+        self.get_page(self.live_server_url, self.admin_registration_page)
 
     def get_help_blocks(self):
         blocks = self.elements_by_class_name(self.elements.HELP_BLOCK)
@@ -88,7 +89,7 @@ class AdminRegistrationPage(BasePage):
     def get_organization_error_text(self):
         return self.element_by_xpath(self.elements.ORGANIZATION_ERROR ).text
 
-    def register_valid_details(self, base_url):
-        self.get_admin_registration_page(base_url)
+    def register_valid_details(self):
+        self.get_admin_registration_page()
         entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
         self.fill_registration_form(entry)

--- a/vms/pom/pages/adminRegistrationPage.py
+++ b/vms/pom/pages/adminRegistrationPage.py
@@ -1,10 +1,11 @@
 from basePage import *
 from pom.locators.adminRegistrationPageLocators import *
+from pom.pageUrls import PageUrls
 
 class AdminRegistrationPage(BasePage):
     """Admin Registration page action methods here"""
 
-    admin_registration_page = '/registration/signup_administrator/'
+    admin_registration_page = PageUrls.admin_registration_page
     success_message = "You have successfully registered!"
 
     def __init__(self, driver):

--- a/vms/pom/pages/adminRegistrationPage.py
+++ b/vms/pom/pages/adminRegistrationPage.py
@@ -1,0 +1,93 @@
+from basePage import *
+from pom.locators.adminRegistrationPageLocators import *
+
+class AdminRegistrationPage(BasePage):
+    """Admin Registration page action methods here"""
+
+    admin_registration_page = '/registration/signup_administrator/'
+    success_message = "You have successfully registered!"
+
+    def __init__(self, driver):
+        self.elements = AdminRegistrationPageLocators()
+        super(AdminRegistrationPage, self).__init__(driver)
+
+    def fill_registration_form(self, info):
+        elements = self.elements
+        self.send_value_to_element_id(elements.USERNAME, info[0])
+        self.send_value_to_element_id(elements.PASSWORD, info[1])
+        self.send_value_to_element_id(elements.FIRST_NAME, info[2])
+        self.send_value_to_element_id(elements.LAST_NAME, info[3])
+        self.send_value_to_element_id(elements.EMAIL, info[4])
+        self.send_value_to_element_id(elements.ADDRESS, info[5])
+        self.send_value_to_element_id(elements.CITY, info[6])
+        self.send_value_to_element_id(elements.STATE, info[7])
+        self.send_value_to_element_id(elements.COUNTRY, info[8])
+        self.send_value_to_element_id(elements.PHONE, info[9])
+        self.send_value_to_element_id(elements.ORGANIZATION, info[10])
+        self.submit_form()
+
+    def get_field_values(self):
+        values = {}
+        elements = self.elements
+        values['username'] = self.get_value_for(elements.USERNAME)
+        values['first_name'] = self.get_value_for(elements.FIRST_NAME)
+        values['last_name'] = self.get_value_for(elements.LAST_NAME)
+        values['email'] = self.get_value_for(elements.EMAIL)
+        values['address'] = self.get_value_for(elements.ADDRESS)
+        values['city'] = self.get_value_for(elements.CITY)
+        values['state'] = self.get_value_for(elements.STATE)
+        values['country'] = self.get_value_for(elements.COUNTRY)
+        values['phone'] = self.get_value_for(elements.PHONE)
+        values['organization'] = self.get_value_for(elements.ORGANIZATION)
+        return values
+
+    def submit_form(self):
+        self.element_by_xpath(self.elements.SUBMIT_PATH).submit()   
+
+    def get_admin_registration_page(self, base_url):
+        self.get_page(base_url, self.admin_registration_page)
+
+    def get_help_blocks(self):
+        blocks = self.elements_by_class_name(self.elements.HELP_BLOCK)
+        return blocks
+
+    def get_message_box_text(self):
+        return self.element_by_class_name(self.elements.MESSAGES).text
+
+    def get_message_box(self):
+        return self.element_by_class_name(self.elements.MESSAGES)
+
+    def get_username_error_text(self):
+        return self.element_by_xpath(self.elements.USERNAME_ERROR).text
+
+    def get_first_name_error_text(self):
+        return self.element_by_xpath(self.elements.FIRST_NAME_ERROR).text
+
+    def get_last_name_error_text(self):
+        return self.element_by_xpath(self.elements.LAST_NAME_ERROR).text
+
+    def get_address_error_text(self):
+        return self.element_by_xpath(self.elements.ADDRESS_ERROR).text
+
+    def get_city_error_text(self):
+        return self.element_by_xpath(self.elements.CITY_ERROR).text
+
+    def get_state_error_text(self):
+        return self.element_by_xpath(self.elements.STATE_ERROR).text
+
+    def get_country_error_text(self):
+        return self.element_by_xpath(self.elements.COUNTRY_ERROR).text
+
+    def get_email_error_text(self):
+        return self.element_by_xpath(self.elements.EMAIL_ERROR).text
+
+    def get_phone_error_text(self):
+        return self.element_by_xpath(self.elements.PHONE_ERROR).text
+
+    def get_organization_error_text(self):
+        return self.element_by_xpath(self.elements.ORGANIZATION_ERROR ).text
+
+    def register_valid_details(self, base_url):
+        self.get_admin_registration_page(base_url)
+        entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
+        self.fill_registration_form(entry)

--- a/vms/pom/pages/administratorReportPage.py
+++ b/vms/pom/pages/administratorReportPage.py
@@ -1,0 +1,49 @@
+from basePage import *
+from pom.locators.administratorReportPageLocators import *
+from selenium.webdriver.support.ui import Select
+from pom.pages.homePage import HomePage
+
+class AdministratorReportPage(BasePage):
+
+    no_results_message = 'Your criteria did not return any results.'
+
+    def __init__(self, driver):
+        self.driver = driver
+        self.home_page = HomePage(self.driver)
+        self.elements = AdministratorReportPageLocators()
+        super(AdministratorReportPage, self).__init__(driver)
+
+    def go_to_admin_report(self):
+        self.home_page.get_admin_report_link().send_keys("\n")
+
+    def fill_report_form(self, info):
+        first_name = self.element_by_xpath(self.elements.FIRST_NAME_SELECTOR)
+        last_name = self.element_by_xpath(self.elements.LAST_NAME_SELECTOR)
+
+        first_name.clear()
+        last_name.clear()
+        [select1, select2, select3] = self.get_event_job_organization_selectors()
+
+        first_name.send_keys(info[0])
+        last_name.send_keys(info[1])
+
+        """select1.select_by_visible_text(info[2])
+        select2.select_by_visible_text(info[3])
+        select3.select_by_visible_text(info[4])"""
+
+        self.submit_form()
+
+    def get_event_job_organization_selectors(self):
+        select1 = Select(self.element_by_xpath(self.elements.REPORT_EVENT_SELECTOR))
+        select2 = Select(self.element_by_xpath(self.elements.REPORT_JOB_SELECTOR))
+        select3 = Select(self.element_by_xpath(self.elements.REPORT_ORG_SELECTOR))
+        return (select1, select2, select3)
+
+    def submit_form(self):
+        self.element_by_xpath(self.elements.SUBMIT_PATH).submit()   
+
+    def get_alert_box_text(self):
+        return self.element_by_class_name(self.elements.NO_RESULT_BOX).text
+
+    def get_shift_summary(self):
+        return self.element_by_xpath(self.elements.REPORT_SHIFT_SUMMARY_PATH).text

--- a/vms/pom/pages/authenticationPage.py
+++ b/vms/pom/pages/authenticationPage.py
@@ -6,14 +6,16 @@ from pom.pageUrls import PageUrls
 class AuthenticationPage(BasePage):
 
     url = PageUrls.authentication_page
+    homepage = PageUrls.homepage
+    server_url = ''
 
     def __init__(self, driver):
         self.elements = AuthenticationPageLocators()
         self.home = HomePageLocators()
         super(AuthenticationPage, self).__init__(driver)
 
-    def login(self, base_url, credentials):
-        self.get_page(base_url, self.url)
+    def login(self,credentials):
+        self.get_page(self.server_url, self.url)
         self.send_value_to_element_id(self.elements.LOGIN_ID,credentials['username'])
         self.send_value_to_element_id(self.elements.LOGIN_PASSWORD,credentials['password'])
         self.element_by_xpath(self.elements.SUBMIT_PATH).submit()

--- a/vms/pom/pages/authenticationPage.py
+++ b/vms/pom/pages/authenticationPage.py
@@ -1,0 +1,28 @@
+from basePage import *
+from pom.locators.authenticationPageLocators import *
+from pom.locators.homePageLocators import *
+from pom.pageUrls import PageUrls
+
+class AuthenticationPage(BasePage):
+
+    url = PageUrls.authentication_page
+
+    def __init__(self, driver):
+        self.elements = AuthenticationPageLocators()
+        self.home = HomePageLocators()
+        super(AuthenticationPage, self).__init__(driver)
+
+    def login(self, base_url, credentials):
+        self.get_page(base_url, self.url)
+        self.send_value_to_element_id(self.elements.LOGIN_ID,credentials['username'])
+        self.send_value_to_element_id(self.elements.LOGIN_PASSWORD,credentials['password'])
+        self.element_by_xpath(self.elements.SUBMIT_PATH).submit()
+
+    def go_to_authentication_page(self):
+        self.click_link(self.home.LOGIN_TEXT)
+
+    def logout(self):
+        self.click_link(self.home.LOGOUT_TEXT)
+
+    def get_incorrect_login_message(self):
+        return self.element_by_class_name(self.elements.INCORRECT_LOGIN_ERROR)

--- a/vms/pom/pages/basePage.py
+++ b/vms/pom/pages/basePage.py
@@ -1,0 +1,25 @@
+
+class BasePage(object):
+    """Base class to initialize the base page that will be called from all pages"""
+
+    def __init__(self, driver):
+        self.driver = driver
+
+    def send_value_to_element_id(self, key, value):
+    	self.driver.find_element_by_id(key).send_keys(value)
+
+    def element_by_xpath(self, path):
+    	return self.driver.find_element_by_xpath(path)
+
+    def get_page(self, base, relative_url):
+    	self.driver.get(base + relative_url)
+
+    def elements_by_class_name(self, class_name):
+    	elements = self.driver.find_elements_by_class_name(class_name)  	
+    	return elements if elements else None
+
+    def element_by_class_name(self,class_name):
+        return self.driver.find_element_by_class_name(class_name)
+
+    def get_value_for(self, field):
+        return self.driver.find_element_by_id(field).get_attribute('value')

--- a/vms/pom/pages/basePage.py
+++ b/vms/pom/pages/basePage.py
@@ -40,3 +40,12 @@ class BasePage(object):
     def find_link(self, link_text):
         element = self.driver.find_element_by_link_text(link_text)
         return element if element else None
+
+    def element_by_id(self, id_name):
+        return self.driver.find_element_by_id(id_name)
+
+    def get_value_for_xpath(self, xpath):
+        return self.driver.find_element_by_xpath(xpath).get_attribute('value')
+
+    def element_by_tag_name(self, tag):
+        return self.driver.find_element_by_tag_name(tag)

--- a/vms/pom/pages/basePage.py
+++ b/vms/pom/pages/basePage.py
@@ -8,6 +8,9 @@ class BasePage(object):
     def send_value_to_element_id(self, key, value):
     	self.driver.find_element_by_id(key).send_keys(value)
 
+    def send_value_to_xpath(self, key, value):
+        self.driver.find_element_by_xpath(key).send_keys(value)
+
     def element_by_xpath(self, path):
     	return self.driver.find_element_by_xpath(path)
 
@@ -21,6 +24,9 @@ class BasePage(object):
     def elements_by_class_name(self, class_name):
     	elements = self.driver.find_elements_by_class_name(class_name)  	
     	return elements if elements else None
+
+    def find_element_by_css_selector(self, selector):
+        return self.driver.find_element_by_css_selector(selector)
 
     def element_by_class_name(self,class_name):
         return self.driver.find_element_by_class_name(class_name)

--- a/vms/pom/pages/basePage.py
+++ b/vms/pom/pages/basePage.py
@@ -11,6 +11,10 @@ class BasePage(object):
     def element_by_xpath(self, path):
     	return self.driver.find_element_by_xpath(path)
 
+    def elements_by_xpath(self, path):
+        elements = self.driver.find_elements_by_xpath(path)
+        return elements if elements else None
+
     def get_page(self, base, relative_url):
     	self.driver.get(base + relative_url)
 
@@ -23,3 +27,10 @@ class BasePage(object):
 
     def get_value_for(self, field):
         return self.driver.find_element_by_id(field).get_attribute('value')
+
+    def click_link(self, link_text):
+        self.driver.find_element_by_link_text(link_text).click()
+
+    def find_link(self, link_text):
+        element = self.driver.find_element_by_link_text(link_text)
+        return element if element else None

--- a/vms/pom/pages/completedShiftsPage.py
+++ b/vms/pom/pages/completedShiftsPage.py
@@ -1,0 +1,61 @@
+from basePage import *
+from pom.locators.completedShiftsPageLocators import CompletedShiftsPageLocators
+from pom.pages.homePage import HomePage
+from pom.pageUrls import PageUrls
+
+class CompletedShiftsPage(BasePage):
+
+    view_hours_page = PageUrls.completed_shifts_page
+
+    def __init__(self, driver):
+        self.driver = driver
+        self.home_page = HomePage(self.driver)
+        self.elements = CompletedShiftsPageLocators()
+        super(CompletedShiftsPage, self).__init__(driver)
+
+    def go_to_completed_shifts(self):
+    	self.home_page.get_completed_shifts_link().click()
+
+    def edit_hours(self, stime, etime):
+        self.element_by_xpath(self.elements.SHIFT_EDIT_PATH + '//a').click()
+        self.log_shift_timings(stime, etime)
+
+    def log_shift_timings(self, stime, etime):
+        self.element_by_xpath(self.elements.START_TIME_FORM).clear()
+        self.send_value_to_xpath(self.elements.START_TIME_FORM, stime)
+        self.element_by_xpath(self.elements.END_TIME_FORM).clear()
+        self.send_value_to_xpath(self.elements.END_TIME_FORM, etime)
+        self.submit_form()
+
+    def submit_form(self):
+        self.element_by_xpath(self.elements.SUBMIT_PATH).submit()
+
+    def get_info_box(self):
+        return self.element_by_class_name(self.elements.INFO_BOX).text
+
+    def get_danger_box(self):
+    	return self.element_by_class_name(self.elements.DANGER_BOX)
+
+    def get_shift_job(self):
+    	return self.element_by_xpath(self.elements.SHIFT_JOB_PATH).text
+
+    def get_shift_date(self):
+    	return self.element_by_xpath(self.elements.SHIFT_DATE_PATH).text
+
+    def get_shift_start_time(self):
+    	return self.element_by_xpath(self.elements.SHIFT_STIME_PATH).text
+
+    def get_shift_end_time(self):
+    	return self.element_by_xpath(self.elements.SHIFT_ETIME_PATH).text
+
+    def get_clear_shift_hours(self):
+    	return self.element_by_xpath(self.elements.SHIFT_CLEAR_PATH).text
+
+    def get_edit_shift_hours(self):
+    	return self.element_by_xpath(self.elements.SHIFT_EDIT_PATH).text
+
+    def get_clear_shift_hours_text(self):
+    	return self.element_by_xpath(self.elements.CLEAR_SHIFT_HOURS_TEXT).text
+
+    def click_to_clear_hours(self):
+    	self.element_by_xpath(self.elements.SHIFT_CLEAR_PATH + '//a').click()

--- a/vms/pom/pages/eventSignUpPage.py
+++ b/vms/pom/pages/eventSignUpPage.py
@@ -1,0 +1,74 @@
+from basePage import *
+from pom.locators.eventSignUpPageLocators import EventSignUpPageLocators
+from pom.pages.homePage import HomePage
+
+class EventSignUpPage(BasePage):
+
+    no_event_message = 'There are no events.'
+
+    def __init__(self, driver):
+        self.driver = driver
+        self.home_page = HomePage(self.driver)
+        self.elements = EventSignUpPageLocators()
+        super(EventSignUpPage, self).__init__(driver)
+
+    def submit_form(self):
+        self.element_by_xpath(self.elements.SUBMIT_PATH).submit()
+
+    def click_to_view_jobs(self):
+        self.element_by_xpath(self.elements.VIEW_JOBS_PATH+ "//a").click()
+
+    def click_to_view_shifts(self):
+        self.element_by_xpath(self.elements.VIEW_SHIFTS_PATH + "//a").click()
+
+    def click_to_sign_up(self):
+        self.element_by_xpath(self.elements.SHIFT_SIGNUP_PATH + "//a").click()
+
+    def get_view_jobs(self):
+        return self.element_by_xpath(self.elements.VIEW_JOBS_PATH).text
+
+    def get_view_shifts(self):
+        return self.element_by_xpath(self.elements.VIEW_SHIFTS_PATH).text
+
+    def get_sign_up(self):
+        return self.element_by_xpath(self.elements.SHIFT_SIGNUP_PATH).text
+
+    def navigate_to_sign_up(self):
+        self.home_page.get_shift_signup_link().click()
+
+    def fill_search_form(self, date):
+        self.element_by_id(self.elements.START_DATE_FROM).clear()
+        self.element_by_id(self.elements.START_DATE_TO).clear()
+        self.send_value_to_element_id(self.elements.START_DATE_FROM,date[0])
+        self.send_value_to_element_id(self.elements.START_DATE_TO,date[1])
+        self.submit_form()
+
+    def get_info_box(self):
+        return self.element_by_class_name(self.elements.INFO_BOX)
+
+    def get_danger_box(self):
+        self.element_by_class_name(self.elements.DANGER_BOX)
+
+    def get_shift_job(self):
+        return self.element_by_xpath(self.elements.SHIFT_JOB_PATH).text
+
+    def get_shift_date(self):
+        return self.element_by_xpath(self.elements.SHIFT_DATE_PATH).text
+
+    def get_shift_start_time(self):
+        return self.element_by_xpath(self.elements.SHIFT_STIME_PATH).text
+
+    def get_shift_end_time(self):
+        return self.element_by_xpath(self.elements.SHIFT_ETIME_PATH).text
+
+    def find_table_tag(self):
+        return self.element_by_tag_name('table')
+
+    def get_event_name(self):
+        return self.element_by_xpath(self.elements.EVENT_NAME).text
+
+    def get_signed_up_shift_text(self):
+        return self.element_by_xpath(self.elements.UPCOMING_SHIFT_SECTION).text
+
+    def get_remaining_slots(self):
+        return self.element_by_xpath(self.elements.SLOTS_REMAINING_PATH).text

--- a/vms/pom/pages/eventsPage.py
+++ b/vms/pom/pages/eventsPage.py
@@ -1,0 +1,224 @@
+from basePage import *
+from pom.locators.eventsPageLocators import *
+from selenium.webdriver.support.ui import Select
+from pom.pages.homePage import HomePage
+from pom.pageUrls import PageUrls
+
+class EventsPage(BasePage):
+
+    event_list_page = PageUrls.event_list_page
+    job_list_page = PageUrls.job_list_page
+    shift_list_page = PageUrls.shift_list_page
+    organization_list_page = PageUrls.organization_list_page
+    create_organization_page = '/organization/create/'
+    create_job_page = '/job/create/'
+    create_event_page = '/event/create/'
+    jobs_tab = 'Jobs'
+    shift_tab = 'Shifts'
+    organization_tab = 'Organizations'
+    live_server_url = ''
+
+    def __init__(self, driver):
+        self.driver = driver
+        self.home_page = HomePage(self.driver)
+        self.elements = EventsPageLocators()
+        super(EventsPage, self).__init__(driver)
+
+    def fill_event_form(self, event):
+        self.element_by_xpath(self.elements.CREATE_EVENT_NAME).clear()
+        self.element_by_xpath(self.elements.CREATE_EVENT_START_DATE).clear()
+        self.element_by_xpath(self.elements.CREATE_EVENT_END_DATE).clear()
+        self.send_value_to_xpath(self.elements.CREATE_EVENT_NAME, event[0])
+        self.send_value_to_xpath(self.elements.CREATE_EVENT_START_DATE, event[1])
+        self.send_value_to_xpath(self.elements.CREATE_EVENT_END_DATE, event[2])
+        self.submit_form()
+
+    def fill_job_form(self, job):
+        self.element_by_xpath(self.elements.CREATE_JOB_NAME).clear()
+        self.element_by_xpath(self.elements.CREATE_JOB_DESCRIPTION).clear()
+        self.element_by_xpath(self.elements.CREATE_JOB_START_DATE).clear()
+        self.element_by_xpath(self.elements.CREATE_JOB_END_DATE).clear()
+
+        self.send_value_to_xpath(self.elements.CREATE_EVENT_ID,job[0])
+        self.send_value_to_xpath(self.elements.CREATE_JOB_NAME,job[1])
+        self.send_value_to_xpath(self.elements.CREATE_JOB_DESCRIPTION,job[2])
+        self.send_value_to_xpath(self.elements.CREATE_JOB_START_DATE,job[3])
+        self.send_value_to_xpath(self.elements.CREATE_JOB_END_DATE,job[4])
+        self.submit_form()
+
+    def fill_shift_form(self, shift):
+        self.element_by_xpath(self.elements.CREATE_SHIFT_DATE).clear()
+        self.element_by_xpath(self.elements.CREATE_SHIFT_START_TIME).clear()
+        self.element_by_xpath(self.elements.CREATE_SHIFT_END_TIME).clear()
+        self.element_by_xpath(self.elements.CREATE_SHIFT_MAX_VOLUNTEER).clear()
+
+        self.send_value_to_xpath(self.elements.CREATE_SHIFT_DATE,shift[0])
+        self.send_value_to_xpath(self.elements.CREATE_SHIFT_START_TIME,shift[1])
+        self.send_value_to_xpath(self.elements.CREATE_SHIFT_END_TIME,shift[2])
+        self.send_value_to_xpath(self.elements.CREATE_SHIFT_MAX_VOLUNTEER,shift[3])
+        self.submit_form()
+
+    def fill_organization_form(self, org):
+        self.element_by_xpath(self.elements.ORG_NAME).clear()
+        self.send_value_to_xpath(self.elements.ORG_NAME,org)
+        self.submit_form()
+
+    def submit_form(self):
+        self.element_by_xpath(self.elements.GENERAL_SUBMIT_PATH).submit()
+
+    def go_to_events_page(self):
+        self.home_page.get_events_link().send_keys('\n')
+
+    def navigate_to_event_list_view(self):
+        self.get_page(self.live_server_url, self.event_list_page)
+
+    def navigate_to_job_list_view(self):
+        self.get_page(self.live_server_url, self.job_list_page)
+
+    def navigate_to_shift_list_view(self):
+        self.get_page(self.live_server_url, self.shift_list_page)
+        self.element_by_xpath(self.elements.VIEW_SHIFT).click()
+
+    def navigate_to_organization_view(self):
+        self.get_page(self.live_server_url, self.organization_list_page)
+
+    def go_to_create_event_page(self):
+        self.click_link('Create Event')
+
+    def go_to_edit_event_page(self):
+        self.element_by_xpath(self.elements.EDIT_EVENT).click()
+
+    def go_to_create_job_page(self):
+        self.get_page(self.live_server_url, self.create_job_page)
+
+    def go_to_edit_job_page(self):
+        self.element_by_xpath(self.elements.EDIT_JOB).click()
+
+    def go_to_create_shift_page(self):
+        self.click_link('Create Shift')
+
+    def go_to_edit_shift_page(self):
+        self.element_by_xpath(self.elements.EDIT_SHIFT).click()
+
+    def go_to_create_organization_page(self):
+        self.get_page(self.live_server_url, self.create_organization_page)
+
+    def get_deletion_box(self):
+        return self.element_by_class_name(self.elements.DELETION_BOX)
+
+    def get_deletion_context(self):
+        return self.element_by_class_name(self.elements.DELETION_TOPIC).text
+
+    def get_message_context(self):
+        return self.element_by_class_name(self.elements.MESSAGE_BOX).text
+
+    def get_event_name(self):
+        return self.element_by_xpath(self.elements.EVENT_NAME).text
+
+    def get_warning_context(self):
+        return self.element_by_class_name(self.elements.WARNING_CONTEXT).text
+
+    def get_danger_message(self):
+        return self.element_by_class_name(self.elements.DANGER_BOX)
+
+    def get_job_name(self):
+        return self.element_by_xpath(self.elements.JOB_NAME).text
+
+    def get_job_event(self):
+        return self.element_by_xpath(self.elements.JOB_EVENT).text
+
+    def get_template_error_message(self):
+        return self.element_by_xpath(self.elements.TEMPLATE_ERROR_MESSAGE).text
+
+    def get_results(self):
+        return self.element_by_xpath(self.elements.RESULTS)
+
+    def get_shift_date(self):
+        return self.element_by_xpath(self.elements.SHIFT_DATE).text
+
+    def get_help_block(self):
+        return self.element_by_class_name(self.elements.HELP_BLOCK)
+
+    def get_org_name(self):
+        return self.element_by_xpath(self.elements.CREATED_ORG_NAME).text
+
+    def get_help_blocks(self):
+        return self.elements_by_class_name(self.elements.HELP_BLOCK)
+
+    def get_event_name_error(self):
+        return self.element_by_xpath(self.elements.EVENT_NAME_ERROR).text
+
+    def get_event_start_date_error(self):
+        return self.element_by_xpath(self.elements.EVENT_START_DATE_ERROR).text
+
+    def get_event_end_date_error(self):
+        return self.element_by_xpath(self.elements.EVENT_END_DATE_ERROR).text
+
+    def get_job_name_error(self):
+        return self.element_by_xpath(self.elements.JOB_NAME_ERROR).text
+
+    def get_job_start_date_error(self):
+        return self.element_by_xpath(self.elements.JOB_START_DATE_ERROR).text
+
+    def get_job_end_date_error(self):
+        return self.element_by_xpath(self.elements.JOB_END_DATE_ERROR).text
+
+    def get_shift_date_error(self):
+        return self.element_by_xpath(self.elements.SHIFT_DATE_ERROR).text
+
+    def get_shift_start_time_error(self):
+        return self.element_by_xpath(self.elements.SHIFT_START_TIME_ERROR).text
+
+    def get_shift_end_time_error(self):
+        return self.driver.find_element_by_xpath(self.elements.SHIFT_END_TIME_ERROR).text
+
+    def get_shift_max_volunteer_error(self):
+        return self.element_by_xpath(self.elements.SHIFT_MAX_VOLUNTEER_ERROR).text
+
+    def get_shift_job(self):
+        return self.element_by_xpath(self.elements.SHIFT_JOB).text
+
+    def get_shift_job_start_date(self):
+        return self.element_by_xpath(self.elements.SHIFT_JOB_START_DATE).text
+
+    def get_shift_job_end_date(self):
+        return self.element_by_xpath(self.elements.SHIFT_JOB_END_DATE).text
+
+    def get_job_event_start_date(self):
+        return self.element_by_id(self.elements.JOB_EVENT_START_DATE).text
+
+    def get_job_event_end_date(self):
+        return self.element_by_id(self.elements.JOB_EVENT_END_DATE).text
+
+    def get_event_name_value(self):
+        return self.get_value_for_xpath(self.elements.CREATE_EVENT_NAME)
+
+    def get_event_start_date_value(self):
+        return self.get_value_for_xpath(self.elements.CREATE_EVENT_START_DATE)
+
+    def get_event_end_date_value(self):
+        return self.get_value_for_xpath(self.elements.CREATE_EVENT_END_DATE)
+
+    def get_job_name_value(self):
+        return self.get_value_for_xpath(self.elements.CREATE_JOB_NAME)
+
+    def get_job_start_date_value(self):
+        return self.get_value_for_xpath(self.elements.CREATE_JOB_START_DATE)
+
+    def get_job_end_date_value(self):
+        return self.get_value_for_xpath(self.elements.CREATE_JOB_END_DATE)
+
+    def get_job_description_value(self):
+        return self.get_value_for_xpath(self.elements.CREATE_JOB_DESCRIPTION)
+
+    def get_shift_date_value(self):
+        return self.get_value_for_xpath(self.elements.CREATE_SHIFT_DATE)
+
+    def get_shift_start_time_value(self):
+        return self.get_value_for_xpath(self.elements.CREATE_SHIFT_START_TIME)
+
+    def get_shift_end_time_value(self):
+        return self.get_value_for_xpath(self.elements.CREATE_SHIFT_END_TIME)
+
+    def get_shift_max_volunteers(self):
+        return self.get_value_for_xpath(self.elements.CREATE_SHIFT_MAX_VOLUNTEER)

--- a/vms/pom/pages/homePage.py
+++ b/vms/pom/pages/homePage.py
@@ -1,0 +1,50 @@
+from basePage import *
+from pom.locators.homePageLocators import *
+
+class HomePage(BasePage):
+
+    def __init__(self, driver):
+        self.elements = HomePageLocators()
+        super(HomePage, self).__init__(driver)
+
+    def get_admin_report_link(self):
+        return self.find_link(self.elements.ADMIN_REPORT_TEXT)
+
+    def get_manage_shifts_link(self):
+        return self.find_link(self.elements.MANAGE_SHIFT_TEXT)
+
+    def get_volunteer_search_link(self):
+        return self.find_link(self.elements.VOLUNTEER_SEARCH_TEXT)
+
+    def get_login_link(self):
+        return self.find_link(self.elements.LOGIN_TEXT)
+
+    def get_events_link(self):
+        return self.find_link(self.elements.ADMIN_EVENTS_TEXT)
+
+    def get_create_admin_link(self):
+        return self.find_link(self.elements.CREATE_ADMIN_TEXT)
+
+    def get_logout_link(self):
+        return self.find_link(self.elements.LOGOUT_TEXT)
+
+    def get_upcoming_shifts_link(self):
+        return self.find_link(self.elements.UPCOMING_SHIFT_TEXT)
+
+    def get_completed_shifts_link(self):
+        return self.find_link(self.elements.COMPLETED_SHIFT_TEXT)
+
+    def get_shift_signup_link(self):
+        return self.find_link(self.elements.SHIFT_SIGN_UP_TEXT)
+
+    def get_volunteer_report_link(self):
+        return self.find_link(self.elements.VOLUNTEER_REPORT_TEXT)
+
+    def get_volunteer_profile_link(self):
+        return self.find_link(self.elements.VOLUNTEER_PROFILE_TEXT)
+
+    def get_no_admin_right(self):
+        return self.elements_by_class_name(self.elements.NO_ADMIN_RIGHT_HEAD)
+
+    def get_no_admin_right_content(self):
+        return self.elements_by_class_name(self.elements.NO_ADMIN_RIGHT_CONTENT)

--- a/vms/pom/pages/jobDetailsPage.py
+++ b/vms/pom/pages/jobDetailsPage.py
@@ -1,0 +1,30 @@
+from basePage import *
+from pom.locators.jobDetailsPageLocators import *
+from pom.pages.eventsPage import EventsPage
+
+class JobDetailsPage(BasePage):
+
+    live_server_url = ''
+
+    def __init__(self, driver):
+        self.driver = driver
+        self.elements = JobDetailsPageLocators()
+        self.events_page = EventsPage(self.driver)
+        super(JobDetailsPage, self).__init__(driver)
+
+    def navigate_to_job_details_view(self):
+        self.events_page.live_server_url = self.live_server_url
+        self.events_page.navigate_to_job_list_view()
+        self.element_by_xpath(self.elements.VIEW_DETAILS).click()
+
+    def get_start_date(self):
+        return self.element_by_xpath(self.elements.JOB_START_DATE).text
+
+    def get_end_date(self):
+        return self.element_by_xpath(self.elements.JOB_END_DATE).text
+
+    def get_name(self):
+        return self.element_by_xpath(self.elements.JOB_NAME).text
+
+    def get_event_name(self):
+        return self.element_by_xpath(self.elements.JOB_EVENT).text

--- a/vms/pom/pages/manageShiftPage.py
+++ b/vms/pom/pages/manageShiftPage.py
@@ -1,0 +1,58 @@
+from basePage import *
+from pom.locators.eventSignUpPageLocators import EventSignUpPageLocators
+from pom.locators.manageShiftPageLocators import ManageShiftPageLocators
+from pom.pages.homePage import HomePage
+from pom.pageUrls import PageUrls
+
+class ManageShiftPage(BasePage):
+
+    shift_page = PageUrls.manage_volunteer_shift_page
+    shift_assignment_text = 'Assign Shift'
+    no_volunteer_shift_message = 'This volunteer does not have any upcoming shifts.'
+    live_server_url = ''
+
+    def __init__(self, driver):
+        self.driver = driver
+        self.home_page = HomePage(self.driver)
+        self.sign_up_elements = EventSignUpPageLocators()
+        self.manage_elements = ManageShiftPageLocators()
+        super(ManageShiftPage, self).__init__(driver)
+
+    def navigate_to_manage_shift_page(self):
+        self.get_page(self.live_server_url, self.shift_page)
+
+    def submit_form(self):
+        self.element_by_xpath(self.manage_elements.SUBMIT_PATH).submit()
+
+    def assign_shift(self):
+        self.click_link(self.shift_assignment_text)
+
+    def select_volunteer(self, number):
+        link_path = '//table//tbody//tr[' + str(number) + ']//td[10]//a'
+        self.element_by_xpath(link_path).click()
+
+    def navigate_to_shift_assignment_page(self):
+        self.element_by_xpath(self.sign_up_elements.VIEW_JOBS_PATH + "//a").click()
+        self.element_by_xpath(self.sign_up_elements.VIEW_SHIFTS_PATH + "//a").click()
+        self.element_by_xpath(self.sign_up_elements.ASSIGN_SHIFTS_PATH + "//a").click()
+
+    def get_info_box(self):
+        return self.element_by_class_name(self.manage_elements.INFO_BOX).text
+
+    def find_table_row(self):
+        return self.element_by_tag_name('tr')
+
+    def get_cancel_shift(self):
+        return self.element_by_xpath(self.manage_elements.CANCEL_SHIFT_PATH)
+
+    def cancel_shift(self):
+        self.element_by_xpath(self.manage_elements.CANCEL_SHIFT_PATH + "//a").click()
+
+    def get_cancellation_box(self):
+        return self.element_by_class_name(self.manage_elements.CANCELLATION_PANEL)
+
+    def get_cancellation_header(self):
+        return self.element_by_class_name(self.manage_elements.CANCELLATION_HEAD).text
+
+    def get_cancellation_message(self):
+        return self.element_by_class_name(self.manage_elements.CANCELLATION_CONFIRMATION).text

--- a/vms/pom/pages/shiftDetailsPage.py
+++ b/vms/pom/pages/shiftDetailsPage.py
@@ -1,0 +1,59 @@
+from basePage import *
+from pom.locators.shiftDetailsPageLocators import *
+from pom.pages.eventsPage import EventsPage
+from pom.pageUrls import PageUrls
+
+class ShiftDetailsPage(BasePage):
+
+    shift_list_page = PageUrls.shift_list_page
+    live_server_url = ''
+
+    def __init__(self, driver):
+        self.driver = driver
+        self.elements = ShiftDetailsPageLocators()
+        self.events_page = EventsPage(self.driver)
+        super(ShiftDetailsPage, self).__init__(driver)
+
+    def navigate_to_shift_details_view(self):
+        self.events_page.live_server_url = self.live_server_url
+        self.events_page.navigate_to_shift_list_view()
+        self.element_by_xpath(self.elements.VIEW_DETAILS + '//a').click()
+
+    def get_shift_job(self):
+        return self.element_by_xpath(self.elements.JOB).text
+
+    def get_shift_date(self):
+        return self.element_by_xpath(self.elements.DATE).text
+
+    def get_max_shift_volunteer(self):
+        return self.element_by_xpath(self.elements.MAX_VOL).text
+
+    def get_shift_start_time(self):
+        return self.element_by_xpath(self.elements.START_TIME).text
+
+    def get_shift_end_time(self):
+        return self.element_by_xpath(self.elements.END_TIME).text
+
+    def get_registered_volunteers(self):
+        return self.elements_by_xpath(self.elements.REGISTERED_VOLUNTEER_LIST)
+
+    def get_registered_volunteer_name(self):
+        return self.element_by_xpath(self.elements.REGISTERED_VOLUNTEER_NAME).text
+
+    def get_registered_volunteer_email(self):
+        return self.element_by_xpath(self.elements.VOL_EMAIL).text
+
+    def get_logged_volunteers(self):
+        return self.elements_by_xpath(self.elements.LOGGED_VOLUNTEER_LIST)
+
+    def get_logged_volunteer_name(self):
+        return self.element_by_xpath(self.elements.LOGGED_VOLUNTEER).text
+
+    def get_logged_start_time(self):
+        return self.element_by_xpath(self.elements.LOGGED_START_TIME).text
+
+    def get_logged_end_time(self):
+        return self.element_by_xpath(self.elements.LOGGED_END_TIME).text
+
+    def get_message_box(self):
+        return self.element_by_class_name(self.elements.ALERT_BOX).text

--- a/vms/pom/pages/upcomingShiftsPage.py
+++ b/vms/pom/pages/upcomingShiftsPage.py
@@ -1,0 +1,56 @@
+from basePage import *
+from pom.locators.upcomingShiftsPageLocators import UpcomingShiftsPageLocators
+from pom.pages.homePage import HomePage
+from pom.pages.completedShiftsPage import CompletedShiftsPage
+from pom.pageUrls import PageUrls
+
+class UpcomingShiftsPage(BasePage):
+
+    view_shift_page = PageUrls.upcoming_shifts_page
+    no_shift_message = 'You do not have any upcoming shifts.'
+
+    def __init__(self, driver):
+        self.driver = driver
+        self.home_page = HomePage(self.driver)
+        self.completed_shifts_page = CompletedShiftsPage(self.driver)
+        self.elements = UpcomingShiftsPageLocators()
+        super(UpcomingShiftsPage, self).__init__(driver)
+
+    def view_upcoming_shifts(self):
+        self.home_page.get_upcoming_shifts_link().send_keys('\n')
+
+    def submit_form(self):
+        self.element_by_xpath(self.elements.SUBMIT_PATH).submit()
+
+    def get_info_box(self):
+        return self.element_by_class_name(self.elements.INFO_BOX).text
+
+    def get_result_container(self):
+        return self.element_by_xpath(self.elements.CONTAINER)
+
+    def get_shift_job(self):
+        return self.element_by_xpath(self.elements.SHIFT_JOB_PATH).text
+
+    def get_shift_date(self):
+        return self.element_by_xpath(self.elements.SHIFT_DATE_PATH).text
+
+    def get_shift_start_time(self):
+        return self.element_by_xpath(self.elements.SHIFT_STIME_PATH).text
+
+    def get_shift_end_time(self):
+        return self.element_by_xpath(self.elements.SHIFT_ETIME_PATH).text
+
+    def get_log_hours(self):
+        return self.element_by_xpath(self.elements.LOG_SHIFT_HOURS_PATH).text
+
+    def click_to_log_hours(self):
+        self.element_by_xpath(self.elements.LOG_SHIFT_HOURS_PATH + "//a").click()
+
+    def log_shift_timings(self, stime, etime):
+        self.completed_shifts_page.log_shift_timings(stime, etime)
+
+    def get_cancel_shift(self):
+        return self.element_by_xpath(self.elements.SHIFT_CANCEL_PATH)
+
+    def cancel_shift(self):
+        self.element_by_xpath(self.elements.SHIFT_CANCEL_PATH + "//a").click()

--- a/vms/pom/pages/volunteerProfilePage.py
+++ b/vms/pom/pages/volunteerProfilePage.py
@@ -1,0 +1,48 @@
+from basePage import *
+from pom.locators.volunteerProfilePageLocators import *
+from pom.pages.homePage import HomePage
+
+class VolunteerProfilePage(BasePage):
+
+    def __init__(self, driver):
+        self.driver = driver
+        self.home_page = HomePage(self.driver)
+        self.elements = VolunteerProfilePageLocators()
+        super(VolunteerProfilePage, self).__init__(driver)
+
+    def navigate_to_profile(self):
+        self.home_page.get_volunteer_profile_link().send_keys("\n")
+
+    def edit_profile(self):
+        self.find_link(self.elements.EDIT_PROFILE_TEXT).send_keys("\n")
+
+    def fill_values(self, new_details):
+        elements = self.elements
+        self.fill_field(elements.PROFILE_FIRST_NAME, new_details[0])
+        self.fill_field(elements.PROFILE_LAST_NAME, new_details[1])
+        self.fill_field(elements.PROFILE_EMAIL, new_details[2])
+        self.fill_field(elements.PROFILE_ADDRESS, new_details[3])
+        self.fill_field(elements.PROFILE_CITY, new_details[4])
+        self.fill_field(elements.PROFILE_STATE, new_details[5])
+        self.fill_field(elements.PROFILE_COUNTRY, new_details[6])
+        self.fill_field(elements.PROFILE_PHONE, new_details[7])
+        self.send_value_to_xpath(elements.SELECT_ORGANIZATION, new_details[8])
+        self.fill_field(elements.UNLISTED_ORGANIZATION, new_details[9])
+        self.submit_form()
+
+    def fill_field(self, xpath, value):
+        field = self.element_by_xpath(xpath)
+        field.clear()
+        field.send_keys(value)
+
+    def upload_resume(self, path):
+        self.send_value_to_xpath(self.elements.RESUME_FILE, path)
+
+    def download_resume_text(self):
+        return self.element_by_xpath(self.elements.DOWNLOAD_RESUME).text
+
+    def get_invalid_format_error(self):
+        return self.driver.find_element_by_xpath(self.elements.INVALID_FORMAT_MESSAGE).text
+
+    def submit_form(self):
+        self.element_by_xpath(self.elements.SUBMIT_PATH).submit()   

--- a/vms/pom/pages/volunteerProfilePage.py
+++ b/vms/pom/pages/volunteerProfilePage.py
@@ -42,7 +42,7 @@ class VolunteerProfilePage(BasePage):
         return self.element_by_xpath(self.elements.DOWNLOAD_RESUME).text
 
     def get_invalid_format_error(self):
-        return self.driver.find_element_by_xpath(self.elements.INVALID_FORMAT_MESSAGE).text
+        return self.element_by_xpath(self.elements.INVALID_FORMAT_MESSAGE).text
 
     def submit_form(self):
         self.element_by_xpath(self.elements.SUBMIT_PATH).submit()   

--- a/vms/pom/pages/volunteerRegistrationPage.py
+++ b/vms/pom/pages/volunteerRegistrationPage.py
@@ -5,6 +5,7 @@ from pom.pageUrls import PageUrls
 class VolunteerRegistrationPage(BasePage):
     """Volunteer Registration page action methods here"""
 
+    live_server_url = ''
     volunteer_registration_page = PageUrls.volunteer_registration_page
     success_message = "You have successfully registered!"
 
@@ -45,8 +46,8 @@ class VolunteerRegistrationPage(BasePage):
     def submit_form(self):
         self.element_by_xpath(self.elements.SUBMIT_PATH).submit()   
 
-    def get_volunteer_registration_page(self, base_url):
-        self.get_page(base_url, self.volunteer_registration_page)
+    def get_volunteer_registration_page(self):
+        self.get_page(self.live_server_url, self.volunteer_registration_page)
 
     def get_help_blocks(self):
         blocks = self.elements_by_class_name(self.elements.HELP_BLOCK)
@@ -88,7 +89,7 @@ class VolunteerRegistrationPage(BasePage):
     def get_organization_error_text(self):
         return self.element_by_xpath(self.elements.ORGANIZATION_ERROR ).text
 
-    def register_valid_details(self, base_url):
-        self.get_volunteer_registration_page(base_url)
+    def register_valid_details(self):
+        self.get_volunteer_registration_page()
         entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
         self.fill_registration_form(entry)

--- a/vms/pom/pages/volunteerRegistrationPage.py
+++ b/vms/pom/pages/volunteerRegistrationPage.py
@@ -1,0 +1,93 @@
+from basePage import *
+from pom.locators.volunteerRegistrationPageLocators import *
+
+class VolunteerRegistrationPage(BasePage):
+    """Volunteer Registration page action methods here"""
+
+    volunteer_registration_page = '/registration/signup_volunteer/'
+    success_message = "You have successfully registered!"
+
+    def __init__(self, driver):
+        self.elements = VolunteerRegistrationPageLocators()
+        super(VolunteerRegistrationPage, self).__init__(driver)
+
+    def fill_registration_form(self, info):
+        elements = self.elements
+        self.send_value_to_element_id(elements.USERNAME, info[0])
+        self.send_value_to_element_id(elements.PASSWORD, info[1])
+        self.send_value_to_element_id(elements.FIRST_NAME, info[2])
+        self.send_value_to_element_id(elements.LAST_NAME, info[3])
+        self.send_value_to_element_id(elements.EMAIL, info[4])
+        self.send_value_to_element_id(elements.ADDRESS, info[5])
+        self.send_value_to_element_id(elements.CITY, info[6])
+        self.send_value_to_element_id(elements.STATE, info[7])
+        self.send_value_to_element_id(elements.COUNTRY, info[8])
+        self.send_value_to_element_id(elements.PHONE, info[9])
+        self.send_value_to_element_id(elements.ORGANIZATION, info[10])
+        self.submit_form()
+
+    def get_field_values(self):
+        values = {}
+        elements = self.elements
+        values['username'] = self.get_value_for(elements.USERNAME)
+        values['first_name'] = self.get_value_for(elements.FIRST_NAME)
+        values['last_name'] = self.get_value_for(elements.LAST_NAME)
+        values['email'] = self.get_value_for(elements.EMAIL)
+        values['address'] = self.get_value_for(elements.ADDRESS)
+        values['city'] = self.get_value_for(elements.CITY)
+        values['state'] = self.get_value_for(elements.STATE)
+        values['country'] = self.get_value_for(elements.COUNTRY)
+        values['phone'] = self.get_value_for(elements.PHONE)
+        values['organization'] = self.get_value_for(elements.ORGANIZATION)
+        return values
+
+    def submit_form(self):
+        self.element_by_xpath(self.elements.SUBMIT_PATH).submit()   
+
+    def get_volunteer_registration_page(self, base_url):
+        self.get_page(base_url, self.volunteer_registration_page)
+
+    def get_help_blocks(self):
+        blocks = self.elements_by_class_name(self.elements.HELP_BLOCK)
+        return blocks
+
+    def get_message_box_text(self):
+        return self.element_by_class_name(self.elements.MESSAGES).text
+
+    def get_message_box(self):
+        return self.element_by_class_name(self.elements.MESSAGES)
+
+    def get_username_error_text(self):
+        return self.element_by_xpath(self.elements.USERNAME_ERROR).text
+
+    def get_first_name_error_text(self):
+        return self.element_by_xpath(self.elements.FIRST_NAME_ERROR).text
+
+    def get_last_name_error_text(self):
+        return self.element_by_xpath(self.elements.LAST_NAME_ERROR).text
+
+    def get_address_error_text(self):
+        return self.element_by_xpath(self.elements.ADDRESS_ERROR).text
+
+    def get_city_error_text(self):
+        return self.element_by_xpath(self.elements.CITY_ERROR).text
+
+    def get_state_error_text(self):
+        return self.element_by_xpath(self.elements.STATE_ERROR).text
+
+    def get_country_error_text(self):
+        return self.element_by_xpath(self.elements.COUNTRY_ERROR).text
+
+    def get_email_error_text(self):
+        return self.element_by_xpath(self.elements.EMAIL_ERROR).text
+
+    def get_phone_error_text(self):
+        return self.element_by_xpath(self.elements.PHONE_ERROR).text
+
+    def get_organization_error_text(self):
+        return self.element_by_xpath(self.elements.ORGANIZATION_ERROR ).text
+
+    def register_valid_details(self, base_url):
+        self.get_volunteer_registration_page(base_url)
+        entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
+        self.fill_registration_form(entry)

--- a/vms/pom/pages/volunteerRegistrationPage.py
+++ b/vms/pom/pages/volunteerRegistrationPage.py
@@ -1,10 +1,11 @@
 from basePage import *
 from pom.locators.volunteerRegistrationPageLocators import *
+from pom.pageUrls import PageUrls
 
 class VolunteerRegistrationPage(BasePage):
     """Volunteer Registration page action methods here"""
 
-    volunteer_registration_page = '/registration/signup_volunteer/'
+    volunteer_registration_page = PageUrls.volunteer_registration_page
     success_message = "You have successfully registered!"
 
     def __init__(self, driver):

--- a/vms/pom/pages/volunteerReportPage.py
+++ b/vms/pom/pages/volunteerReportPage.py
@@ -1,0 +1,42 @@
+from basePage import *
+from pom.locators.volunteerReportPageLocators import *
+from selenium.webdriver.support.ui import Select
+from pom.pageUrls import PageUrls
+from pom.pages.homePage import HomePage
+from pom.pages.authenticationPage import AuthenticationPage
+
+class VolunteerReportPage(BasePage):
+
+    no_results_message = 'Your criteria did not return any results.'
+
+    def __init__(self, driver):
+        self.driver = driver
+        self.authentication_page = AuthenticationPage(self.driver)
+        self.home_page = HomePage(self.driver)
+        self.elements = VolunteerReportPageLocators()
+        super(VolunteerReportPage, self).__init__(driver)
+
+    def login_and_navigate_to_report_page(self, base_url):
+        self.authentication_page.login(base_url, { 'username' : 'volunteer', 'password' : 'volunteer'})
+        self.home_page.get_volunteer_report_link().send_keys("\n")
+
+    def get_event_job_selectors(self):
+        select1 = Select(self.element_by_xpath(self.elements.REPORT_EVENT_SELECTOR))
+        select2 = Select(self.element_by_xpath(self.elements.REPORT_JOB_SELECTOR))
+        return (select1, select2)
+
+    def fill_report_form(self, dates):
+        self.element_by_xpath(self.elements.REPORT_START_DATE).clear()
+        self.element_by_xpath(self.elements.REPORT_END_DATE).clear()
+        self.send_value_to_xpath(self.elements.REPORT_START_DATE, dates['start'])
+        self.send_value_to_xpath(self.elements.REPORT_END_DATE, dates['end'])
+        self.submit_form()
+
+    def submit_form(self):
+        self.element_by_xpath(self.elements.SUBMIT_PATH).submit()   
+
+    def get_alert_box_text(self):
+        return self.element_by_class_name(self.elements.NO_RESULT_BOX).text
+
+    def get_shift_summary(self):
+        return self.element_by_xpath(self.elements.REPORT_SHIFT_SUMMARY_PATH).text

--- a/vms/pom/pages/volunteerReportPage.py
+++ b/vms/pom/pages/volunteerReportPage.py
@@ -8,6 +8,7 @@ from pom.pages.authenticationPage import AuthenticationPage
 class VolunteerReportPage(BasePage):
 
     no_results_message = 'Your criteria did not return any results.'
+    live_server_url = ''
 
     def __init__(self, driver):
         self.driver = driver
@@ -16,8 +17,9 @@ class VolunteerReportPage(BasePage):
         self.elements = VolunteerReportPageLocators()
         super(VolunteerReportPage, self).__init__(driver)
 
-    def login_and_navigate_to_report_page(self, base_url):
-        self.authentication_page.login(base_url, { 'username' : 'volunteer', 'password' : 'volunteer'})
+    def login_and_navigate_to_report_page(self):
+        self.authentication_page.server_url = self.live_server_url
+        self.authentication_page.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
         self.home_page.get_volunteer_report_link().send_keys("\n")
 
     def get_event_job_selectors(self):

--- a/vms/pom/pages/volunteerSearchPage.py
+++ b/vms/pom/pages/volunteerSearchPage.py
@@ -1,0 +1,53 @@
+from basePage import *
+from pom.locators.volunteerSearchPageLocators import *
+from pom.pages.authenticationPage import AuthenticationPage
+
+class VolunteerSearchPage(BasePage):
+
+    def __init__(self, driver):
+        self.driver = driver
+        self.authentication_page = AuthenticationPage(self.driver)
+        self.elements = VolunteerSearchPageLocators()
+        super(VolunteerSearchPage, self).__init__(driver)
+
+    def submit_form(self):
+        self.element_by_class_name(self.elements.SUBMIT_PATH).click()
+
+    def send_to_field(self, field, value):
+        text_box = self.find_element_by_css_selector(field)
+        text_box.clear()
+        text_box.send_keys(value)
+
+    def search_first_name_field(self, search_text):
+        self.send_to_field(self.elements.FIRST_NAME_FIELD, search_text)
+
+    def search_last_name_field(self, search_text):
+        self.send_to_field(self.elements.LAST_NAME_FIELD, search_text)
+
+    def search_city_field(self, search_text):
+        self.send_to_field(self.elements.CITY_FIELD, search_text)
+
+    def search_state_field(self, search_text):
+        self.send_to_field(self.elements.STATE_FIELD, search_text)
+
+    def search_country_field(self, search_text):
+        self.send_to_field(self.elements.COUNTRY_FIELD, search_text)
+
+    def search_organization_field(self, search_text):
+        self.send_to_field(self.elements.ORG_FIELD, search_text)
+
+    def get_help_block(self):
+        return self.element_by_class_name(self.elements.HELP_BLOCK)
+
+    def get_search_results(self):
+        search_results = self.element_by_xpath(self.elements.RESULT_BODY)
+        return search_results
+
+    def get_results_list(self, search_results):
+
+        result = []
+        for tr in search_results.find_elements_by_tag_name('tr'):
+            row = tr.text.split()
+            result.append(row)
+
+        return result

--- a/vms/pom/pages/volunteerSearchPage.py
+++ b/vms/pom/pages/volunteerSearchPage.py
@@ -1,8 +1,11 @@
 from basePage import *
 from pom.locators.volunteerSearchPageLocators import *
 from pom.pages.authenticationPage import AuthenticationPage
+from pom.pageUrls import PageUrls
 
 class VolunteerSearchPage(BasePage):
+
+    volunteer_search_page = PageUrls.volunteer_search_page
 
     def __init__(self, driver):
         self.driver = driver

--- a/vms/pom/tests.py
+++ b/vms/pom/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/vms/pom/views.py
+++ b/vms/pom/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/vms/registration/tests/test_functional_admin.py
+++ b/vms/registration/tests/test_functional_admin.py
@@ -3,6 +3,8 @@ from django.contrib.staticfiles.testing import LiveServerTestCase
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
+from pom.pages.adminRegistrationPage import AdminRegistrationPage
+from pom.pageUrls import PageUrls
 import re
 
 from organization.models import Organization
@@ -42,36 +44,10 @@ class SignUpAdmin(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.homepage = '/'
-        cls.admin_registration_page = '/registration/signup_administrator/'
-        cls.authentication_page = '/authentication/login/'
-
-        cls.username = 'id_username'
-        cls.password = 'id_password'
-        cls.first_name = 'id_first_name'
-        cls.last_name = 'id_last_name'
-        cls.email = 'id_email'
-        cls.address = 'id_address'
-        cls.city = 'id_city'
-        cls.state = 'id_state'
-        cls.country = 'id_country'
-        cls.phone = 'id_phone_number'
-        cls.organization = 'id_unlisted_organization'
-
-        cls.username_error = "id('div_id_username')/div/p/strong"
-        cls.first_name_error = "id('div_id_first_name')/div/p/strong"
-        cls.last_name_error = "id('div_id_last_name')/div/p/strong"
-        cls.email_error = "id('div_id_email')/div/p/strong"
-        cls.address_error = "id('div_id_address')/div/p/strong"
-        cls.city_error = "id('div_id_city')/div/p/strong"
-        cls.state_error = "id('div_id_state')/div/p/strong"
-        cls.country_error = "id('div_id_country')/div/p/strong"
-        cls.phone_error = "id('div_id_phone_number')/div/p/strong"
-        cls.organization_error = "id('div_id_unlisted_organization')/div/p/strong"
-
         cls.driver = webdriver.Firefox()
         cls.driver.maximize_window()
         super(SignUpAdmin, cls).setUpClass()
+        cls.page = AdminRegistrationPage(cls.driver)
 
     def setUp(self):
         # create an org prior to registration. Bug in Code
@@ -89,281 +65,247 @@ class SignUpAdmin(LiveServerTestCase):
         cls.driver.quit()
         super(SignUpAdmin, cls).tearDownClass()
 
-    def fill_registration_form(self, info):
-        self.driver.find_element_by_id(self.username).send_keys(info[0])
-        self.driver.find_element_by_id(self.password).send_keys(info[1])
-        self.driver.find_element_by_id(self.first_name).send_keys(info[2])
-        self.driver.find_element_by_id(self.last_name).send_keys(info[3])
-        self.driver.find_element_by_id(self.email).send_keys(info[4])
-        self.driver.find_element_by_id(self.address).send_keys(info[5])
-        self.driver.find_element_by_id(self.city).send_keys(info[6])
-        self.driver.find_element_by_id(self.state).send_keys(info[7])
-        self.driver.find_element_by_id(self.country).send_keys(info[8])
-        self.driver.find_element_by_id(self.phone).send_keys(info[9])
-        self.driver.find_element_by_id(self.organization).send_keys(info[10])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
     def verify_field_values(self, info):
-        self.assertEqual(self.driver.find_element_by_id(self.username).get_attribute('value'),info[0])
-        self.assertEqual(self.driver.find_element_by_id(self.first_name).get_attribute('value'),info[1])
-        self.assertEqual(self.driver.find_element_by_id(self.last_name).get_attribute('value'),info[2])
-        self.assertEqual(self.driver.find_element_by_id(self.email).get_attribute('value'),info[3])
-        self.assertEqual(self.driver.find_element_by_id(self.address).get_attribute('value'),info[4])
-        self.assertEqual(self.driver.find_element_by_id(self.city).get_attribute('value'),info[5])
-        self.assertEqual(self.driver.find_element_by_id(self.state).get_attribute('value'),info[6])
-        self.assertEqual(self.driver.find_element_by_id(self.country).get_attribute('value'),info[7])
-        self.assertEqual(self.driver.find_element_by_id(self.phone).get_attribute('value'),info[8])
-        self.assertEqual(self.driver.find_element_by_id(self.organization).get_attribute('value'),info[9])
-
-    def register_valid_details(self):
-        self.driver.get(self.live_server_url + self.admin_registration_page)
-        entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
-        self.fill_registration_form(entry)
+        page = self.page
+        values = page.get_field_values()
+        self.assertEqual(values['username'],info[0])
+        self.assertEqual(values['first_name'],info[1])
+        self.assertEqual(values['last_name'],info[2])
+        self.assertEqual(values['email'],info[3])
+        self.assertEqual(values['address'],info[4])
+        self.assertEqual(values['city'],info[5])
+        self.assertEqual(values['state'],info[6])
+        self.assertEqual(values['country'],info[7])
+        self.assertEqual(values['phone'],info[8])
+        self.assertEqual(values['organization'],info[9])
 
     def test_null_values(self):
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page = self.page
+        page.live_server_url = self.live_server_url
+        page.get_admin_registration_page()
 
         entry = ['','','','','','','','','','','']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
+        blocks = page.get_help_blocks()
+        self.assertNotEqual(blocks, None)
         # verify that 10 of the fields are compulsory
-        self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
-                10)
+        self.assertEqual(len(blocks),10)
 
     def test_successful_registration(self):
-        self.register_valid_details()
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
+        page = self.page
+        page.live_server_url = self.live_server_url
+        page.register_valid_details()
+        self.assertEqual(page.get_help_blocks(), None)
+        self.assertEqual(page.get_message_box_text(),
+                page.success_message)
 
     def test_name_fields(self):
         # register valid admin user
-        self.register_valid_details()
-
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
+        page = self.page
+        page.live_server_url = self.live_server_url
+        page.register_valid_details()
+        self.assertNotEqual(page.get_message_box(), None)
+        self.assertEqual(page.get_message_box_text(),page.success_message)
 
         # register a user again with username same as already registered user
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
+                PageUrls.homepage)
 
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email1@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.username_error).text,
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_username_error_text(),
                 'User with this Username already exists.')
 
         # test numeric characters in first-name, last-name
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name-1','admin-last-name-1','admin-email1@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.first_name_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.last_name_error).text,
-                'Enter a valid value.')
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_first_name_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_last_name_error_text(),'Enter a valid value.')
 
         # test special characters in first-name, last-name
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username','admin-password!@#$%^&*()_','name-!@#$%^&*()_','name-!@#$%^&*()_','admin-email1@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.first_name_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.last_name_error).text,
-                'Enter a valid value.')
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_first_name_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_last_name_error_text(),'Enter a valid value.')
 
         # test length of first-name, last-name not exceed 30
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name-!@#$%^&*()_','admin-last-name-!@#$%^&*()_','admin-email1@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        error_message = self.driver.find_element_by_xpath(self.first_name_error).text
+        self.assertNotEqual(page.get_help_blocks(),None)
+        error_message = page.get_first_name_error_text()
         self.assertTrue(bool(re.search(r'Ensure this value has at most 20 characters', str(error_message))))
 
-        error_message = self.driver.find_element_by_xpath(self.last_name_error).text,
+        error_message = page.get_last_name_error_text()
         self.assertTrue(bool(re.search(r'Ensure this value has at most 20 characters', str(error_message))))
 
     def test_location_fields(self):
         # test numeric characters in address, city, state, country
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page = self.page
+        page.live_server_url = self.live_server_url
+        page.get_admin_registration_page()
 
         entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','email1@systers.org','123 New-City address','1 admin-city','007 admin-state','54 admin-country','9999999999','admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
+        self.assertNotEqual(page.get_help_blocks(),None)
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.admin_registration_page)
+                page.admin_registration_page)
 
         #verify that messages are displayed for city, state and country but not address
-        self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
-                3)
-        self.assertEqual(self.driver.find_element_by_xpath(self.city_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.state_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.country_error).text,
-                'Enter a valid value.')
+        self.assertEqual(len(page.get_help_blocks()),3)
+        self.assertEqual(page.get_city_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_state_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_country_error_text(),'Enter a valid value.')
 
         # test special characters in address, city, state, country
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username-2','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','email2@systers.org','admin-address!@#$()','!$@%^#&admin-city','!$@%^#&admin-state','&%^*admin-country!@$#','9999999999','admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
+        self.assertNotEqual(page.get_help_blocks(),None)
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.admin_registration_page)
+                page.admin_registration_page)
 
         # verify that messages are displayed for all fields
-        self.assertEqual(self.driver.find_element_by_xpath(self.address_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.city_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.state_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.country_error).text,
-                'Enter a valid value.')
+        self.assertEqual(page.get_address_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_city_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_state_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_country_error_text(),'Enter a valid value.')
 
     def test_email_field(self):
 
+        page = self.page
+        page.live_server_url = self.live_server_url
         # register valid admin user
-        self.register_valid_details()
+        page.register_valid_details()
 
         # verify successful registration
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
+        self.assertNotEqual(page.get_message_box(),None)
+        self.assertEqual(page.get_message_box_text(),page.success_message)
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
+                PageUrls.homepage)
 
         # Try to register admin again with same email address
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.admin_registration_page)
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.email_error).text,
+                page.admin_registration_page)
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_email_error_text(),
                 'Administrator with this Email already exists.')
 
     def test_phone_field(self):
 
+        page = self.page
+        page.live_server_url = self.live_server_url
         # register valid admin user with valid phone number for country
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email@systers.org','admin-address','admin-city','admin-state','India','022 2403 6606','admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify successful registration
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
+        self.assertNotEqual(page.get_message_box(),None)
+        self.assertEqual(page.get_message_box_text(),page.success_message)
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
+                PageUrls.homepage)
 
         # Try to register admin with incorrect phone number for country
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email1@systers.org','admin-address','admin-city','admin-state','India','237937913','admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.admin_registration_page)
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.phone_error).text,
+                page.admin_registration_page)
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_phone_error_text(),
                 "This phone number isn't valid for the selected country")
 
         # Use invalid characters in phone number
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','admin-email1@systers.org','admin-address','admin-city','admin-state','India','23&79^37913','admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.admin_registration_page)
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.phone_error).text,
-                "Please enter a valid phone number")
+                page.admin_registration_page)
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_phone_error_text(),"Please enter a valid phone number")
 
     def test_organization_field(self):
 
+        page = self.page
+        page.live_server_url = self.live_server_url
         # test numeric characters in organization
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username-1','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','email1@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','13 admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify successful registration
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
+        self.assertNotEqual(page.get_message_box(),None)
+        self.assertEqual(page.get_message_box_text(),page.success_message)
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
+                PageUrls.homepage)
 
         # Use invalid characters in organization
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username-2','admin-password!@#$%^&*()_','admin-first-name','admin-last-name','email2@systers.org','admin-address','admin-city','admin-state','admin-country','9999999999','!$&admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.admin_registration_page)
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.organization_error).text,
-                "Enter a valid value.")
+                page.admin_registration_page)
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_organization_error_text(),"Enter a valid value.")
 
     def test_field_value_retention(self):
 
+        page = self.page
+        page.live_server_url = self.live_server_url
         # send invalid value in fields - first name, state, phone, organization
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name-3','admin-last-name','email1@systers.org','admin-address','admin-city','admin-state','admin-country','99999.!9999','@#admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that user wasn't registered and that field values are not erased
+        self.assertEqual(self.driver.current_url, self.live_server_url + page.admin_registration_page)
         details = ['admin-username','admin-first-name-3','admin-last-name','email1@systers.org','admin-address','admin-city','admin-state','admin-country','99999.!9999','@#admin-org']
         self.verify_field_values(details)
 
         # send invalid value in fields - last name, address, city, country
-        self.driver.get(self.live_server_url + self.admin_registration_page)
+        page.get_admin_registration_page()
 
         entry = ['admin-username','admin-password!@#$%^&*()_','admin-first-name','admin-last-name-3','email1@systers.org','admin-address$@!','admin-city#$','admin-state','admin-country 15','99999.!9999','@#admin-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that user wasn't registered and that field values are not erased
+        self.assertEqual(self.driver.current_url, self.live_server_url + page.admin_registration_page)
         details = ['admin-username','admin-first-name','admin-last-name-3','email1@systers.org','admin-address$@!','admin-city#$','admin-state','admin-country 15','99999.!9999','@#admin-org']
         self.verify_field_values(details)

--- a/vms/registration/tests/test_functional_admin.py
+++ b/vms/registration/tests/test_functional_admin.py
@@ -8,6 +8,9 @@ from pom.pageUrls import PageUrls
 import re
 
 from organization.models import Organization
+from django.contrib.auth.models import User
+from administrator.models import Administrator
+
 from shift.utils import create_organization, create_country
 
 class SignUpAdmin(LiveServerTestCase):
@@ -92,6 +95,10 @@ class SignUpAdmin(LiveServerTestCase):
         # verify that 10 of the fields are compulsory
         self.assertEqual(len(blocks),10)
 
+        # database check to verify that user, administrator are not created
+        self.assertEqual(len(User.objects.all()),0)
+        self.assertEqual(len(Administrator.objects.all()),0)
+
     def test_successful_registration(self):
         page = self.page
         page.live_server_url = self.live_server_url
@@ -99,6 +106,16 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(page.get_help_blocks(), None)
         self.assertEqual(page.get_message_box_text(),
                 page.success_message)
+
+        # database check to verify that user, administrator are created with correct credentials
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Administrator.objects.all()),1)
+
+        # check that empty list not returned for added filters
+        self.assertNotEqual(len(User.objects.filter(
+            username='admin-username')), 0)
+        self.assertNotEqual(len(Administrator.objects.filter(
+            email='admin-email@systers.org')), 0)
 
     def test_name_fields(self):
         # register valid admin user
@@ -121,6 +138,10 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(page.get_username_error_text(),
                 'User with this Username already exists.')
 
+        # database check to verify that new user, administrator are not created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Administrator.objects.all()),1)
+
         # test numeric characters in first-name, last-name
         page.get_admin_registration_page()
 
@@ -131,6 +152,10 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(page.get_first_name_error_text(),'Enter a valid value.')
         self.assertEqual(page.get_last_name_error_text(),'Enter a valid value.')
 
+        # database check to verify that new user, administrator are not created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Administrator.objects.all()),1)
+
         # test special characters in first-name, last-name
         page.get_admin_registration_page()
 
@@ -140,6 +165,10 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertNotEqual(page.get_help_blocks(),None)
         self.assertEqual(page.get_first_name_error_text(),'Enter a valid value.')
         self.assertEqual(page.get_last_name_error_text(),'Enter a valid value.')
+
+        # database check to verify that new user, administrator are not created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Administrator.objects.all()),1)
 
         # test length of first-name, last-name not exceed 30
         page.get_admin_registration_page()
@@ -153,6 +182,10 @@ class SignUpAdmin(LiveServerTestCase):
 
         error_message = page.get_last_name_error_text()
         self.assertTrue(bool(re.search(r'Ensure this value has at most 20 characters', str(error_message))))
+
+        # database check to verify that new user, administrator are not created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Administrator.objects.all()),1)
 
     def test_location_fields(self):
         # test numeric characters in address, city, state, country
@@ -173,6 +206,10 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(page.get_state_error_text(),'Enter a valid value.')
         self.assertEqual(page.get_country_error_text(),'Enter a valid value.')
 
+        # database check to verify that user, administrator is not created
+        self.assertEqual(len(User.objects.all()),0)
+        self.assertEqual(len(Administrator.objects.all()),0)
+
         # test special characters in address, city, state, country
         page.get_admin_registration_page()
 
@@ -188,6 +225,10 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(page.get_city_error_text(),'Enter a valid value.')
         self.assertEqual(page.get_state_error_text(),'Enter a valid value.')
         self.assertEqual(page.get_country_error_text(),'Enter a valid value.')
+
+        # database check to verify that user, administrator is not created
+        self.assertEqual(len(User.objects.all()),0)
+        self.assertEqual(len(Administrator.objects.all()),0)
 
     def test_email_field(self):
 
@@ -215,6 +256,10 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(page.get_email_error_text(),
                 'Administrator with this Email already exists.')
 
+        # database check to verify that no user, administrator is created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Administrator.objects.all()),1)
+
     def test_phone_field(self):
 
         page = self.page
@@ -231,6 +276,10 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 PageUrls.homepage)
 
+        # database check to verify that user, administrator is created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Administrator.objects.all()),1)
+
         # Try to register admin with incorrect phone number for country
         page.get_admin_registration_page()
 
@@ -244,6 +293,10 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(page.get_phone_error_text(),
                 "This phone number isn't valid for the selected country")
 
+        # database check to verify that no new user, administrator is created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Administrator.objects.all()),1)
+
         # Use invalid characters in phone number
         page.get_admin_registration_page()
 
@@ -255,6 +308,10 @@ class SignUpAdmin(LiveServerTestCase):
                 page.admin_registration_page)
         self.assertNotEqual(page.get_help_blocks(),None)
         self.assertEqual(page.get_phone_error_text(),"Please enter a valid phone number")
+
+        # database check to verify that no new user, administrator is created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Administrator.objects.all()),1)
 
     def test_organization_field(self):
 
@@ -272,6 +329,10 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 PageUrls.homepage)
 
+        # database check to verify that user, administrator is created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Administrator.objects.all()),1)
+
         # Use invalid characters in organization
         page.get_admin_registration_page()
 
@@ -283,6 +344,10 @@ class SignUpAdmin(LiveServerTestCase):
                 page.admin_registration_page)
         self.assertNotEqual(page.get_help_blocks(),None)
         self.assertEqual(page.get_organization_error_text(),"Enter a valid value.")
+
+        # database check to verify that no new user, administrator is created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Administrator.objects.all()),1)
 
     def test_field_value_retention(self):
 
@@ -299,6 +364,10 @@ class SignUpAdmin(LiveServerTestCase):
         details = ['admin-username','admin-first-name-3','admin-last-name','email1@systers.org','admin-address','admin-city','admin-state','admin-country','99999.!9999','@#admin-org']
         self.verify_field_values(details)
 
+        # database check to verify that no user, administrator is created
+        self.assertEqual(len(User.objects.all()),0)
+        self.assertEqual(len(Administrator.objects.all()),0)
+
         # send invalid value in fields - last name, address, city, country
         page.get_admin_registration_page()
 
@@ -309,3 +378,7 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(self.driver.current_url, self.live_server_url + page.admin_registration_page)
         details = ['admin-username','admin-first-name','admin-last-name-3','email1@systers.org','admin-address$@!','admin-city#$','admin-state','admin-country 15','99999.!9999','@#admin-org']
         self.verify_field_values(details)
+
+        # database check to verify that no user, administrator is created
+        self.assertEqual(len(User.objects.all()),0)
+        self.assertEqual(len(Administrator.objects.all()),0)

--- a/vms/registration/tests/test_functional_volunteer.py
+++ b/vms/registration/tests/test_functional_volunteer.py
@@ -8,6 +8,8 @@ from pom.pageUrls import PageUrls
 import re
 
 from organization.models import Organization
+from django.contrib.auth.models import User
+from volunteer.models import Volunteer
 from shift.utils import create_organization, create_country
 
 class SignUpVolunteer(LiveServerTestCase):
@@ -91,6 +93,10 @@ class SignUpVolunteer(LiveServerTestCase):
         # verify that all of the fields are compulsory
         self.assertEqual(len(blocks),11)
 
+        # database check to verify that user, volunteer are not created
+        self.assertEqual(len(User.objects.all()),0)
+        self.assertEqual(len(Volunteer.objects.all()),0)
+
     def test_successful_registration(self):
         page = self.page
         page.live_server_url = self.live_server_url
@@ -98,6 +104,16 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(page.get_help_blocks(), None)
         self.assertEqual(page.get_message_box_text(),
                 page.success_message)
+
+        # database check to verify that user, volunteer created and their credentials
+        self.assertEqual(len(User.objects.all()),1 )
+        self.assertEqual(len(Volunteer.objects.all()),1)
+
+        # check that empty list not returned for added filters
+        self.assertNotEqual(len(User.objects.filter(
+            username='volunteer-username')), 0)
+        self.assertNotEqual(len(Volunteer.objects.filter(
+            email='volunteer-email@systers.org')), 0)
 
     def test_name_fields(self):
         # register valid volunteer user
@@ -120,6 +136,10 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(page.get_username_error_text(),
                 'User with this Username already exists.')
 
+        # database check to verify that only 1 user, volunteer exists
+        self.assertEqual(len(User.objects.all()),1 )
+        self.assertEqual(len(Volunteer.objects.all()),1)
+
         # test numeric characters in first-name, last-name
         page.get_volunteer_registration_page()
 
@@ -130,6 +150,10 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(page.get_first_name_error_text(),'Enter a valid value.')
         self.assertEqual(page.get_last_name_error_text(),'Enter a valid value.')
 
+        # database check to verify that only 1 user, volunteer exists
+        self.assertEqual(len(User.objects.all()),1 )
+        self.assertEqual(len(Volunteer.objects.all()),1)
+
         # test special characters in first-name, last-name
         page.get_volunteer_registration_page()
 
@@ -139,6 +163,10 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertNotEqual(page.get_help_blocks(),None)
         self.assertEqual(page.get_first_name_error_text(),'Enter a valid value.')
         self.assertEqual(page.get_last_name_error_text(),'Enter a valid value.')
+
+        # database check to verify that only 1 user, volunteer exists
+        self.assertEqual(len(User.objects.all()),1 )
+        self.assertEqual(len(Volunteer.objects.all()),1)
 
         # test length of first-name, last-name not exceed 30
         page.get_volunteer_registration_page()
@@ -152,6 +180,10 @@ class SignUpVolunteer(LiveServerTestCase):
 
         error_message = page.get_last_name_error_text()
         self.assertTrue(bool(re.search(r'Ensure this value has at most 30 characters', str(error_message))))
+
+        # database check to verify that only 1 user, volunteer exists
+        self.assertEqual(len(User.objects.all()),1 )
+        self.assertEqual(len(Volunteer.objects.all()),1)
 
     def test_location_fields(self):
         # test numeric characters in address, city, state, country
@@ -173,6 +205,10 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(page.get_state_error_text(),'Enter a valid value.')
         self.assertEqual(page.get_country_error_text(),'Enter a valid value.')
 
+        # database check to verify that no user, volunteer created
+        self.assertEqual(len(User.objects.all()),0)
+        self.assertEqual(len(Volunteer.objects.all()),0)
+
         # Test special characters in address, city, state, country
         page.get_volunteer_registration_page()
 
@@ -188,6 +224,10 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(page.get_city_error_text(),'Enter a valid value.')
         self.assertEqual(page.get_state_error_text(),'Enter a valid value.')
         self.assertEqual(page.get_country_error_text(),'Enter a valid value.')
+
+        # database check to verify that no user, volunteer created
+        self.assertEqual(len(User.objects.all()),0)
+        self.assertEqual(len(Volunteer.objects.all()),0)
 
     def test_email_field(self):
 
@@ -214,6 +254,10 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertNotEqual(page.get_help_blocks(),None)
         self.assertEqual(page.get_email_error_text(),'Volunteer with this Email already exists.')
 
+        # database check to verify that no new user, volunteer created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Volunteer.objects.all()),1)
+
     def test_phone_field(self):
 
         page = self.page
@@ -230,6 +274,10 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 PageUrls.homepage)
 
+        # database check to verify that user, volunteer created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Volunteer.objects.all()),1)
+
         # Try to register volunteer with incorrect phone number for country
         page.get_volunteer_registration_page()
 
@@ -243,6 +291,10 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(page.get_phone_error_text(),
                 "This phone number isn't valid for the selected country")
 
+        # database check to verify that no new user, volunteer created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Volunteer.objects.all()),1)
+
         # Use invalid characters in phone number
         page.get_volunteer_registration_page()
 
@@ -254,6 +306,10 @@ class SignUpVolunteer(LiveServerTestCase):
                 page.volunteer_registration_page)
         self.assertNotEqual(page.get_help_blocks(),None)
         self.assertEqual(page.get_phone_error_text(),"Please enter a valid phone number")
+
+        # database check to verify that no new user, volunteer created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Volunteer.objects.all()),1)
 
     def test_organization_field(self):
 
@@ -271,6 +327,10 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(self.driver.current_url, self.live_server_url +
                 PageUrls.homepage)
 
+        # database check to verify that user, volunteer created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Volunteer.objects.all()),1)
+
         # Use invalid characters in organization
         page.get_volunteer_registration_page()
 
@@ -282,6 +342,10 @@ class SignUpVolunteer(LiveServerTestCase):
                 page.volunteer_registration_page)
         self.assertNotEqual(page.get_help_blocks(),None)
         self.assertEqual(page.get_organization_error_text(),"Enter a valid value.")
+
+        # database check to verify that no new user, volunteer created
+        self.assertEqual(len(User.objects.all()),1)
+        self.assertEqual(len(Volunteer.objects.all()),1)
 
     def test_field_value_retention(self):
 
@@ -298,6 +362,10 @@ class SignUpVolunteer(LiveServerTestCase):
         details = ['volunteer-username','volunteer-first-name-3','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state!','volunteer-country','99999.!9999','@#volunteer-org']
         self.verify_field_values(details) 
 
+        # database check to verify that no user, volunteer created
+        self.assertEqual(len(User.objects.all()),0)
+        self.assertEqual(len(Volunteer.objects.all()),0)
+
         # send invalid value in fields - last name, address, city, country
         page.get_volunteer_registration_page()
 
@@ -308,3 +376,7 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(self.driver.current_url, self.live_server_url + page.volunteer_registration_page)
         details = ['volunteer-username','volunteer-first-name','volunteer-last-name-3','volunteer-email@systers.org','volunteer-address$@!','volunteer-city#$','volunteer-state','volunteer-country 15','9999999999','volunteer-org']
         self.verify_field_values(details)
+
+        # database check to verify that no user, volunteer created
+        self.assertEqual(len(User.objects.all()),0)
+        self.assertEqual(len(Volunteer.objects.all()),0)

--- a/vms/registration/tests/test_functional_volunteer.py
+++ b/vms/registration/tests/test_functional_volunteer.py
@@ -3,6 +3,8 @@ from django.contrib.staticfiles.testing import LiveServerTestCase
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
+from pom.pages.volunteerRegistrationPage import VolunteerRegistrationPage
+from pom.pageUrls import PageUrls
 import re
 
 from organization.models import Organization
@@ -41,35 +43,9 @@ class SignUpVolunteer(LiveServerTestCase):
     '''
     @classmethod
     def setUpClass(cls):
-        cls.homepage = '/'
-        cls.volunteer_registration_page = '/registration/signup_volunteer/'
-        cls.authentication_page = '/authentication/login/'
-
-        cls.username = 'id_username'
-        cls.password = 'id_password'
-        cls.first_name = 'id_first_name'
-        cls.last_name = 'id_last_name'
-        cls.email = 'id_email'
-        cls.address = 'id_address'
-        cls.city = 'id_city'
-        cls.state = 'id_state'
-        cls.country = 'id_country'
-        cls.phone = 'id_phone_number'
-        cls.organization = 'id_unlisted_organization'
-
-        cls.username_error = "id('div_id_username')/div/p/strong"
-        cls.first_name_error = "id('div_id_first_name')/div/p/strong"
-        cls.last_name_error = "id('div_id_last_name')/div/p/strong"
-        cls.email_error = "id('div_id_email')/div/p/strong"
-        cls.address_error = "id('div_id_address')/div/p/strong"
-        cls.city_error = "id('div_id_city')/div/p/strong"
-        cls.state_error = "id('div_id_state')/div/p/strong"
-        cls.country_error = "id('div_id_country')/div/p/strong"
-        cls.phone_error = "id('div_id_phone_number')/div/p/strong"
-        cls.organization_error = "id('div_id_unlisted_organization')/div/p/strong"
-
         cls.driver = webdriver.Firefox()
         cls.driver.maximize_window()
+        cls.page = VolunteerRegistrationPage(cls.driver)
         super(SignUpVolunteer, cls).setUpClass()
 
     def setUp(self):
@@ -88,285 +64,247 @@ class SignUpVolunteer(LiveServerTestCase):
         cls.driver.quit()
         super(SignUpVolunteer, cls).tearDownClass()
 
-    def fill_registration_form(self, info):
-        self.driver.find_element_by_id(self.username).send_keys(info[0])
-        self.driver.find_element_by_id(self.password).send_keys(info[1])
-        self.driver.find_element_by_id(self.first_name).send_keys(info[2])
-        self.driver.find_element_by_id(self.last_name).send_keys(info[3])
-        self.driver.find_element_by_id(self.email).send_keys(info[4])
-        self.driver.find_element_by_id(self.address).send_keys(info[5])
-        self.driver.find_element_by_id(self.city).send_keys(info[6])
-        self.driver.find_element_by_id(self.state).send_keys(info[7])
-        self.driver.find_element_by_id(self.country).send_keys(info[8])
-        self.driver.find_element_by_id(self.phone).send_keys(info[9])
-        self.driver.find_element_by_id(self.organization).send_keys(info[10])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
     def verify_field_values(self, info):
-        self.assertEqual(self.driver.find_element_by_id(self.username).get_attribute('value'),info[0])
-        self.assertEqual(self.driver.find_element_by_id(self.first_name).get_attribute('value'),info[1])
-        self.assertEqual(self.driver.find_element_by_id(self.last_name).get_attribute('value'),info[2])
-        self.assertEqual(self.driver.find_element_by_id(self.email).get_attribute('value'),info[3])
-        self.assertEqual(self.driver.find_element_by_id(self.address).get_attribute('value'),info[4])
-        self.assertEqual(self.driver.find_element_by_id(self.city).get_attribute('value'),info[5])
-        self.assertEqual(self.driver.find_element_by_id(self.state).get_attribute('value'),info[6])
-        self.assertEqual(self.driver.find_element_by_id(self.country).get_attribute('value'),info[7])
-        self.assertEqual(self.driver.find_element_by_id(self.phone).get_attribute('value'),info[8])
-        self.assertEqual(self.driver.find_element_by_id(self.organization).get_attribute('value'),info[9])
-
-    def register_valid_details(self):
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
-        entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
-        self.fill_registration_form(entry)
+        page = self.page
+        values = page.get_field_values()
+        self.assertEqual(values['username'],info[0])
+        self.assertEqual(values['first_name'],info[1])
+        self.assertEqual(values['last_name'],info[2])
+        self.assertEqual(values['email'],info[3])
+        self.assertEqual(values['address'],info[4])
+        self.assertEqual(values['city'],info[5])
+        self.assertEqual(values['state'],info[6])
+        self.assertEqual(values['country'],info[7])
+        self.assertEqual(values['phone'],info[8])
+        self.assertEqual(values['organization'],info[9])
 
     def test_null_values(self):
-        self.driver.get(self.live_server_url
-                        + self.volunteer_registration_page)
+        page = self.page
+        page.live_server_url = self.live_server_url
+        page.get_volunteer_registration_page()
 
         entry = ['','','','','','','','','','','']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
+        blocks = page.get_help_blocks()
+        self.assertNotEqual(blocks, None)
         # verify that all of the fields are compulsory
-        self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
-                11)
+        self.assertEqual(len(blocks),11)
 
     def test_successful_registration(self):
-        self.register_valid_details()
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
+        page = self.page
+        page.live_server_url = self.live_server_url
+        page.register_valid_details()
+        self.assertEqual(page.get_help_blocks(), None)
+        self.assertEqual(page.get_message_box_text(),
+                page.success_message)
 
     def test_name_fields(self):
         # register valid volunteer user
-        self.register_valid_details()
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
+        page = self.page
+        page.live_server_url = self.live_server_url
+        page.register_valid_details()
+        self.assertNotEqual(page.get_message_box(), None)
+        self.assertEqual(page.get_message_box_text(),page.success_message)
 
         # register a user again with username same as already registered user
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
+                PageUrls.homepage)
 
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email1@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.username_error).text,
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_username_error_text(),
                 'User with this Username already exists.')
 
         # test numeric characters in first-name, last-name
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name-1','volunteer-last-name-1','volunteer-email1@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.first_name_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.last_name_error).text,
-                'Enter a valid value.')
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_first_name_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_last_name_error_text(),'Enter a valid value.')
 
         # test special characters in first-name, last-name
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
-        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','first-name-!@#$%^&*()_','last-name!@#$%^&*()_','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
-        self.fill_registration_form(entry)
+        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','first-name-!@#$%^&*()_','last-name!@#$%^&*()_','volunteer-email3@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.first_name_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.last_name_error).text,
-                'Enter a valid value.')
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_first_name_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_last_name_error_text(),'Enter a valid value.')
 
         # test length of first-name, last-name not exceed 30
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
-        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name-long-asdfghjkl','volunteer-last-name-long-asdfghjkl','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
-        self.fill_registration_form(entry)
+        entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name-long-asdfghjkl','volunteer-last-name-long-asdfghjkl','volunteer-email4@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        error_message = self.driver.find_element_by_xpath(self.first_name_error).text
+        self.assertNotEqual(page.get_help_blocks(),None)
+        error_message = page.get_first_name_error_text()
         self.assertTrue(bool(re.search(r'Ensure this value has at most 30 characters', str(error_message))))
 
-        error_message = self.driver.find_element_by_xpath(self.last_name_error).text,
+        error_message = page.get_last_name_error_text()
         self.assertTrue(bool(re.search(r'Ensure this value has at most 30 characters', str(error_message))))
 
     def test_location_fields(self):
         # test numeric characters in address, city, state, country
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page = self.page
+        page.live_server_url = self.live_server_url
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email1@systers.org','123 New-City address','1 volunteer-city','007 volunteer-state','54 volunteer-country','9999999999','volunteer-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
+        self.assertNotEqual(page.get_help_blocks(),None)
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.volunteer_registration_page)
+                page.volunteer_registration_page)
 
         # Verify that messages are displayed for city, state and country but not address
         # Test commented out as there is a bug in the template
-        """self.assertEqual(len(self.driver.find_elements_by_class_name('help-block')),
-                3)"""
-        self.assertEqual(self.driver.find_element_by_xpath(self.city_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.state_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.country_error).text,
-                'Enter a valid value.')
+        # self.assertEqual(len(page.get_help_blocks()),3)
+        self.assertEqual(page.get_city_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_state_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_country_error_text(),'Enter a valid value.')
 
         # Test special characters in address, city, state, country
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username-2','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email2@systers.org','volunteer-address!@#$()','!$@%^#&volunteer-city','!$@%^#&volunteer-state','&%^*volunteer-country!@$#','9999999999','volunteer-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
+        self.assertNotEqual(page.get_help_blocks(),None)
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.volunteer_registration_page)
+                page.volunteer_registration_page)
 
         # verify that messages are displayed for all fields
-        self.assertEqual(self.driver.find_element_by_xpath(self.address_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.city_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.state_error).text,
-                'Enter a valid value.')
-        self.assertEqual(self.driver.find_element_by_xpath(self.country_error).text,
-                'Enter a valid value.')
+        self.assertEqual(page.get_address_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_city_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_state_error_text(),'Enter a valid value.')
+        self.assertEqual(page.get_country_error_text(),'Enter a valid value.')
 
     def test_email_field(self):
 
+        page = self.page
+        page.live_server_url = self.live_server_url
         # register valid volunteer user
-        self.register_valid_details()
+        page.register_valid_details()
 
         # verify successful registration
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
+        self.assertNotEqual(page.get_message_box(),None)
+        self.assertEqual(page.get_message_box_text(),page.success_message)
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
+                PageUrls.homepage)
 
         # Try to register volunteer again with same email address
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that volunteer wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.volunteer_registration_page)
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.email_error).text,
-                'Volunteer with this Email already exists.')
+                page.volunteer_registration_page)
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_email_error_text(),'Volunteer with this Email already exists.')
 
     def test_phone_field(self):
 
+        page = self.page
+        page.live_server_url = self.live_server_url
         # register valid volunteer user with valid phone number for country
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify successful registration
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
+        self.assertNotEqual(page.get_message_box(),None)
+        self.assertEqual(page.get_message_box_text(),page.success_message)
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
+                PageUrls.homepage)
 
         # Try to register volunteer with incorrect phone number for country
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email1@systers.org','volunteer-address','volunteer-city','volunteer-state','India','237937913','volunteer-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.volunteer_registration_page)
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.phone_error).text,
+                page.volunteer_registration_page)
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_phone_error_text(),
                 "This phone number isn't valid for the selected country")
 
         # Use invalid characters in phone number
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email1@systers.org','volunteer-address','volunteer-city','volunteer-state','India','23&79^37913','volunteer-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.volunteer_registration_page)
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.phone_error).text,
-                "Please enter a valid phone number")
+                page.volunteer_registration_page)
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_phone_error_text(),"Please enter a valid phone number")
 
     def test_organization_field(self):
 
+        page = self.page
+        page.live_server_url = self.live_server_url
         # test numeric characters in organization
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username-1','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email1@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','volunteer-org 13']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify successful registration
-        self.assertNotEqual(self.driver.find_elements_by_class_name('messages'),
-                None)
-        self.assertEqual(self.driver.find_element_by_class_name('messages').text,
-                'You have successfully registered!')
+        self.assertNotEqual(page.get_message_box(),None)
+        self.assertEqual(page.get_message_box_text(),page.success_message)
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.homepage)
+                PageUrls.homepage)
 
         # Use invalid characters in organization
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username-2','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name','volunteer-email2@systers.org','volunteer-address','volunteer-city','volunteer-state','volunteer-country','9999999999','!*^$volunteer-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that user wasn't registered
         self.assertEqual(self.driver.current_url, self.live_server_url +
-                self.volunteer_registration_page)
-        self.assertNotEqual(self.driver.find_elements_by_class_name('help-block'),
-                None)
-        self.assertEqual(self.driver.find_element_by_xpath(self.organization_error).text,
-                "Enter a valid value.")
+                page.volunteer_registration_page)
+        self.assertNotEqual(page.get_help_blocks(),None)
+        self.assertEqual(page.get_organization_error_text(),"Enter a valid value.")
 
     def test_field_value_retention(self):
 
+        page = self.page
+        page.live_server_url = self.live_server_url
         # send invalid value in fields - first name, state, phone, organization
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name-3','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state!','volunteer-country','99999.!9999','@#volunteer-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that user wasn't registered and that field values are not erased
-        self.assertEqual(self.driver.current_url, self.live_server_url + self.volunteer_registration_page)
+        self.assertEqual(self.driver.current_url, self.live_server_url + page.volunteer_registration_page)
         details = ['volunteer-username','volunteer-first-name-3','volunteer-last-name','volunteer-email@systers.org','volunteer-address','volunteer-city','volunteer-state!','volunteer-country','99999.!9999','@#volunteer-org']
-        self.verify_field_values(details)
-        
+        self.verify_field_values(details) 
 
         # send invalid value in fields - last name, address, city, country
-        self.driver.get(self.live_server_url + self.volunteer_registration_page)
+        page.get_volunteer_registration_page()
 
         entry = ['volunteer-username','volunteer-password!@#$%^&*()_','volunteer-first-name','volunteer-last-name-3','volunteer-email@systers.org','volunteer-address$@!','volunteer-city#$','volunteer-state','volunteer-country 15','9999999999','volunteer-org']
-        self.fill_registration_form(entry)
+        page.fill_registration_form(entry)
 
         # verify that user wasn't registered and that field values are not erased
-        self.assertEqual(self.driver.current_url, self.live_server_url + self.volunteer_registration_page)
+        self.assertEqual(self.driver.current_url, self.live_server_url + page.volunteer_registration_page)
         details = ['volunteer-username','volunteer-first-name','volunteer-last-name-3','volunteer-email@systers.org','volunteer-address$@!','volunteer-city#$','volunteer-state','volunteer-country 15','9999999999','volunteer-org']
         self.verify_field_values(details)

--- a/vms/shift/tests/test_manageVolunteerShift.py
+++ b/vms/shift/tests/test_manageVolunteerShift.py
@@ -7,6 +7,7 @@ from pom.pages.manageShiftPage import ManageShiftPage
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
+from shift.models import VolunteerShift, Shift
 from shift.utils import (
     create_admin,
     create_volunteer_with_details,
@@ -245,6 +246,11 @@ class ManageVolunteerShift(LiveServerTestCase):
         manage_shift_page.select_volunteer(1)
         self.check_job_details(['job name', 'May 20, 2017', '9 a.m.', '3 p.m.'])
 
+        # database check to ensure volunteer has been assigned the shift
+        self.assertEqual(len(VolunteerShift.objects.all()), 1)
+        self.assertNotEqual(len(VolunteerShift.objects.filter(
+            volunteer_id=v1.id, shift_id = s1.id)), 0)
+
     def test_slots_remaining_in_shift(self):
         sign_up_page = self.sign_up_page
         manage_shift_page = self.manage_shift_page
@@ -336,6 +342,9 @@ class ManageVolunteerShift(LiveServerTestCase):
         manage_shift_page.select_volunteer(1)
         self.check_job_details(['job name', 'May 20, 2017', '9 a.m.', '3 p.m.'])
 
+        # database check to ensure volunteer is registered
+        self.assertEqual(len(VolunteerShift.objects.all()), 1)
+
         # cancel assigned shift
         self.assertEqual(manage_shift_page.get_cancel_shift().text, 'Cancel Shift Registration')
         manage_shift_page.cancel_shift()
@@ -355,6 +364,9 @@ class ManageVolunteerShift(LiveServerTestCase):
         slots_after_cancellation = sign_up_page.get_remaining_slots()
         self.assertEqual(slots_remaining_before_assignment,
                 slots_after_cancellation)
+
+        # database check to ensure registration is cancelled
+        self.assertEqual(len(VolunteerShift.objects.all()), 0)
 
     def test_assign_same_shift_to_volunteer_twice(self):
         sign_up_page = self.sign_up_page

--- a/vms/shift/tests/test_manageVolunteerShift.py
+++ b/vms/shift/tests/test_manageVolunteerShift.py
@@ -1,5 +1,9 @@
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
+from pom.pages.eventSignUpPage import EventSignUpPage
+from pom.pages.authenticationPage import AuthenticationPage
+from pom.pages.manageShiftPage import ManageShiftPage
+
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
@@ -10,7 +14,6 @@ from shift.utils import (
     create_job_with_details,
     create_shift_with_details
     )
-
 
 class ManageVolunteerShift(LiveServerTestCase):
     '''
@@ -41,10 +44,6 @@ class ManageVolunteerShift(LiveServerTestCase):
     '''
     @classmethod
     def setUpClass(cls):
-        cls.homepage = '/'
-        cls.shift_page = '/shift/volunteer_search/'
-        cls.authentication_page = '/authentication/login/'
-        cls.settings_page = '/event/list/'
 
         cls.volunteer_1 = ['volunteer-one', 'volunteer-one', 'volunteer-one',
                 'volunteer-one', 'volunteer-one', 'volunteer-one', 'volunteer-one',
@@ -53,23 +52,17 @@ class ManageVolunteerShift(LiveServerTestCase):
                 'volunteer-two', 'volunteer-two', 'volunteer-two', 'volunteer-two',
                 '9999999999', 'volunteer-email2@systers.org', 'volunteer-two']
 
-        cls.job_name_path = '//table//tbody//tr[1]//td[1]'
-        cls.job_date_path = '//table//tbody//tr[1]//td[2]'
-        cls.job_stime_path = '//table//tbody//tr[1]//td[3]'
-        cls.job_etime_path = '//table//tbody//tr[1]//td[4]'
-        cls.view_jobs_path = '//table//tbody//tr[1]//td[4]'
-        cls.view_shifts_path = '//table//tbody//tr[1]//td[4]'
-        cls.assign_shifts_path = '//table//tbody//tr[1]//td[4]'
-        cls.slots_remaining_path = '//table//tbody//tr[1]//td[5]'
-        cls.cancel_shift_path = '//table//tbody//tr[1]//td[5]'
-
         cls.driver = webdriver.Firefox()
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
+        cls.sign_up_page = EventSignUpPage(cls.driver)
+        cls.manage_shift_page = ManageShiftPage(cls.driver)
+        cls.authentication_page = AuthenticationPage(cls.driver)
         super(ManageVolunteerShift, cls).setUpClass()
 
     def setUp(self):
         create_admin()
+        self.login_admin()
 
     def tearDown(self):
         pass
@@ -79,31 +72,9 @@ class ManageVolunteerShift(LiveServerTestCase):
         cls.driver.quit()
         super(ManageVolunteerShift, cls).tearDownClass()
 
-    def login(self, credentials):
-        self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id('id_login').send_keys(credentials['username'])
-        self.driver.find_element_by_id('id_password').send_keys(credentials['password'])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def navigate_to_manage_shift_page(self):
-        self.driver.find_element_by_link_text('Manage Volunteer Shifts').click()
-        self.assertEqual(self.driver.current_url,
-                self.live_server_url + self.shift_page)
-
     def login_admin(self):
-        self.login({ 'username' : 'admin', 'password' : 'admin'})
-
-    def select_volunteer(self, number):
-        link_path = '//table//tbody//tr[' + str(number) + ']//td[10]//a'
-        self.driver.find_element_by_xpath(link_path).click()
-
-    def navigate_to_shift_assignment_page(self):
-        self.driver.find_element_by_xpath(
-                self.view_jobs_path + "//a").click()
-        self.driver.find_element_by_xpath(
-                self.view_shifts_path + "//a").click()
-        self.driver.find_element_by_xpath(
-                self.assign_shifts_path + "//a").click()
+        self.authentication_page.server_url = self.live_server_url
+        self.authentication_page.login({ 'username' : 'admin', 'password' : 'admin'})
 
     def create_shift(self, shift):
         # register event to create job
@@ -121,85 +92,87 @@ class ManageVolunteerShift(LiveServerTestCase):
         return s1
 
     def check_job_details(self, details):
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.job_name_path).text, details[0])
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.job_date_path).text, details[1])
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.job_stime_path).text, details[2])
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.job_etime_path).text, details[3])
-
-    def assign_shift(self):
-        self.driver.find_element_by_link_text('Assign Shift').click()
+        sign_up_page = self.sign_up_page
+        self.assertEqual(sign_up_page.get_shift_job(), details[0])
+        self.assertEqual(sign_up_page.get_shift_date(), details[1])
+        self.assertEqual(sign_up_page.get_shift_start_time(), details[2])
+        self.assertEqual(sign_up_page.get_shift_end_time(), details[3])
 
     def test_table_layout(self):
+        sign_up_page = self.sign_up_page
+        manage_shift_page = self.manage_shift_page
+
         # register volunteers
         v1 = create_volunteer_with_details(self.volunteer_1)
 
         shift = ['09:00', '15:00', '1']
         s1 = self.create_shift(shift)
 
-        self.login_admin()
+        self.manage_shift_page.live_server_url = self.live_server_url
         # open manage volunteer shift
-        self.navigate_to_manage_shift_page()
+        self.manage_shift_page.navigate_to_manage_shift_page()
 
         # volunteer-one does not have any registered shifts
-        self.select_volunteer(1)
-        self.assign_shift()
+        manage_shift_page.select_volunteer(1)
+        manage_shift_page.assign_shift()
 
         # events shown in table
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-info')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.view_jobs_path).text, 'View Jobs')
-        self.driver.find_element_by_xpath(
-                self.view_jobs_path + "//a").click()
+            sign_up_page.get_info_box()
+        self.assertEqual(sign_up_page.get_view_jobs(), 'View Jobs')
+        sign_up_page.click_to_view_jobs()
 
         # arrived on page2 with jobs
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.view_shifts_path).text, 'View Shifts')
-        self.driver.find_element_by_xpath(
-                self.view_shifts_path + "//a").click()
+        self.assertEqual(sign_up_page.get_view_shifts(), 'View Shifts')
+        sign_up_page.click_to_view_shifts()
 
         # arrived on page3 with shifts, assign shift to volunteer one
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.assign_shifts_path).text, 'Assign Shift')
+        self.assertEqual(sign_up_page.get_sign_up(), 'Assign Shift')
 
     def test_landing_page_without_any_registered_volunteers(self):
-        self.login_admin()
-        self.navigate_to_manage_shift_page()
+        manage_shift_page = self.manage_shift_page
+        self.manage_shift_page.live_server_url = self.live_server_url
+        # open manage volunteer shift
+        self.manage_shift_page.navigate_to_manage_shift_page()
+        manage_shift_page.navigate_to_manage_shift_page()
+        
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_tag_name('tr')
+            manage_shift_page.find_table_row()
 
     def test_landing_page_with_registered_volunteers(self):
+        manage_shift_page = self.manage_shift_page
+        self.manage_shift_page.live_server_url = self.live_server_url
+
         # register volunteer
         v1 = create_volunteer_with_details(self.volunteer_1)
 
-        # login admin user
-        self.login_admin()
-        self.navigate_to_manage_shift_page()
+        manage_shift_page.navigate_to_manage_shift_page()
 
-        self.assertNotEqual(self.driver.find_element_by_tag_name('tr'), None)
-        self.select_volunteer(1)
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
-               'This volunteer does not have any upcoming shifts.')
+        self.assertNotEqual(manage_shift_page.find_table_row(), None)
+        manage_shift_page.select_volunteer(1)
+        self.assertEqual(manage_shift_page.get_info_box(),manage_shift_page.no_volunteer_shift_message)
 
     def test_events_page_with_no_events(self):
+        sign_up_page = self.sign_up_page
+        manage_shift_page = self.manage_shift_page
+
         # register volunteers
         v1 = create_volunteer_with_details(self.volunteer_1)
 
-        # login admin user
-        self.login_admin()
-        self.navigate_to_manage_shift_page()
+        self.manage_shift_page.live_server_url = self.live_server_url
+        # open manage volunteer shift
+        self.manage_shift_page.navigate_to_manage_shift_page()
 
-        self.select_volunteer(1)
-        self.assign_shift()
+        manage_shift_page.select_volunteer(1)
+        manage_shift_page.assign_shift()
 
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
-               'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
 
     def test_jobs_page_with_no_jobs(self):
+        sign_up_page = self.sign_up_page
+        manage_shift_page = self.manage_shift_page
+        self.manage_shift_page.live_server_url = self.live_server_url
+
         # register volunteers
         v1 = create_volunteer_with_details(self.volunteer_1)
 
@@ -207,17 +180,18 @@ class ManageVolunteerShift(LiveServerTestCase):
         event = ['event-name', '2017-05-20', '2017-05-20']
         e1 = create_event_with_details(event)
 
-        # login admin
-        self.login_admin()
         # open manage volunteer shift
-        self.navigate_to_manage_shift_page()
-        self.select_volunteer(1)
-        self.assign_shift()
+        manage_shift_page.navigate_to_manage_shift_page()
+        manage_shift_page.select_volunteer(1)
+        manage_shift_page.assign_shift()
 
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text,'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
 
     def test_assign_shifts_with_no_shifts(self):
+        sign_up_page = self.sign_up_page
+        manage_shift_page = self.manage_shift_page
+        self.manage_shift_page.live_server_url = self.live_server_url
+
         # register volunteers
         v1 = create_volunteer_with_details(self.volunteer_1)
 
@@ -229,52 +203,53 @@ class ManageVolunteerShift(LiveServerTestCase):
         job = ['job name', '2017-05-20', '2017-05-20', 'job description', e1]
         j1 = create_job_with_details(job)
 
-        # login admin
-        self.login_admin()
         # open manage volunteer shift
-        self.navigate_to_manage_shift_page()
-        self.select_volunteer(1)
-        self.assign_shift()
+        manage_shift_page.navigate_to_manage_shift_page()
+        manage_shift_page.select_volunteer(1)
+        manage_shift_page.assign_shift()
 
         # no events shown in table
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text,'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
 
     def test_assign_shifts_with_registered_shifts(self):
+        sign_up_page = self.sign_up_page
+        manage_shift_page = self.manage_shift_page
+        self.manage_shift_page.live_server_url = self.live_server_url
+
         # register volunteers
         v1 = create_volunteer_with_details(self.volunteer_1)
 
         shift = ['09:00', '15:00', '1']
         s1 = self.create_shift(shift)
 
-        self.login_admin()
-        # open manage volunteer shift
-        self.navigate_to_manage_shift_page()
-
         # volunteer-one does not have any registered shifts
-        self.select_volunteer(1)
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text, 
-            'This volunteer does not have any upcoming shifts.')
+        manage_shift_page.navigate_to_manage_shift_page()
+        manage_shift_page.select_volunteer(1)
+        self.assertEqual(manage_shift_page.get_info_box(), 
+            manage_shift_page.no_volunteer_shift_message)
 
-        self.assign_shift()
+        manage_shift_page.assign_shift()
 
         # events shown in table
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-info')
-        self.navigate_to_shift_assignment_page()
+            sign_up_page.get_info_box()
+        manage_shift_page.navigate_to_shift_assignment_page()
 
         # confirm on shift assignment to volunteer-one
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        manage_shift_page.submit_form()
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-danger')
+            sign_up_page.get_danger_box()
 
         # check shift assignment to volunteer-one
-        self.navigate_to_manage_shift_page()
-        self.select_volunteer(1)
+        manage_shift_page.navigate_to_manage_shift_page()
+        manage_shift_page.select_volunteer(1)
         self.check_job_details(['job name', 'May 20, 2017', '9 a.m.', '3 p.m.'])
 
     def test_slots_remaining_in_shift(self):
+        sign_up_page = self.sign_up_page
+        manage_shift_page = self.manage_shift_page
+        self.manage_shift_page.live_server_url = self.live_server_url
+
         # register volunteers
         v1 = create_volunteer_with_details(self.volunteer_1)
         v2 = create_volunteer_with_details(self.volunteer_2)
@@ -282,153 +257,140 @@ class ManageVolunteerShift(LiveServerTestCase):
         shift = ['09:00', '15:00', '1']
         s1 = self.create_shift(shift)
 
-        self.login_admin()
         # open manage volunteer shift
-        self.navigate_to_manage_shift_page()
+        manage_shift_page.navigate_to_manage_shift_page()
 
         # volunteer-one does not have any registered shifts
-        self.select_volunteer(1)
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text, 
-            'This volunteer does not have any upcoming shifts.')
+        manage_shift_page.select_volunteer(1)
+        self.assertEqual(manage_shift_page.get_info_box(), 
+            manage_shift_page.no_volunteer_shift_message)
 
-        self.assign_shift()
+        manage_shift_page.assign_shift()
 
         # events shown in table
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-info')
-        self.navigate_to_shift_assignment_page()
+            sign_up_page.get_info_box()
+        manage_shift_page.navigate_to_shift_assignment_page()
 
         # confirm on shift assignment to volunteer-one
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        manage_shift_page.submit_form()
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-danger')
+            sign_up_page.get_danger_box()
 
         # check shift assignment to volunteer-one
-        self.navigate_to_manage_shift_page()
-        self.select_volunteer(1)
+        manage_shift_page.navigate_to_manage_shift_page()
+        manage_shift_page.select_volunteer(1)
         self.check_job_details(['job name', 'May 20, 2017', '9 a.m.', '3 p.m.'])
 
         # open manage volunteer shift again to assign shift to volunteer two
-        self.navigate_to_manage_shift_page()
+        manage_shift_page.navigate_to_manage_shift_page()
 
         # volunteer-two does not have any registered shifts
-        self.select_volunteer(2)
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text, 
-            'This volunteer does not have any upcoming shifts.')
+        manage_shift_page.select_volunteer(2)
+        self.assertEqual(manage_shift_page.get_info_box(), 
+            manage_shift_page.no_volunteer_shift_message)
 
-        self.assign_shift()
+        manage_shift_page.assign_shift()
 
         #no events shown in table
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text,
-            'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)
             
     def test_cancel_assigned_shift(self):
+        sign_up_page = self.sign_up_page
+        manage_shift_page = self.manage_shift_page
+        self.manage_shift_page.live_server_url = self.live_server_url
+
         # register volunteers
         v1 = create_volunteer_with_details(self.volunteer_1)
 
         shift = ['09:00', '15:00', '1']
         s1 = self.create_shift(shift)
 
-        self.login_admin()
         # open manage volunteer shift
-        self.navigate_to_manage_shift_page()
+        manage_shift_page.navigate_to_manage_shift_page()
 
         # volunteer-one does not have any registered shifts
-        self.select_volunteer(1)
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text, 
-            'This volunteer does not have any upcoming shifts.')
+        manage_shift_page.select_volunteer(1)
+        self.assertEqual(manage_shift_page.get_info_box(), 
+            manage_shift_page.no_volunteer_shift_message)
 
-        self.assign_shift()
+        manage_shift_page.assign_shift()
 
         # events shown in table
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-info')
-        self.driver.find_element_by_xpath(
-                self.view_jobs_path + "//a").click()
-        self.driver.find_element_by_xpath(
-                self.view_shifts_path + "//a").click()
+            sign_up_page.get_info_box().text
+        sign_up_page.click_to_view_jobs()
+        sign_up_page.click_to_view_shifts()
 
         # arrived on shifts page, assign shift to volunteer one
-        slots_remaining_before_assignment = self.driver.find_element_by_xpath(
-                self.slots_remaining_path).text
-        self.driver.find_element_by_xpath(
-                self.assign_shifts_path + "//a").click()
+        slots_remaining_before_assignment = sign_up_page.get_remaining_slots()
+        sign_up_page.click_to_sign_up()
 
         # confirm on shift assignment to volunteer-one
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        sign_up_page.submit_form()
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-danger')
+            sign_up_page.get_danger_box()
 
         # check shift assignment to volunteer-one
-        self.navigate_to_manage_shift_page()
-        self.select_volunteer(1)
+        manage_shift_page.navigate_to_manage_shift_page()
+        manage_shift_page.select_volunteer(1)
         self.check_job_details(['job name', 'May 20, 2017', '9 a.m.', '3 p.m.'])
 
         # cancel assigned shift
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.cancel_shift_path).text, 'Cancel Shift Registration')
-        self.driver.find_element_by_xpath(
-                self.cancel_shift_path + "//a").click()
-        self.assertNotEqual(self.driver.find_element_by_class_name(
-            'panel-danger'), None)
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'btn-danger').text, 'Yes, Cancel this Shift')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        self.assertEqual(manage_shift_page.get_cancel_shift().text, 'Cancel Shift Registration')
+        manage_shift_page.cancel_shift()
+        self.assertNotEqual(manage_shift_page.get_cancellation_box(), None)
+        self.assertEqual(manage_shift_page.get_cancellation_message(), 'Yes, Cancel this Shift')
+        manage_shift_page.submit_form()
 
         # check cancelled shift reflects in volunteer shift details
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text,
-            'This volunteer does not have any upcoming shifts.')
+        self.assertEqual(manage_shift_page.get_info_box(),
+            manage_shift_page.no_volunteer_shift_message)
 
         # check slots remaining increases by one, after cancellation of
         # assigned shift
-        self.assign_shift()
-        self.driver.find_element_by_xpath(
-                self.view_jobs_path + "//a").click()
-        self.driver.find_element_by_xpath(
-                self.view_shifts_path + "//a").click()
-        slots_after_cancellation = self.driver.find_element_by_xpath(
-                self.slots_remaining_path).text
+        manage_shift_page.assign_shift()
+        sign_up_page.click_to_view_jobs()
+        sign_up_page.click_to_view_shifts()
+        slots_after_cancellation = sign_up_page.get_remaining_slots()
         self.assertEqual(slots_remaining_before_assignment,
                 slots_after_cancellation)
 
     def test_assign_same_shift_to_volunteer_twice(self):
+        sign_up_page = self.sign_up_page
+        manage_shift_page = self.manage_shift_page
+        self.manage_shift_page.live_server_url = self.live_server_url
+
         # register volunteers
         v1 = create_volunteer_with_details(self.volunteer_1)
 
         shift = ['09:00', '15:00', '1']
         s1 = self.create_shift(shift)
 
-        self.login_admin()
         # open manage volunteer shift
-        self.navigate_to_manage_shift_page()
+        manage_shift_page.navigate_to_manage_shift_page()
 
         # volunteer-one does not have any registered shifts
-        self.select_volunteer(1)
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text, 
-            'This volunteer does not have any upcoming shifts.')
+        manage_shift_page.select_volunteer(1)
+        self.assertEqual(manage_shift_page.get_info_box(),
+            manage_shift_page.no_volunteer_shift_message)
 
-        self.assign_shift()
+        manage_shift_page.assign_shift()
 
         # events shown in table
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-info')
-        self.navigate_to_shift_assignment_page()
+            sign_up_page.get_info_box()
+        manage_shift_page.navigate_to_shift_assignment_page()
 
         # confirm on shift assignment to volunteer-one
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        manage_shift_page.submit_form()
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_class_name('alert-danger')
+            sign_up_page.get_danger_box()
 
         # assign same shift to voluteer-one again
         # Check volunteer-one has one registered shift now
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.job_name_path).text, 'job name')
-        self.assign_shift()
+        self.assertEqual(sign_up_page.get_shift_job(), 'job name')
+        manage_shift_page.assign_shift()
 
         # events page
-        self.assertEqual(self.driver.find_element_by_class_name('alert-info').text, 'There are no events.')
+        self.assertEqual(sign_up_page.get_info_box().text,sign_up_page.no_event_message)

--- a/vms/shift/tests/test_shiftHours.py
+++ b/vms/shift/tests/test_shiftHours.py
@@ -3,6 +3,9 @@ from django.contrib.staticfiles.testing import LiveServerTestCase
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
+from pom.pages.completedShiftsPage import CompletedShiftsPage
+from pom.pages.authenticationPage import AuthenticationPage
+
 from shift.utils import (
     create_volunteer,
     create_event_with_details,
@@ -17,25 +20,16 @@ class ShiftHours(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.homepage = '/'
-        cls.authentication_page = '/authentication/login/'
-        cls.view_hours_page = '/shift/view_hours/'
-        cls.shift_job_path = '//table//tbody//tr[1]//td[1]'
-        cls.shift_date_path = '//table//tbody//tr[1]//td[2]'
-        cls.shift_stime_path = '//table//tbody//tr[1]//td[3]'
-        cls.shift_etime_path = '//table//tbody//tr[1]//td[4]'
-        cls.shift_edit_path = '//table//tbody//tr[1]//td[5]'
-        cls.shift_clear_path = '//table//tbody//tr[1]//td[6]'
-        cls.start_time_form = '//input[@name = "start_time"]'
-        cls.end_time_form = '//input[@name = "end_time"]'
-
         cls.driver = webdriver.Firefox()
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
+        cls.completed_shifts_page = CompletedShiftsPage(cls.driver)
+        cls.authentication_page = AuthenticationPage(cls.driver)
         super(ShiftHours, cls).setUpClass()
 
     def setUp(self):
         self.v1 = create_volunteer()
+        self.login_volunteer()
 
     def tearDown(self):
         pass
@@ -45,17 +39,11 @@ class ShiftHours(LiveServerTestCase):
         cls.driver.quit()
         super(ShiftHours, cls).tearDownClass()
 
-    def login(self, credentials):
-        self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id('id_login').send_keys(credentials['username'])
-        self.driver.find_element_by_id('id_password').send_keys(credentials['password'])
-        self.driver.find_element_by_xpath('//form[1]').submit()
+    def login_volunteer(self):
+        self.authentication_page.server_url = self.live_server_url
+        self.authentication_page.login({'username' : 'volunteer', 'password' : 'volunteer'})
 
-    def login_volunteer_and_navigate(self):
-        self.login({'username' : 'volunteer', 'password' : 'volunteer'})
-        self.driver.find_element_by_link_text('Completed Shifts').click()
-
-    def register_dataset(self, ):
+    def register_dataset(self):
         
         # create shift and log hours
         e1 = create_event_with_details(['event', '2017-06-15', '2017-06-17'])
@@ -63,110 +51,69 @@ class ShiftHours(LiveServerTestCase):
         s1 = create_shift_with_details(['2017-06-15', '09:00', '15:00', '6', j1])
         log_hours_with_details(self.v1, s1, '12:00', '13:00')
 
-    def edit_hours(self, stime, etime):
-        self.driver.find_element_by_xpath(
-                self.shift_edit_path + '//a').click()
-
-        self.assertEqual(self.driver.find_element_by_xpath(
-            'html/body/div[2]/div[2]/form/fieldset/legend').text,
-            'Edit Shift Hours')
-        self.driver.find_element_by_xpath(self.start_time_form).clear()
-        self.driver.find_element_by_xpath(
-                self.start_time_form).send_keys(stime)
-
-        self.driver.find_element_by_xpath(self.end_time_form).clear()
-        self.driver.find_element_by_xpath(
-                self.end_time_form).send_keys(
-                        etime)
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
     def test_view_with_unlogged_shift(self):
-        self.login_volunteer_and_navigate()
-
+        completed_shifts_page = self.completed_shifts_page
+        completed_shifts_page.go_to_completed_shifts()
         self.assertEqual(self.driver.current_url, self.live_server_url + 
-                self.view_hours_page + str(self.v1.id))
+            completed_shifts_page.view_hours_page + str(self.v1.id))
 
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text, 'You have not logged any hours.')
+        self.assertEqual(completed_shifts_page.get_info_box(),
+            'You have not logged any hours.')
 
     def test_view_with_logged_shift(self):
         self.register_dataset()
-        self.login_volunteer_and_navigate()
+        completed_shifts_page = self.completed_shifts_page
+        completed_shifts_page.go_to_completed_shifts()
 
-        self.assertEqual(self.driver.current_url, self.live_server_url + 
-                self.view_hours_page + str(self.v1.id))
-
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_job_path).text, 'job')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_date_path).text, 'June 15, 2017')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_stime_path).text, 'noon')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_etime_path).text, '1 p.m.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_edit_path).text, 'Edit Hours')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_clear_path).text, 'Clear Hours')
+        self.assertEqual(completed_shifts_page.get_shift_job(), 'job')
+        self.assertEqual(completed_shifts_page.get_shift_date(), 'June 15, 2017')
+        self.assertEqual(completed_shifts_page.get_shift_start_time(), 'noon')
+        self.assertEqual(completed_shifts_page.get_shift_end_time(), '1 p.m.')
+        self.assertEqual(completed_shifts_page.get_edit_shift_hours(), 'Edit Hours')
+        self.assertEqual(completed_shifts_page.get_clear_shift_hours(), 'Clear Hours')
 
     def test_edit_hours(self):
         self.register_dataset()
-        self.login_volunteer_and_navigate()
+        completed_shifts_page = self.completed_shifts_page
+        completed_shifts_page.go_to_completed_shifts()
 
-        self.assertEqual(self.driver.current_url, self.live_server_url + 
-                self.view_hours_page + str(self.v1.id))
-
-        self.edit_hours('10:00','13:00')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_stime_path).text, '10 a.m.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_etime_path).text, '1 p.m.')
+        completed_shifts_page.edit_hours('10:00','13:00')
+        self.assertEqual(completed_shifts_page.get_shift_start_time(), '10 a.m.')
+        self.assertEqual(completed_shifts_page.get_shift_end_time(), '1 p.m.')
 
     def test_end_hours_less_than_start_hours(self):
         self.register_dataset()
-        self.login_volunteer_and_navigate()
+        completed_shifts_page = self.completed_shifts_page
+        completed_shifts_page.go_to_completed_shifts()
 
-        self.assertEqual(self.driver.current_url, self.live_server_url + 
-                self.view_hours_page + str(self.v1.id))
-
-        self.edit_hours('14:00', '12:00')
+        completed_shifts_page.edit_hours('14:00', '12:00')
 
         try:
-            self.driver.find_element_by_class_name('alert-danger')
+            completed_shifts_page.get_danger_box()
         except NoSuchElementException:
             raise Exception("End hours greater than start hours")
 
     def test_logged_hours_between_shift_hours(self):
         self.register_dataset()
-        self.login_volunteer_and_navigate()
+        completed_shifts_page = self.completed_shifts_page
+        completed_shifts_page.go_to_completed_shifts()
 
-        self.assertEqual(self.driver.current_url, self.live_server_url +
-                         self.view_hours_page + str(self.v1.id))
-
-        self.edit_hours('10:00','16:00')
-        self.assertEqual(
-            self.driver.find_element_by_class_name('alert-danger').text,
+        completed_shifts_page.edit_hours('10:00','16:00')
+        self.assertEqual(completed_shifts_page.get_danger_box().text,
             'Logged hours should be between shift hours')
 
     def test_cancel_hours(self):
         self.register_dataset()
-        self.login_volunteer_and_navigate()
+        completed_shifts_page = self.completed_shifts_page
+        completed_shifts_page.go_to_completed_shifts()
 
-        self.assertEqual(self.driver.current_url, self.live_server_url + 
-                self.view_hours_page + str(self.v1.id))
+        self.assertEqual(completed_shifts_page.get_shift_job(), 'job')
+        self.assertEqual(completed_shifts_page.get_clear_shift_hours(), 'Clear Hours')
+        completed_shifts_page.click_to_clear_hours()
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_job_path).text, 'job')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_clear_path).text, 'Clear Hours')
-        self.driver.find_element_by_xpath(
-                self.shift_clear_path + '//a').click()
-
-        self.assertEqual(self.driver.find_element_by_xpath(
-            'html/body/div[2]/form/div/div[1]/h3').text,
+        self.assertEqual(completed_shifts_page.get_clear_shift_hours_text(),
             'Clear Shift Hours')
-        self.driver.find_element_by_xpath('//form[1]').submit()
+        completed_shifts_page.submit_form()
 
         with self.assertRaises(NoSuchElementException):
-            self.assertEqual(self.driver.find_element_by_xpath(
-                self.shift_job_path).text, 'job')
+            self.assertEqual(completed_shifts_page.get_shift_job(), 'job')

--- a/vms/shift/tests/test_viewVolunteerShift.py
+++ b/vms/shift/tests/test_viewVolunteerShift.py
@@ -1,5 +1,9 @@
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
+from pom.pages.upcomingShiftsPage import UpcomingShiftsPage
+from pom.pages.authenticationPage import AuthenticationPage
+from pom.pages.manageShiftPage import ManageShiftPage
+
 from shift.utils import (
     create_volunteer,
     create_event_with_details,
@@ -19,27 +23,17 @@ class ViewVolunteerShift(LiveServerTestCase):
     '''
     @classmethod
     def setUpClass(cls):
-        cls.homepage = '/'
-        cls.authentication_page = '/authentication/login/'
-        cls.view_shift_page = '/shift/view_volunteer_shifts/'     
-        
-        cls.shift_job_path = '//table//tbody//tr[1]//td[1]'
-        cls.shift_date_path = '//table//tbody//tr[1]//td[2]'
-        cls.shift_stime_path = '//table//tbody//tr[1]//td[3]'
-        cls.shift_etime_path = '//table//tbody//tr[1]//td[4]'
-        cls.shift_cancel_path = '//table//tbody//tr[1]//td[6]'
-        cls.log_shift_hours_path = '//table//tbody//tr[1]//td[5]'
-
-        cls.start_time_form = '//input[@name = "start_time"]'
-        cls.end_time_form = '//input[@name = "end_time"]'
-
         cls.driver = webdriver.Firefox()
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
+        cls.manage_shift_page = ManageShiftPage(cls.driver)
+        cls.upcoming_shift_page = UpcomingShiftsPage(cls.driver)
+        cls.authentication_page = AuthenticationPage(cls.driver)
         super(ViewVolunteerShift, cls).setUpClass()
 
     def setUp(self):
         self.v1 = create_volunteer()
+        self.login_volunteer()
 
     def tearDown(self):
         pass
@@ -49,18 +43,10 @@ class ViewVolunteerShift(LiveServerTestCase):
         cls.driver.quit()
         super(ViewVolunteerShift, cls).tearDownClass()
 
-    def view_upcoming_shifts(self):
-        self.driver.find_element_by_link_text('Upcoming Shifts').send_keys("\n")
-
-    def login(self, credentials):
-        self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id('id_login').send_keys(credentials['username'])
-        self.driver.find_element_by_id('id_password').send_keys(credentials['password'])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
     def login_volunteer(self):
         credentials = {'username' : 'volunteer', 'password' : 'volunteer'}
-        self.login(credentials)
+        self.authentication_page.server_url = self.live_server_url
+        self.authentication_page.login(credentials)
 
     def test_access_another_existing_volunteer_view(self):
         '''
@@ -71,21 +57,21 @@ class ViewVolunteerShift(LiveServerTestCase):
         test_volunteer = create_volunteer_with_details(details)
 
         self.login_volunteer()
-        self.driver.get(self.live_server_url + self.view_shift_page + str(test_volunteer_id))
+        upcoming_shift_page = self.upcoming_shift_page
+        upcoming_shift_page.get_page(self.live_server_url, upcoming_shift_page.view_shift_page + str(test_volunteer_id))
         '''
         pass
 
     def test_access_another_nonexisting_volunteer_view(self):
-        self.login_volunteer()
-        self.driver.get(self.live_server_url + self.view_shift_page + '65459')
+        upcoming_shift_page = self.upcoming_shift_page
+        upcoming_shift_page.get_page(self.live_server_url, upcoming_shift_page.view_shift_page + '65459')
         found = re.search('Not Found', self.driver.page_source)
         self.assertNotEqual(found, None)
 
     def test_view_without_any_assigned_shift(self):
-        self.login_volunteer()
-        self.view_upcoming_shifts()
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text, 'You do not have any upcoming shifts.')
+        upcoming_shift_page = self.upcoming_shift_page
+        upcoming_shift_page.view_upcoming_shifts()
+        self.assertEqual(upcoming_shift_page.get_info_box(), upcoming_shift_page.no_shift_message)
 
     def register_dataset(self):
 
@@ -99,62 +85,51 @@ class ViewVolunteerShift(LiveServerTestCase):
     def test_view_with_assigned_and_unlogged_shift(self):
 
         self.register_dataset()
-        self.login_volunteer()
-        self.view_upcoming_shifts()
+        upcoming_shift_page = self.upcoming_shift_page
+        upcoming_shift_page.view_upcoming_shifts()
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_job_path).text, 'jobOneInEventFour')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_date_path).text, 'June 1, 2017')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_stime_path).text, '9 a.m.')
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.shift_etime_path).text, '3 p.m.')
+        self.assertEqual(upcoming_shift_page.get_shift_job(), 'jobOneInEventFour')
+        self.assertEqual(upcoming_shift_page.get_shift_date(), 'June 1, 2017')
+        self.assertEqual(upcoming_shift_page.get_shift_start_time(), '9 a.m.')
+        self.assertEqual(upcoming_shift_page.get_shift_end_time(), '3 p.m.')
 
     def test_log_hours_and_logged_shift_does_not_appear_in_upcoming_shifts(self):
 
         self.register_dataset()
-        self.login_volunteer()
-        self.view_upcoming_shifts()
+        upcoming_shift_page = self.upcoming_shift_page
+        upcoming_shift_page.view_upcoming_shifts()
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-                self.log_shift_hours_path).text, 'Log Hours')
-        self.driver.find_element_by_xpath(
-                self.log_shift_hours_path + "//a").click()
+        self.assertEqual(upcoming_shift_page.get_log_hours(), 'Log Hours')
 
-        self.driver.find_element_by_xpath(
-                self.start_time_form).send_keys('09:00')
-        self.driver.find_element_by_xpath(
-                self.end_time_form).send_keys('12:00')
-        self.driver.find_element_by_xpath('//form').submit()
+        upcoming_shift_page.click_to_log_hours()
+        upcoming_shift_page.log_shift_timings('09:00', '12:00')
 
         # check logged shift does not appear in Upcoming Shifts
-        self.view_upcoming_shifts()
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text, 'You do not have any upcoming shifts.')
+        upcoming_shift_page.view_upcoming_shifts()
+        self.assertEqual(upcoming_shift_page.get_info_box(), upcoming_shift_page.no_shift_message)
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_xpath('//table')
+            upcoming_shift_page.get_result_container()
 
     def test_cancel_shift_registration(self):
 
         self.register_dataset()
-        self.login_volunteer()
-        self.view_upcoming_shifts()
+        upcoming_shift_page = self.upcoming_shift_page
+        manage_shift_page = self.manage_shift_page
+        upcoming_shift_page.view_upcoming_shifts()
 
-        self.assertEqual(self.driver.find_element_by_xpath(
-                self.shift_cancel_path).text, 'Cancel Shift Registration')
-        self.driver.find_element_by_xpath(
-                self.shift_cancel_path + '//a').click()
+        self.assertEqual(upcoming_shift_page.get_cancel_shift().text, 'Cancel Shift Registration')
+        upcoming_shift_page.cancel_shift()
 
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'panel-title').text, 'Cancel Shift Confirmation')
-        self.assertEqual(self.driver.find_element_by_class_name('btn-danger').text,
+        self.assertNotEqual(manage_shift_page.get_cancellation_box(),None)
+        self.assertEqual(manage_shift_page.get_cancellation_header(),
+            'Cancel Shift Confirmation')
+        self.assertEqual(manage_shift_page.get_cancellation_message(),
                 'Yes, Cancel this Shift')
-        self.driver.find_element_by_xpath('//form').submit()
+        manage_shift_page.submit_form()
 
         # check shift removed from upcoming shifts
-        self.driver.find_element_by_link_text('Upcoming Shifts').click()
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-info').text, 'You do not have any upcoming shifts.')
+        upcoming_shift_page.view_upcoming_shifts()
+        self.assertEqual(upcoming_shift_page.get_info_box(),
+            upcoming_shift_page.no_shift_message)
         with self.assertRaises(NoSuchElementException):
-            self.driver.find_element_by_xpath('//table')
+            upcoming_shift_page.get_result_container()

--- a/vms/shift/tests/test_viewVolunteerShift.py
+++ b/vms/shift/tests/test_viewVolunteerShift.py
@@ -112,6 +112,13 @@ class ViewVolunteerShift(LiveServerTestCase):
         with self.assertRaises(NoSuchElementException):
             upcoming_shift_page.get_result_container()
 
+        # database check to ensure volunteer has logged the hours
+        self.assertEqual(len(VolunteerShift.objects.all()), 1)
+        self.assertNotEqual(len(VolunteerShift.objects.filter(
+            start_time__isnull=False, end_time__isnull=False)), 0)
+        self.assertNotEqual(len(VolunteerShift.objects.filter(
+            start_time='09:00', end_time='12:00')), 0)
+
     def test_cancel_shift_registration(self):
 
         self.register_dataset()

--- a/vms/shift/tests/test_viewVolunteerShift.py
+++ b/vms/shift/tests/test_viewVolunteerShift.py
@@ -4,6 +4,8 @@ from pom.pages.upcomingShiftsPage import UpcomingShiftsPage
 from pom.pages.authenticationPage import AuthenticationPage
 from pom.pages.manageShiftPage import ManageShiftPage
 
+from shift.models import VolunteerShift
+
 from shift.utils import (
     create_volunteer,
     create_event_with_details,
@@ -133,3 +135,6 @@ class ViewVolunteerShift(LiveServerTestCase):
             upcoming_shift_page.no_shift_message)
         with self.assertRaises(NoSuchElementException):
             upcoming_shift_page.get_result_container()
+
+        # database check to ensure shift registration is cancelled
+        self.assertEqual(len(VolunteerShift.objects.all()), 0)

--- a/vms/shift/utils.py
+++ b/vms/shift/utils.py
@@ -189,28 +189,34 @@ def create_volunteer():
     return volunteer
 
 def register_event_utility():
-    Event.objects.create(
+    event = Event.objects.create(
         name = 'event',
         start_date = '2016-05-10',
         end_date = '2018-06-16'
         )
 
+    return event
+
 def register_job_utility():
-    Job.objects.create(
+    job = Job.objects.create(
         name = 'job',
         start_date = '2016-05-10',
         end_date = '2017-06-15',
         event = Event.objects.get(name = 'event')
         )
 
+    return job
+
 def register_shift_utility():
-    Shift.objects.create(
+    shift = Shift.objects.create(
         date = '2017-06-15',
         start_time = '09:00',
         end_time = '15:00',
         max_volunteers ='6',
         job = Job.objects.get(name = 'job')
         )
+
+    return shift
 
 def register_volunteer_for_shift_utility(shift, volunteer):
         vol_shift = VolunteerShift.objects.create(

--- a/vms/vms/settings.py
+++ b/vms/vms/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = (
     'vms',
     'volunteer',
     'cities_light',
+    'pom',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/vms/volunteer/tests/test_volunteerProfile.py
+++ b/vms/volunteer/tests/test_volunteerProfile.py
@@ -101,6 +101,18 @@ class VolunteerProfile(LiveServerTestCase):
         found_org = re.search(new_details[9], page_source)
         self.assertNotEqual(found_org, None)
 
+        # database check to ensure that profile has been updated
+        self.assertEqual(len(Volunteer.objects.all()), 1)
+        self.assertNotEqual(len(Volunteer.objects.filter(
+            first_name = new_details[0],
+            last_name = new_details[1],
+            email=new_details[2],
+            address = new_details[3],
+            city = new_details[4],
+            state = new_details[5],
+            country = new_details[6],
+            phone_number = new_details[7])), 0)
+
     def test_upload_resume(self):
         pass
         '''

--- a/vms/volunteer/tests/test_volunteerProfile.py
+++ b/vms/volunteer/tests/test_volunteerProfile.py
@@ -6,31 +6,21 @@ from selenium.common.exceptions import NoSuchElementException
 from volunteer.models import Volunteer
 from shift.utils import create_volunteer_with_details
 
+from pom.pages.authenticationPage import AuthenticationPage
+from pom.pages.volunteerProfilePage import VolunteerProfilePage
+
 import re
 
 class VolunteerProfile(LiveServerTestCase):
     '''
     '''
     @classmethod
-    def setUpClass(cls):
-        cls.homepage = '/'
-        cls.authentication_page = '/authentication/login/'
-        cls.profile_first_name_path = '//input[@name = "first_name"]'
-        cls.profile_last_name_path = '//input[@name = "last_name"]'
-        cls.profile_email_path = '//input[@name = "email"]'
-        cls.profile_address_path = '//input[@name = "address"]'
-        cls.profile_city_path = '//input[@name = "city"]'
-        cls.profile_state_path = '//input[@name = "state"]'
-        cls.profile_country_path = '//input[@name = "country"]'
-        cls.profile_phone_path = '//input[@name = "phone_number"]'
-        cls.select_organization_path = '//select[@name = "organization_name"]'
-        cls.unlisted_organization_path = '//input[@name = "unlisted_organization"]'
-        cls.resume_file_path = '//input[@name = "resume_file"]'
-        cls.download_resume_path = './/*[@id="collapseResumeFile"]/div/form/button'
-        
+    def setUpClass(cls):       
         cls.driver = webdriver.Firefox()
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
+        cls.profile_page = VolunteerProfilePage(cls.driver)
+        cls.authentication_page = AuthenticationPage(cls.driver)
         super(VolunteerProfile, cls).setUpClass()
 
     def setUp(self):
@@ -38,6 +28,8 @@ class VolunteerProfile(LiveServerTestCase):
         self.v1 = create_volunteer_with_details(vol)
         self.v1.unlisted_organization = 'Detective'
         self.v1.save()
+        self.login_correctly()
+        self.profile_page.navigate_to_profile()
 
     def tearDown(self):
         pass
@@ -47,28 +39,12 @@ class VolunteerProfile(LiveServerTestCase):
         cls.driver.quit()
         super(VolunteerProfile, cls).tearDownClass()
 
-    def login(self, credentials):
-        self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id('id_login').send_keys(credentials['username'])
-        self.driver.find_element_by_id('id_password').send_keys(credentials['password'])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
     def login_correctly(self):
-        self.login({ 'username' : "Sherlock", 'password' : "volunteer"})
-
-    def navigate_to_profile(self):
-        self.driver.find_element_by_link_text('Profile').send_keys("\n")
-
-    def edit_profile(self):
-        self.driver.find_element_by_link_text('Edit Profile').send_keys("\n")
-
-    def fill_field(self, xpath, value):
-        self.driver.find_element_by_xpath(xpath).clear()
-        self.driver.find_element_by_xpath(xpath).send_keys(value)
+        self.authentication_page.server_url = self.live_server_url
+        self.authentication_page.login({ 'username' : "Sherlock", 'password' : "volunteer"})
 
     def test_details_tab(self):
-        self.login_correctly()
-        self.navigate_to_profile()
+        profile_page = self.profile_page
         page_source = self.driver.page_source
 
         found_email = re.search(self.v1.email, page_source)
@@ -87,24 +63,11 @@ class VolunteerProfile(LiveServerTestCase):
         self.assertNotEqual(found_org, None)
 
     def test_edit_profile(self):
-        self.login_correctly()
-        self.navigate_to_profile()
-        self.edit_profile()
+        profile_page = self.profile_page
+        profile_page.edit_profile()
 
         new_details = ['Harvey', 'Specter', 'hspecter@ps.com', 'Empire State Building', 'NYC', 'New York', 'USA', '9999999998', 'None', 'Lawyer']
-
-        self.fill_field(self.profile_first_name_path, new_details[0])
-        self.fill_field(self.profile_last_name_path, new_details[1])
-        self.fill_field(self.profile_email_path, new_details[2])
-        self.fill_field(self.profile_address_path, new_details[3])
-        self.fill_field(self.profile_city_path, new_details[4])
-        self.fill_field(self.profile_state_path, new_details[5])
-        self.fill_field(self.profile_country_path, new_details[6])
-        self.fill_field(self.profile_phone_path, new_details[7])
-        self.driver.find_element_by_xpath(
-                self.select_organization_path).send_keys(new_details[8])
-        self.fill_field(self.unlisted_organization_path, new_details[9])
-        self.driver.find_element_by_xpath('//form').submit()
+        profile_page.fill_values(new_details)
 
         page_source = self.driver.page_source
 
@@ -142,33 +105,21 @@ class VolunteerProfile(LiveServerTestCase):
         pass
         '''
         #Tested locally
-        self.login_correctly()
-        self.navigate_to_profile()
-        self.edit_profile()
-
-        self.driver.find_element_by_xpath(
-                self.resume_file_path).send_keys('/home/jlahori/Downloads/water.pdf')
-
-        self.driver.find_element_by_xpath('//form').submit()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            self.download_resume_path).text,
-            'Download Resume')
+        profile_page = self.profile_page
+        profile_page.edit_profile()
+        profile_page.upload_resume('/home/jlahori/Downloads/water.pdf')
+        profile_page.submit_form()
+        self.assertEqual(profile_page.download_resume_text(),'Download Resume')
         '''
 
     def test_invalid_resume_format(self):
         pass
         '''
         #Tested locally
-        self.login_correctly()
-        self.navigate_to_profile()
-        self.edit_profile()
-
-        self.driver.find_element_by_xpath(
-                self.resume_file_path).send_keys('/home/jlahori/Downloads/ca.crt')
-
-        self.driver.find_element_by_xpath('//form').submit()
-        self.assertEqual(self.driver.find_element_by_xpath(
-            'html/body/div[2]/div[2]/form/fieldset/div[13]/div/p/strong').text,
-            'Uploaded file is invalid.')
+        profile_page = self.profile_page
+        profile_page.edit_profile()
+        profile_page.upload_resume('/home/jlahori/Downloads/ca.crt')
+        profile_page.submit_form()
+        self.assertEqual(profile_page.get_invalid_format_error(),'Uploaded file is invalid.')
         '''
         

--- a/vms/volunteer/tests/test_volunteerReport.py
+++ b/vms/volunteer/tests/test_volunteerReport.py
@@ -2,13 +2,15 @@ from django.contrib.staticfiles.testing import LiveServerTestCase
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver.support.ui import Select
+
+from pom.pages.volunteerReportPage import VolunteerReportPage
 
 from shift.utils import (
     create_volunteer,
     register_event_utility,
     register_job_utility,
-    register_shift_utility
+    register_shift_utility,
+    log_hours_utility
     )
 
 class VolunteerReport(LiveServerTestCase):
@@ -16,17 +18,10 @@ class VolunteerReport(LiveServerTestCase):
     '''
     @classmethod
     def setUpClass(cls):
-        cls.homepage = '/'
-        cls.authentication_page = '/authentication/login/'
-        cls.report_start_date = '//input[@name = "start_date"]'
-        cls.report_end_date = '//input[@name = "end_date"]'
-        cls.report_event_selector = '//select[@name = "event_name"]'
-        cls.report_job_selector = '//select[@name = "job_name"]'
-        cls.report_shift_summary_path = '//div[2]/div[4]'
-
         cls.driver = webdriver.Firefox()
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
+        cls.report_page = VolunteerReportPage(cls.driver)
         super(VolunteerReport, cls).setUpClass()
 
     def setUp(self):
@@ -40,131 +35,116 @@ class VolunteerReport(LiveServerTestCase):
         cls.driver.quit()
         super(VolunteerReport, cls).tearDownClass()
 
-    def login(self, credentials):
-        self.driver.get(self.live_server_url + self.authentication_page)
-        self.driver.find_element_by_id('id_login').send_keys(credentials['username'])
-        self.driver.find_element_by_id('id_password').send_keys(credentials['password'])
-        self.driver.find_element_by_xpath('//form[1]').submit()
-
-    def login_and_navigate_to_report_page(self):
-        self.login({ 'username' : 'volunteer', 'password' : 'volunteer'})
-        self.driver.find_element_by_link_text('Report').send_keys("\n")
-
-    def get_event_job_selectors(self):
-        select1 = Select(self.driver.find_element_by_xpath(self.report_event_selector))
-        select2 = Select(self.driver.find_element_by_xpath(self.report_job_selector))
-        return (select1, select2)
-
-    def fill_report_form(self, dates):
-        self.driver.find_element_by_xpath(
-                self.report_start_date).clear()
-        self.driver.find_element_by_xpath(
-                self.report_end_date).clear()
-        self.driver.find_element_by_xpath(
-                self.report_start_date).send_keys(dates['start'])
-        self.driver.find_element_by_xpath(
-                self.report_end_date).send_keys(dates['end'])
-        self.driver.find_element_by_xpath('//form').submit()
-
     def verify_shift_details(self, total_shifts, hours):
-        total_no_of_shifts =  self.driver.find_element_by_xpath(
-                self.report_shift_summary_path).text.split(' ')[10].strip('\nTotal')
-
-        total_no_of_hours =  self.driver.find_element_by_xpath(
-                self.report_shift_summary_path).text.split(' ')[-1].strip('\n')
-        
+        total_no_of_shifts = self.report_page.get_shift_summary().split(' ')[10].strip('\nTotal')
+        total_no_of_hours = self.report_page.get_shift_summary().split(' ')[-1].strip('\n')
         self.assertEqual(total_no_of_shifts, total_shifts)
         self.assertEqual(total_no_of_hours, hours)
 
     def test_report_without_any_created_shifts(self):
-        self.login_and_navigate_to_report_page()
-        self.driver.find_element_by_xpath('//form').submit()
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-danger').text, 'Your criteria did not return any results.')
+        report_page = self.report_page
+        report_page.live_server_url = self.live_server_url
+        report_page.login_and_navigate_to_report_page()
+        report_page.submit_form()
+        self.assertEqual(report_page.get_alert_box_text(),report_page.no_results_message)
 
-#Failing test case which has been documented
+#Failing test case which has been documented as per bug #327
 #Test commented out to prevent travis build failure
 
     """def test_report_with_empty_fields(self):
+        report_page = self.report_page
+        report_page.live_server_url = self.live_server_url
         register_event_utility()
         register_job_utility()
         register_shift_utility()
         log_hours_utility()
 
-        self.login_and_navigate_to_report_page()
-        self.driver.find_element_by_xpath('//form').submit()
+        report_page.login_and_navigate_to_report_page()
+        report_page.submit_form()
         self.verify_shift_details('1','3.0')"""
 
     def test_only_logged_shifts_appear_in_report(self):
+        report_page = self.report_page
+        report_page.live_server_url = self.live_server_url
+
         register_event_utility()
         register_job_utility()
         register_shift_utility()
 
-        self.login_and_navigate_to_report_page()
-        self.driver.find_element_by_xpath('//form').submit()
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-danger').text, 'Your criteria did not return any results.')
+        report_page.login_and_navigate_to_report_page()
+        report_page.submit_form()
+        self.assertEqual(report_page.get_alert_box_text(),report_page.no_results_message)
 
 #Failing test cases which have been documented
 #Tests commented out to prevent travis build failure
 
     """def test_date_field(self):
+        report_page = self.report_page
+        report_page.live_server_url = self.live_server_url
+
         register_event_utility()
         register_job_utility()
         register_shift_utility()
         log_hours_utility()
 
-        self.login_and_navigate_to_report_page()
-        self.fill_report_form({ 'start' : '2015-06-11', 'end' : '2017-06-16'})
+        report_page.login_and_navigate_to_report_page(self.live_server_url)
+        report_page.fill_report_form({ 'start' : '2015-06-11', 'end' : '2017-06-16'})
         self.verify_shift_details('1','3.0')
 
         #incorrect date
-        self.fill_report_form({ 'start' : '2015-05-10', 'end' : '2015-06-01'})
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-danger').text, 'Your criteria did not return any results.')
+        report_page.fill_report_form({ 'start' : '2015-05-10', 'end' : '2015-06-01'})
+        self.assertEqual(report_page.get_alert_box_text(),report_page.no_results_message)
 
     def test_event_field(self):
+        report_page = self.report_page
+        report_page.live_server_url = self.live_server_url
+
         register_event_utility()
         register_job_utility()
         register_shift_utility()
         log_hours_utility()
 
-        self.login_and_navigate_to_report_page()
-        [select1, select2] = self.get_event_job_selectors()
+        report_page.login_and_navigate_to_report_page()
+        [select1, select2] = report_page.get_event_job_selectors()
         select1.select_by_visible_text('event')
 
-        self.driver.find_element_by_xpath('//form').submit()
+        report_page.submit_form()
         self.verify_shift_details('1','3.0')
 
     def test_job_field(self):
+        report_page = self.report_page
+        report_page.live_server_url = self.live_server_url
+
         register_event_utility()
         register_job_utility()
         register_shift_utility()
         log_hours_utility()
 
-        self.login_and_navigate_to_report_page()
-        [select1, select2] = self.get_event_job_selectors()
+        report_page.login_and_navigate_to_report_page()
+        [select1, select2] = report_page.get_event_job_selectors()
         select2.select_by_visible_text('job')
-        self.driver.find_element_by_xpath('//form').submit()
+        report_page.submit_form()
         self.verify_shift_details('1','3.0')
 
     def test_intersection_of_fields(self):
+        report_page = self.report_page
+        report_page.live_server_url = self.live_server_url
+
         register_event_utility()
         register_job_utility()
         register_shift_utility()
         log_hours_utility()
 
-        self.login_and_navigate_to_report_page()
-        [select1, select2] = self.get_event_job_selectors()
+        report_page.login_and_navigate_to_report_page()
+        [select1, select2] = report_page.get_event_job_selectors()
         select1.select_by_visible_text('event')
         select2.select_by_visible_text('job')
-        self.fill_report_form({ 'start' : '2015-06-11', 'end' : '2017-06-16'})
+        report_page.fill_report_form({ 'start' : '2015-06-11', 'end' : '2017-06-16'})
         self.verify_shift_details('1','3.0')
 
         # event, job correct and date incorrect
-        [select1, select2] = self.get_event_job_selectors()
+        [select1, select2] = report_page.get_event_job_selectors()
         select1.select_by_visible_text('event')
         select2.select_by_visible_text('job')
-        self.fill_report_form({ 'start' : '2015-05-10', 'end' : '2015-06-01'})
-        self.assertEqual(self.driver.find_element_by_class_name(
-            'alert-danger').text, 'Your criteria did not return any results.')"""
+        report_page.fill_report_form({ 'start' : '2015-05-10', 'end' : '2015-06-01'})
+        self.assertEqual(report_page.get_alert_box_text(),report_page.no_results_message)"""


### PR DESCRIPTION
Added database checks to tests corresponding to CRUD operations in following cases and number of tests-

1. Sign up Admin/volunteer with invalid/valid credentials (16 tests )
2. Create/edit event with valid/invalid details (9 tests)
3. Create/edit job with valid/invalid details (9 tests)
4. Create/edit shift with valid/invalid details (9 tests)
5. Create/edit/delete organization (5 tests )
6. Delete event, job, shift (6 tests)
7. Shift registration, cancel shift registration, edit volunteer profile (5 tests)
8. Add/edit/cancel hours by volunteer/admin (5 tests)

This PR contains the commits from PR #375 as the changes for database checks have been made _after_ the tests were redesigned to follow POM. This was done as otherwise there would be too many merge conflicts to fix.

The actual changes can be seen here once PR #375 is merged or can be currently seen [here](https://github.com/smarshy/vms/pull/3)