### PR TITLE
Logging hours (adding & editing) shows shift time

### DIFF
--- a/vms/shift/templates/shift/add_hours.html
+++ b/vms/shift/templates/shift/add_hours.html
@@ -27,6 +27,16 @@
             {% csrf_token %}
             <fieldset>
                 <legend>{% trans "Log Shift Hours" %}</legend>
+                <div class="form-group">
+                        <label class="col-md-2 control-label">
+                            {% trans "Entire Shift Duration" %}
+                        </label>
+                        <div class="col-md-8">
+                                  <p class="form-control-static" id="Shift_date_here">
+                                    {{shift.start_time}} - {{shift.end_time}}
+                                  </p>
+                        </div>
+                    </div>
                 {% if form.start_time.errors %}
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">{% trans "Start Time" %}</label>

--- a/vms/shift/templates/shift/add_hours_manager.html
+++ b/vms/shift/templates/shift/add_hours_manager.html
@@ -27,6 +27,17 @@
             {% csrf_token %}
             <fieldset>
                 <legend>{% trans "Log Shift Hours" %}</legend>
+                <div class="form-group">
+                        <label class="col-md-2 control-label">
+                            {% trans "Entire Shift Duration" %}
+                        </label>
+                        <div class="col-md-8">
+                                  <p class="form-control-static" id="Shift_date_here">
+                                    {{shift.start_time}} - {{shift.end_time}}
+                                  </p>
+                        </div>
+                    </div>
+
                 {% if form.start_time.errors %}
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">{% trans "Start Time" %}</label>

--- a/vms/shift/templates/shift/edit_hours.html
+++ b/vms/shift/templates/shift/edit_hours.html
@@ -27,6 +27,29 @@
             {% csrf_token %}
             <fieldset>
                 <legend>{% trans "Edit Shift Hours" %}</legend>
+
+                <div class="form-group">
+                         <label class="col-md-2 control-label">
+                             {% trans "Entire Shift Duration" %}
+                         </label>
+                         <div class="col-md-8">
+                                   <p class="form-control-static" id="Shift_detail_here">
+                                     {{shift.start_time}} - {{shift.end_time}}
+                                   </p>
+                         </div>
+                </div>
+                <div class="form-group">
+                         <label class="col-md-2 control-label">
+                             {% trans "Logged Shift Duration" %}
+                         </label>
+                         <div class="col-md-8">
+                                   <p class="form-control-static" id="Logged_shift_detail_here">
+                                     {{volunteer_shift.start_time}} - {{volunteer_shift.end_time}}
+                                   </p>
+                         </div>
+                </div>
+
+
                 {% if form.start_time.errors %}
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">{% trans "Start Time" %}</label>

--- a/vms/shift/templates/shift/edit_hours_manager.html
+++ b/vms/shift/templates/shift/edit_hours_manager.html
@@ -27,6 +27,29 @@
             {% csrf_token %}
             <fieldset>
                 <legend>{% trans "Edit Shift Hours" %}</legend>
+
+                <div class="form-group">
+                         <label class="col-md-2 control-label">
+                             {% trans "Entire Shift Duration" %}
+                         </label>
+                         <div class="col-md-8">
+                                   <p class="form-control-static" id="Shift_detail_here">
+                                     {{shift.start_time}} - {{shift.end_time}}
+                                   </p>
+                         </div>
+                </div>
+                <div class="form-group">
+                         <label class="col-md-2 control-label">
+                             {% trans "Logged Shift Duration" %}
+                         </label>
+                         <div class="col-md-8">
+                                   <p class="form-control-static" id="Logged_shift_detail_here">
+                                     {{volunteer_shift.start_time}} - {{volunteer_shift.end_time}}
+                                   </p>
+                         </div>
+                </div>
+
+
                 {% if form.start_time.errors %}
                     <div class="form-group has-error">
                         <label class="col-md-2 control-label">{% trans "Start Time" %}</label>

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -75,14 +75,14 @@ class AddHoursView(LoginRequiredMixin, FormView):
                     return render(
                         self.request,
                         'shift/add_hours.html',
-                        {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id,}
+                        {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift,}
                     )
             else:
                 messages.add_message(self.request, messages.INFO, 'End time should be greater than start time')
                 return render(
                     self.request,
                     'shift/add_hours.html',
-                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id,}
+                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift,}
                 )
         except:
             raise Http404
@@ -127,7 +127,7 @@ class AddHoursManagerView(AdministratorLoginRequiredMixin, FormView):
                     return render(
                         self.request,
                         'shift/add_hours_manager.html',
-                        {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id,}
+                        {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift,}
                     )
 
             else:
@@ -135,7 +135,7 @@ class AddHoursManagerView(AdministratorLoginRequiredMixin, FormView):
                 return render(
                     self.request,
                     'shift/add_hours_manager.html',
-                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id,}
+                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift,}
                 )
         except:
             raise Http404
@@ -380,6 +380,7 @@ class EditHoursView(LoginRequiredMixin, FormView):
         volunteer_id = self.kwargs['volunteer_id']
         shift_id = self.kwargs['shift_id']
         shift = get_shift_by_id(shift_id)
+        volunteer_shift = get_volunteer_shift_by_id(volunteer_id, shift_id)
         start_time = form.cleaned_data['start_time']
         end_time = form.cleaned_data['end_time']
         shift_start_time = shift.start_time
@@ -399,7 +400,7 @@ class EditHoursView(LoginRequiredMixin, FormView):
                     return render(
                         self.request,
                         'shift/edit_hours.html',
-                        {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
+                        {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift, 'volunteer_shift':volunteer_shift,}
                     )
 
             else:
@@ -407,7 +408,7 @@ class EditHoursView(LoginRequiredMixin, FormView):
                 return render(
                     self.request,
                     'shift/edit_hours.html',
-                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
+                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift, 'volunteer_shift':volunteer_shift,}
                 )
         except:
             raise Http404
@@ -429,6 +430,7 @@ class EditHoursManagerView(AdministratorLoginRequiredMixin, FormView):
         volunteer_id = self.kwargs['volunteer_id']
         shift_id = self.kwargs['shift_id']
         shift = get_shift_by_id(shift_id)
+        volunteer_shift = get_volunteer_shift_by_id(volunteer_id, shift_id)
         start_time = form.cleaned_data['start_time']
         end_time = form.cleaned_data['end_time']
         shift_start_time = shift.start_time
@@ -443,7 +445,7 @@ class EditHoursManagerView(AdministratorLoginRequiredMixin, FormView):
                     return render(
                         self.request,
                         'shift/edit_hours_manager.html',
-                        {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
+                        {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift, 'volunteer_shift':volunteer_shift,}
                     )
 
             else:
@@ -451,7 +453,7 @@ class EditHoursManagerView(AdministratorLoginRequiredMixin, FormView):
                 return render(
                     self.request,
                     'shift/edit_hours_manager.html',
-                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id}
+                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift, 'volunteer_shift':volunteer_shift,}
                 )
 
         except:


### PR DESCRIPTION
Closes #409 
GH link : https://github.com/systers/vms/issues/409
- views.py : AddHoursView and EditHoursView modified to pass
             shift and volunteer shift values to render.
- templates/shift/add_hours.html : Modify to display shift hours.
- templates/shift/edit_hours.html : Modify to display shift and logged
                                    shift hours.