### PR TITLE
Volunteer profile: Restrict file type in resume

### DIFF
--- a/vms/volunteer/models.py
+++ b/vms/volunteer/models.py
@@ -10,6 +10,7 @@ from django.db import models
 # local Django
 from organization.models import Organization
 
+from volunteer.validators import validate_file_extension
 
 class Volunteer(models.Model):
     id = models.AutoField(primary_key=True)
@@ -111,6 +112,7 @@ class Volunteer(models.Model):
     resume_file = models.FileField(
         upload_to='vms/resume/',
         max_length=75,
+        validators=[validate_file_extension],
         blank=True
         )
     reminder_days = models.IntegerField(

--- a/vms/volunteer/validators.py
+++ b/vms/volunteer/validators.py
@@ -1,0 +1,7 @@
+def validate_file_extension(value):
+    import os
+    from django.core.exceptions import ValidationError
+    ext = os.path.splitext(value.name)[1]  # [0] returns path+filename
+    valid_extensions = ['.pdf', '.doc', '.docx']
+    if not ext.lower() in valid_extensions:
+        raise ValidationError(u'Unsupported file extension.')


### PR DESCRIPTION
The upload_resume field in profile form accepts
files having extensions like .pdf, .doc, and .docx only.

Closes https://github.com/systers/vms/issues/565

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

# How Has This Been Tested?
Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test.


# Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes
