### PR TITLE
shifts_views.py: Log shift hours

### DIFF
--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -67,33 +67,40 @@ class AddHoursView(LoginRequiredMixin, FormView):
         end_time = form.cleaned_data['end_time']
         shift_start_time = shift.start_time
         shift_end_time = shift.end_time
+        shift_date = shift.date
         try:
-            if (end_time > start_time):
-                if (start_time >= shift_start_time and end_time <= shift_end_time):
-                    add_shift_hours(
-                        volunteer_id,
-                        shift_id,
-                        start_time,
-                        end_time
-                    )
-                    return HttpResponseRedirect(reverse(
-                        'shift:view_hours',
-                        args=(volunteer_id,)
-                    ))
-                else:
-                    messages.add_message(self.request, messages.INFO, 'Logged hours should be between shift hours')
-                    return render(
-                        self.request,
-                        'shift/add_hours.html',
-                        {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift,}
-                    )
-            else:
+            if (not end_time > start_time):
                 messages.add_message(self.request, messages.INFO, 'End time should be greater than start time')
                 return render(
                     self.request,
                     'shift/add_hours.html',
                     {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift,}
                 )
+            if (not (start_time >= shift_start_time and end_time <= shift_end_time)):
+                messages.add_message(self.request, messages.INFO, 'Logged hours should be between shift hours')
+                return render(
+                    self.request,
+                    'shift/add_hours.html',
+                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift,}
+                )
+            if (not shift_date < date.today()):
+                messages.add_message(self.request, messages.INFO, 'Shift hours can be logged only after the shift date expires.')
+                return render(
+                    self.request,
+                    'shift/add_hours.html',
+                    {'form': form, 'shift_id': shift_id, 'volunteer_id': volunteer_id, 'shift':shift,}
+                    )
+
+            add_shift_hours(
+                volunteer_id,
+                shift_id,
+                start_time,
+                end_time
+            )
+            return HttpResponseRedirect(reverse(
+                'shift:view_hours',
+                args=(volunteer_id,)
+                ))
         except:
             raise Http404
 


### PR DESCRIPTION
This allows the volunteers to log shift hours
only after the shift date has expired and displays
proper message otherwise.

Closes https://github.com/systers/vms/issues/502

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

# Mocks
![shiftlogs1](https://user-images.githubusercontent.com/19872082/35686958-89269ffe-0793-11e8-912e-62ddfa93e0e4.png)
![shiftlogs2](https://user-images.githubusercontent.com/19872082/35686983-948d68dc-0793-11e8-809b-d4df60df8b0d.png)

# Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
