### PR TITLE
Added fix to disable unauthorized access by volunteers

### DIFF
--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -15,7 +15,7 @@ from django.core.urlresolvers import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.shortcuts import render_to_response
 from django.http import Http404
-
+from vms.utils import check_correct_volunteer
 
 class AdministratorLoginRequiredMixin(object):
 
@@ -122,6 +122,7 @@ class EventListView(LoginRequiredMixin, ListView):
 
 
 @login_required
+@check_correct_volunteer
 def list_sign_up(request, volunteer_id):
     if request.method == 'POST':
         form = EventDateForm(request.POST)

--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -15,7 +15,7 @@ from django.core.urlresolvers import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.shortcuts import render_to_response
 from django.http import Http404
-from vms.utils import check_correct_volunteer
+from vms.utils import check_correct_volunteer_shift_sign_up
 
 class AdministratorLoginRequiredMixin(object):
 
@@ -122,7 +122,7 @@ class EventListView(LoginRequiredMixin, ListView):
 
 
 @login_required
-@check_correct_volunteer
+@check_correct_volunteer_shift_sign_up
 def list_sign_up(request, volunteer_id):
     if request.method == 'POST':
         form = EventDateForm(request.POST)

--- a/vms/shift/tests/test_viewVolunteerShift.py
+++ b/vms/shift/tests/test_viewVolunteerShift.py
@@ -67,7 +67,7 @@ class ViewVolunteerShift(LiveServerTestCase):
     def test_access_another_nonexisting_volunteer_view(self):
         upcoming_shift_page = self.upcoming_shift_page
         upcoming_shift_page.get_page(self.live_server_url, upcoming_shift_page.view_shift_page + '65459')
-        found = re.search('Not Found', self.driver.page_source)
+        found = re.search('You don\'t have the required rights', self.driver.page_source)
         self.assertNotEqual(found, None)
 
     def test_view_without_any_assigned_shift(self):

--- a/vms/shift/tests/test_viewVolunteerShift.py
+++ b/vms/shift/tests/test_viewVolunteerShift.py
@@ -68,7 +68,6 @@ class ViewVolunteerShift(LiveServerTestCase):
         upcoming_shift_page = self.upcoming_shift_page
         upcoming_shift_page.get_page(self.live_server_url, upcoming_shift_page.view_shift_page + '65459')
         found = re.search('You don\'t have the required rights', self.driver.page_source)
-        found = re.search('You don\'t have the necessary rights to access this page', self.driver.page_source)
         self.assertNotEqual(found, None)
 
     def test_view_without_any_assigned_shift(self):

--- a/vms/shift/tests/test_viewVolunteerShift.py
+++ b/vms/shift/tests/test_viewVolunteerShift.py
@@ -66,7 +66,7 @@ class ViewVolunteerShift(LiveServerTestCase):
 
     def test_access_another_nonexisting_volunteer_view(self):
         upcoming_shift_page = self.upcoming_shift_page
