### PR TITLE
Job editing now shows shift dates

### DIFF
--- a/vms/job/services.py
+++ b/vms/job/services.py
@@ -2,6 +2,9 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from job.models import Job
 from shift.services import get_shifts_with_open_slots_for_volunteer, get_volunteer_shifts_with_hours, get_unlogged_shifts_by_volunteer_id
+from shift.services import get_shifts_by_job_id
+
+from shift.models import Shift
 
 def job_not_empty(job_id):
     """ Check if the job exists and is not empty """
@@ -69,6 +72,11 @@ def get_job_by_id(job_id):
         result = job
 
     return result
+
+
+def get_job_shift_dates_distinct(job_id):
+    shift_list = get_shifts_by_job_id(job_id)
+    return shift_list.values_list('date', flat=True).distinct()
 
 
 def get_jobs_by_event_id(e_id):

--- a/vms/job/templates/job/edit.html
+++ b/vms/job/templates/job/edit.html
@@ -98,6 +98,18 @@
                             </div>
                         </div>
                     {% endif %}
+                    <div class="form-group">
+                        <label class="col-md-2 control-label">
+                            {% trans "Shifts" %}
+                        </label>
+                        <div class="col-md-8">
+                                {% for shift_date in shift_list %}
+                                  <p class="form-control-static" id="Shift_date_here">
+                                    {{shift_date}}
+                                  </p>
+                                {% endfor %}
+                        </div>
+                    </div>
                     {% if form.start_date.errors %}
                         <div class="form-group has-error">
                             <label class="col-md-2 control-label">{% trans "Start Date" %}<span class="asteriskField">*</span></label>

--- a/vms/job/views.py
+++ b/vms/job/views.py
@@ -92,12 +92,12 @@ class JobUpdateView(LoginRequiredMixin, AdministratorLoginRequiredMixin, UpdateV
     template_name = 'job/edit.html'
     success_url = reverse_lazy('job:list')
     def get_object(self, queryset=None):
-        job_id = self.kwargs['job_id']
-        obj = Job.objects.get(pk=job_id)
+        obj = get_job_by_id(self.kwargs['job_id'])
         return obj
     def get_context_data(self, **kwargs):
         context = super(JobUpdateView, self).get_context_data(**kwargs)
         context['event_list'] = get_events_ordered_by_name()
+        context['shift_list'] = get_job_shift_dates_distinct(self.kwargs['job_id'])
         return context
     def form_valid(self, form):
         job_id = self.kwargs['job_id']


### PR DESCRIPTION
Closes #396 
    GH link : https://github.com/systers/vms/issues/396
    - job/services.py : Add get_job_shift_dates_distinct()
    - job/views.py    : JobUpdateView.get_object() modified to use
                        get_job_by_id.
                        JobUpdateView.get_context_data modified to set
                        shift dates in context.
    - templates/job/edit.html : Modified to display shift dates.