### PR TITLE
Updated link of guide in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Installation
 The VMS project uses the [Django](https://www.djangoproject.com/) web
 framework and [Python](https://www.python.org/).
 
-To get started, read the [Installation Guide](http://vms.readthedocs.org/en/latest/Installation%20Guide/).
+To get started, read the [Installation Guide](https://github.com/systers/vms/blob/develop/docs/Installation%20Guide.md).
 
 
 Contribute


### PR DESCRIPTION
@tapasweni-pathak Students are getting confused as the old link uses a guide which isn't updated. All the documentation updates are being made in the docs/installation guide. Can you please merge this soon?