### PR TITLE
Referencing Issue #321: Don’t allow shift cancellation once a shift has started

### DIFF
--- a/vms/shift/templates/shift/cancel_shift.html
+++ b/vms/shift/templates/shift/cancel_shift.html
@@ -7,21 +7,32 @@
     <form action="{% url 'shift:cancel' shift_id volunteer_id %}" method="post">
         {% csrf_token %}
         <div class="panel panel-danger">
-            <div class="panel-heading">
-                <h3 class="panel-title">{% trans "Cancel Shift Confirmation" %}</h3>
-            </div>
-            <div class="panel-body">
                 <br>
-                {% if user.administrator %}
-                    {% trans "Are you sure you want to cancel this registered shift?" %}
+                {% if error %}
+                    <div class="panel-heading">
+                        <h3 class="panel-title">{% trans "Can't Cancel Shift" %}</h3>
+                    </div>
+                    <div class="panel-body">
+                        {{ error }}
+                        <br>
+                        <br>
+                    </div>
                 {% else %}
-                    {% trans "Are you sure you want to cancel this shift you are signed up for?" %}
+                    <div class="panel-heading">
+                        <h3 class="panel-title">{% trans "Cancel Shift Confirmation" %}</h3>
+                    </div>
+                    <div class="panel-body">
+                        {% if user.administrator %}
+                            {% trans "Are you sure you want to cancel this registered shift?" %}
+                        {% else %}
+                            {% trans "Are you sure you want to cancel this shift you are signed up for?" %}
+                        {% endif %}
+                        <br>
+                        <br>
+                        <button class="btn btn-danger" type="submit">{% trans "Yes, Cancel this Shift" %}</button>
+                        <input type="button" class="btn btn-default" value="{% blocktrans %}Return to Previous Page{% endblocktrans %}" onClick="javascript:history.go(-1);">
+                    </div>
                 {% endif %}
-                <br>
-                <br>
-                <button class="btn btn-danger" type="submit">{% trans "Yes, Cancel this Shift" %}</button>
-                <input type="button" class="btn btn-default" value="{% blocktrans %}Return to Previous Page{% endblocktrans %}" onClick="javascript:history.go(-1);">
-            </div>
         </div>
     </form>
 {% endblock %}

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -21,6 +21,7 @@ from django.core.urlresolvers import reverse_lazy
 from volunteer.utils import vol_id_check
 from vms.utils import check_correct_volunteer, check_correct_volunteer_shift
 
+
 class AdministratorLoginRequiredMixin(object):
 
     @method_decorator(login_required)
@@ -180,6 +181,16 @@ def cancel(request, shift_id, volunteer_id):
                     'vms/no_volunteer_rights.html',
                     status=403
                 )
+        shift = get_shift_by_id(shift_id)
+        shift_time = datetime.datetime.combine(shift.job.start_date, shift.start_time)
+        if shift.job.start_date <= datetime.date.today() and shift.job.end_date >= datetime.date.today():
+            if datetime.datetime.utcnow().time() >= shift.start_time :
+                return render(
+                    request,
+                    'shift/cancel_shift.html',
+                    {'shift_id': shift_id, 'volunteer_id': volunteer_id, 
+                    'error': 'This shift has already started.'}
+                    )
 
         if request.method == 'POST':
             try:


### PR DESCRIPTION
Fixes #321 

Currently I have made changes according to UTC time. I tried several ways to fix the django overriding of default timezone settings but i was unable to get the system timezone. Also so we need the timezone of the system or where the request has been generated?