### PR TITLE
vms_style.css: Remove extra space from report template

### DIFF
--- a/vms/vms/static/vms/css/style.css
+++ b/vms/vms/static/vms/css/style.css
@@ -27,6 +27,7 @@ body {
 -------------------------------------------------- */
 body > .container {
   padding: 60px 15px 0;
+  overflow-x: hidden;
 }
 
 .container .text-muted {


### PR DESCRIPTION
Closes https://github.com/systers/vms/issues/569

# Type of Change:
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

# Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
