### PR TITLE
Event editing now shows job dates

### DIFF
--- a/vms/event/templates/event/edit.html
+++ b/vms/event/templates/event/edit.html
@@ -88,6 +88,18 @@
                         </div>
                     </div>
                 {% endif %}
+
+                <div class="form-group">
+                    <label class="col-md-2 control-label">{% trans "Jobs" %}</label>
+                        <div class="col-md-8">
+                                {% for job_dates in job_list %}
+                                  <p class="form-control-static" id="Job_date_here">
+                                  {{job_dates.0}} - {{job_dates.1}}
+                                  </p>
+                                {% endfor %}
+                        </div>
+                    </div>
+
 				{% if form.country.errors %}
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">{% trans "Country" %}</label>

--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -11,6 +11,7 @@ from django.views.generic.edit import DeleteView
 from django.views.generic import ListView
 from event.services import *
 from event.models import *
+from job.services import get_jobs_by_event_id
 from django.core.urlresolvers import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.shortcuts import render_to_response
@@ -77,6 +78,12 @@ class EventUpdateView(LoginRequiredMixin, AdministratorLoginRequiredMixin, Updat
         event_id = self.kwargs['event_id']
         obj = Event.objects.get(pk=event_id)
         return obj
+
+    def get_context_data(self, **kwargs):
+        context = super(EventUpdateView, self).get_context_data(**kwargs)
+        job_obj = get_jobs_by_event_id(self.kwargs['event_id'])
+        context['job_list'] = job_obj.values_list('start_date', 'end_date').distinct()
+        return context
 
     def post(self, request, *args, **kwargs):
         event_id = self.kwargs['event_id']


### PR DESCRIPTION
Closes #397 
GH link : https://github.com/systers/vms/issues/397
 - event/views.py : EventUpdateView.get_context_data() added
                    to set job start and end dates to context.
 - event/templates/event/edit.html : Modified to display job dates.