-        upcoming_shift_page.get_page(self.live_server_url, upcoming_shift_page.view_shift_page + '65459'
+        upcoming_shift_page.get_page(self.live_server_url, upcoming_shift_page.view_shift_page + '65459')
         found = re.search('You don\'t have the required rights', self.driver.page_source)
         found = re.search('You don\'t have the necessary rights to access this page', self.driver.page_source)
         self.assertNotEqual(found, None)

--- a/vms/vms/templates/vms/no_volunteer_rights.html
+++ b/vms/vms/templates/vms/no_volunteer_rights.html
@@ -1,0 +1,22 @@
+{% extends "vms/base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+    <div class="spacer"></div>
+   
+        {% csrf_token %}
+        <div class="panel panel-danger">
+            <div class="panel-heading">
+                <h3 class="panel-title">{% trans "No Access" %}</h3>
+            </div>
+            <div class="panel-body">
+                <br>
+                {% trans "You don't have the required rights" %}
+                <br>
+                <br>
+                <input type="button" class="btn btn-default" value="{% blocktrans %}Return to Previous Page{% endblocktrans %}" onClick="javascript:history.go(-1);">
+            </div>
+        </div>
+   
+{% endblock %}

--- a/vms/vms/utils.py
+++ b/vms/vms/utils.py
@@ -1,0 +1,80 @@
+from functools import wraps
+from django.http import Http404
+from django.shortcuts import render
+from volunteer.models import Volunteer
+
+
+def check_correct_volunteer(func):
+    @wraps(func)
+    def wrapped_view(request, volunteer_id):
+        req_volunteer = getattr(request.user, "volunteer",
+                                hasattr(request.user, "administrator"))
+        if not req_volunteer:
+            raise Http404
+        elif req_volunteer is not True:
+            try:
+                volunteer = Volunteer.objects.get(id=volunteer_id)
+            except Volunteer.DoesNotExist:
+                return render(
+                    request,
+                    "vms/no_volunteer_rights.html",
+                    status=403
+                )
+            if volunteer.id == req_volunteer.id:
+                return func(request, volunteer_id)
+            else:
+                return render(
+                    request,
+                    "vms/no_volunteer_rights.html",
+                    status=403
+                )
+        else:
+            return render(
+                request,
+                "vms/no_volunteer_rights.html",
+                status=403
+            )
+        return render(
+                request,
+                "vms/no_volunteer_rights.html",
+                status=403
+            )
+    return wrapped_view
+
+
+def check_correct_volunteer_shift(func):
+    @wraps(func)
+    def wrapped_view(request, shift_id, volunteer_id):
+        req_volunteer = getattr(request.user, "volunteer",
+                                hasattr(request.user, "administrator"))
+        if not req_volunteer:
+            raise Http404
+        elif req_volunteer is not True:
+            try:
+                volunteer = Volunteer.objects.get(id=volunteer_id)
+            except Volunteer.DoesNotExist:
+                return render(
+                    request,
+                    "vms/no_volunteer_rights.html",
+                    status=403
+                )
+            if volunteer.id == req_volunteer.id:
+                return func(request, volunteer_id)
+            else:
+                return render(
+                    request,
+                    "vms/no_volunteer_rights.html",
+                    status=403
+                )
+        else:
+            return render(
+                request,
+                "vms/no_volunteer_rights.html",
+                status=403
+            )
+        return render(
+                request,
+                "vms/no_volunteer_rights.html",
+                status=403
+            )
+    return wrapped_view

--- a/vms/vms/utils.py
+++ b/vms/vms/utils.py
@@ -21,7 +21,7 @@ def check_correct_volunteer(func):
                     status=403
                 )
             if volunteer.id == req_volunteer.id:
-                return func(request, volunteer_id)
+                return func(request, volunteer_id=volunteer_id)
             else:
                 return render(
                     request,
@@ -59,7 +59,47 @@ def check_correct_volunteer_shift(func):
                     status=403
                 )
             if volunteer.id == req_volunteer.id:
-                return func(request, volunteer_id)
+                return func(request, volunteer_id=volunteer_id)
+            else:
+                return render(
+                    request,
+                    "vms/no_volunteer_rights.html",
+                    status=403
+                )
+        else:
+            return render(
+                request,
+                "vms/no_volunteer_rights.html",
+                status=403
+            )
+        return render(
+                request,
+                "vms/no_volunteer_rights.html",
+                status=403
+            )
+    return wrapped_view
+
+
+def check_correct_volunteer_shift_sign_up(func):
+    @wraps(func)
+    def wrapped_view(request, volunteer_id):
+        req_volunteer = getattr(request.user, "volunteer",
+                                hasattr(request.user, "administrator"))
+        if req_volunteer is True:
+            return func(request, volunteer_id=volunteer_id)
+        if not req_volunteer:
+            raise Http404
+        elif req_volunteer is not True:
+            try:
+                volunteer = Volunteer.objects.get(id=volunteer_id)
+            except Volunteer.DoesNotExist:
+                return render(
+                    request,
+                    "vms/no_volunteer_rights.html",
+                    status=403
+                )
+            if volunteer.id == req_volunteer.id:
+                return func(request, volunteer_id=volunteer_id)
             else:
                 return render(
                     request,

--- a/vms/volunteer/views.py
+++ b/vms/volunteer/views.py
@@ -21,7 +21,8 @@ from volunteer.services import *
 from volunteer.validation import validate_file
 from django.views.generic import View
 from django.core.urlresolvers import reverse_lazy
-
+from vms.utils import check_correct_volunteer
+from django.utils.decorators import method_decorator
 
 @login_required
 def download_resume(request, volunteer_id):
@@ -59,6 +60,11 @@ def delete_resume(request, volunteer_id):
 '''
 
 class VolunteerUpdateView(LoginRequiredMixin, UpdateView, FormView):
+
+    @method_decorator(check_correct_volunteer)
+    def dispatch(self, *args, **kwargs):
+        return super(VolunteerUpdateView, self).dispatch(*args, **kwargs)
+
     form_class = VolunteerForm
     template_name = 'volunteer/edit.html'
     success_url = reverse_lazy('volunteer:profile')
@@ -108,6 +114,10 @@ class VolunteerUpdateView(LoginRequiredMixin, UpdateView, FormView):
 class ProfileView(LoginRequiredMixin, DetailView):
     template_name = 'volunteer/profile.html'
 
+    @method_decorator(check_correct_volunteer)
+    def dispatch(self, *args, **kwargs):
+        return super(ProfileView, self).dispatch(*args, **kwargs)
+
     def get_object(self, queryset=None):
         volunteer_id = self.kwargs['volunteer_id']
         obj = Volunteer.objects.get(id=self.kwargs['volunteer_id'])
@@ -122,6 +132,10 @@ class ProfileView(LoginRequiredMixin, DetailView):
 '''
 
 class GenerateReportView(LoginRequiredMixin, View):
+
+    @method_decorator(check_correct_volunteer)
+    def dispatch(self, *args, **kwargs):
+        return super(GenerateReportView, self).dispatch(*args, **kwargs)
 
     def get(self, request, *args, **kwargs):
         view = ShowFormView.as_view()


### PR DESCRIPTION
Fixes issue #326 

In addition to the links mentioned in the issue, I've also fixed these urls -
1) `/volunteer/edit/` - Previously could be accessed by anyone
2) `/volunteer/add_hours/` - Previously could be accessed by anyone
3) `/volunteer/edit_hours/` - Previously could be accessed by anyone
4) `/shift/cancel/` - Previously showed an Http 403 page, fixed to show same error page as other ones.

Here is the screenshot -
![screenshot from 2017-01-13 23-10-43](https://cloud.githubusercontent.com/assets/17357089/21939535/36f5c790-d9e6-11e6-8469-267be20639e9.png)

**PS: In this commit, administrators cannot see the volunteer restricted pages too _except shift sign-up page_. If this needs to be changed, please tell me.**