### PR TITLE
Added the about page

### DIFF
--- a/vms/vms/settings.py
+++ b/vms/vms/settings.py
@@ -28,6 +28,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
     'administrator',
     'authentication',
     'event',
@@ -123,3 +124,5 @@ LOGIN_REDIRECT_URL = reverse_lazy('home:index')
 RECOVER_ONLY_ACTIVE_USERS = False
 ACCOUNT_ACTIVATION_DAYS = 2
 ANONYMOUS_USER_ID = -1
+
+SITE_ID = 1

--- a/vms/vms/settings.py
+++ b/vms/vms/settings.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
+    'django.contrib.flatpages',
     'administrator',
     'authentication',
     'event',

--- a/vms/vms/templates/flatpages/default.html
+++ b/vms/vms/templates/flatpages/default.html
@@ -1,0 +1,26 @@
+{% extends "vms/base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+
+{% if messages %}
+
+<div class="alert alert-dismissible alert-success">
+  <button type="button" class="close" data-dismiss="alert">×</button>
+  <ul class="messages">
+    {% for message in messages %}
+    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+    {% endfor %}
+</ul>
+</div>
+
+{% endif %}
+
+    <div class="jumbotron jumbotron-custom">
+        <h1>{{ flatpage.title }}</h1>
+        {{ flatpage.content }}
+    </div>
+{% endblock %}
+
+

--- a/vms/vms/templates/vms/base.html
+++ b/vms/vms/templates/vms/base.html
@@ -40,7 +40,7 @@
 
 		<div class="navbar-collapse collapse" id="bs-example-navbar-collapse-1" aria-expanded="false" style="height: 1px;">
 			<ul class="nav navbar-nav text-uppercase">
-				<li><a href="{% url 'home:index' %}">{% trans "About" %}</a></li>
+				<li><a href="{% url 'about' %}">{% trans "About" %}</a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right text-uppercase">
                     {% if user.is_authenticated %}

--- a/vms/vms/urls.py
+++ b/vms/vms/urls.py
@@ -1,11 +1,13 @@
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
+from django.contrib.flatpages import views
 
 
 admin.autodiscover()
 
 urlpatterns = patterns('',
     url(r'^$', include('home.urls', namespace='home')),
+    url(r'^about/$', views.flatpage, {'url' : '/about/'}, name='about'),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^administrator/', include('administrator.urls', namespace='administrator')),
     url(r'^authentication/', include('authentication.urls', namespace='authentication')),


### PR DESCRIPTION


Fixes #403

Leveraged the Django flatpages app to enable the About page. You will need to create a flatpage object for the About page in the database to make this work. One way to do this is by using the Django Admin interface (see screenshot). Make sure that the url value of the object is set to: **/about/**

Using the flatpages app has the advantage that new static pages, like Contact Us, Privacy Policy etc. can now be added simply by creating appropriate flatpage objects in the database and adding URL patterns in urls.py.

<img width="776" alt="screen shot 2016-12-13 at 11 25 25 pm" src="https://cloud.githubusercontent.com/assets/12381508/21170226/4c1a991a-c191-11e6-9611-b679026c5720.png">