### PR TITLE
[#509] Introduce python-3.x style imports, fix code style+smell

### DIFF
--- a/vms/administrator/admin.py
+++ b/vms/administrator/admin.py
@@ -1,5 +1,5 @@
 #Django
-from administrator.models import Administrator
+from vms.administrator.models import Administrator
 
 # local Django
 from django.contrib import admin

--- a/vms/administrator/forms.py
+++ b/vms/administrator/forms.py
@@ -1,14 +1,18 @@
 from django import forms
 from django.db import models
 from django.forms import ModelForm
-from administrator.models import Administrator
+
+
+from vms.administrator.models import Administrator
 
 
 class AdministratorForm(ModelForm):
     class Meta:
         model = Administrator
-        fields = ['first_name', 'last_name', 'address', 'city', 'state', 'country', 'phone_number',
-                  'unlisted_organization', 'email']
+        fields = [
+            'first_name', 'last_name', 'address', 'city', 'state', 'country',
+            'phone_number', 'unlisted_organization', 'email'
+        ]
 
 
 class ReportForm(forms.Form):

--- a/vms/administrator/models.py
+++ b/vms/administrator/models.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 from django.core.validators import RegexValidator
 from django.db import models
 
-from organization.models import Organization
+from vms.organization.models import Organization
 
 
 class Administrator(models.Model):

--- a/vms/administrator/tests/test_formFields.py
+++ b/vms/administrator/tests/test_formFields.py
@@ -7,18 +7,18 @@ from selenium.webdriver.support.ui import Select
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
 # local Django
-from event.models import Event
-from job.models import Job
-from pom.locators.eventsPageLocators import *
-from pom.pages.authenticationPage import AuthenticationPage
-from pom.pages.eventsPage import EventsPage
-from shift.models import Shift
-from shift.utils import (
+from vms.event.models import Event
+from vms.job.models import Job
+from vms.pom.locators.eventsPageLocators import *
+from vms.pom.pages.authenticationPage import AuthenticationPage
+from vms.pom.pages.eventsPage import EventsPage
+from vms.shift.models import Shift
+from vms.shift.utils import (
     create_admin,
     create_event_with_details,
     create_job_with_details,
     create_shift_with_details
-    )
+)
 
 
 class FormFields(LiveServerTestCase):
@@ -169,7 +169,7 @@ class FormFields(LiveServerTestCase):
 
         # check that job was not edited and that error messages appear as
         # expected
-        self.assertNotEqual(self.driver.current_url, 
+        self.assertNotEqual(self.driver.current_url,
             self.live_server_url + settings.job_list_page)
         self.assertEqual(len(settings.get_help_blocks()), 3)
 
@@ -446,4 +446,3 @@ class FormFields(LiveServerTestCase):
         select.select_by_visible_text('event')
         self.assertEqual(settings.get_job_event_start_date(), 'June 15, 2017')
         self.assertEqual(settings.get_job_event_end_date(), 'June 17, 2017')"""
-    

--- a/vms/administrator/tests/test_report.py
+++ b/vms/administrator/tests/test_report.py
@@ -7,9 +7,9 @@ from django.contrib.staticfiles.testing import LiveServerTestCase
 from django.db import IntegrityError
 
 # local Django
-from pom.locators.administratorReportPageLocators import *
-from pom.pages.administratorReportPage import AdministratorReportPage
-from pom.pages.authenticationPage import AuthenticationPage
+from vms.pom.locators.administratorReportPageLocators import *
+from vms.pom.pages.administratorReportPage import AdministratorReportPage
+from vms.pom.pages.authenticationPage import AuthenticationPage
 from shift.utils import (
     create_admin,
     create_volunteer,
@@ -19,7 +19,7 @@ from shift.utils import (
     create_shift_with_details,
     log_hours_with_details,
     register_volunteer_for_shift_utility
-    )
+)
 
 
 class Report(LiveServerTestCase):

--- a/vms/administrator/tests/test_settings.py
+++ b/vms/administrator/tests/test_settings.py
@@ -6,14 +6,14 @@ from selenium.common.exceptions import NoSuchElementException
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
 # local Django
-from event.models import Event
-from job.models import Job
-from organization.models import Organization
-from pom.pages.eventsPage import EventsPage
-from pom.pages.authenticationPage import AuthenticationPage
-from pom.locators.eventsPageLocators import *
-from shift.models import Shift
-from shift.utils import (
+from vms.event.models import Event
+from vms.job.models import Job
+from vms.organization.models import Organization
+from vms.pom.pages.eventsPage import EventsPage
+from vms.pom.pages.authenticationPage import AuthenticationPage
+from vms.pom.locators.eventsPageLocators import *
+from vms.shift.models import Shift
+from vms.shift.utils import (
     create_admin,
     create_event_with_details,
     create_job_with_details,
@@ -21,7 +21,7 @@ from shift.utils import (
     create_volunteer,
     register_volunteer_for_shift_utility,
     create_organization
-    )
+)
 
 
 class Settings(LiveServerTestCase):
@@ -228,7 +228,7 @@ class Settings(LiveServerTestCase):
         self.assertNotEqual(len(Event.objects.filter(name=edited_event[0])), 0)
 
     def test_create_and_edit_event_with_invalid_start_date(self):
-        
+
         settings = self.settings
         settings.live_server_url = self.live_server_url
         settings.go_to_create_event_page()
@@ -908,7 +908,7 @@ class Settings(LiveServerTestCase):
 
         self.assertEqual(settings.get_help_block().text,
             'Organization with this Name already exists.')
-        
+
         # database check to ensure that duplicate organization is created
         self.assertEqual(len(Organization.objects.all()), 1)
 

--- a/vms/administrator/urls.py
+++ b/vms/administrator/urls.py
@@ -2,10 +2,11 @@
 from django.conf.urls import patterns, url
 
 # local Django
-from administrator import views
-from administrator.views import *
+from vms.administrator import views
+from vms.administrator.views import *
 
-urlpatterns = patterns('',
-                       url(r'^report/$', GenerateReportView.as_view(), name='report'),
-                       url(r'^settings/$', views.settings, name='settings'),
-                       )
+urlpatterns = patterns(
+    '',
+    url(r'^report/$', GenerateReportView.as_view(), name='report'),
+    url(r'^settings/$', views.settings, name='settings'),
+)


### PR DESCRIPTION
Alright. This is a start. Let me explain what all are started here: 

* Introduce a proper  __init__.py on django root so that we can use proper `vms.appname.lables` on import (mandatory for python3.x conversion). 
* Use inbuilt `get_context_data()` rather than using class variables and passing (was not working at cases and is ugly). 
* Fix imports in `administrator/`. Probably we can assign the rest to someone else as its a simple easy first task. 