### PR TITLE
Jobs added in the job list while viewing the report as volunteer.Logut button for django admin.

### DIFF
--- a/vms/vms/templates/vms/base.html
+++ b/vms/vms/templates/vms/base.html
@@ -39,7 +39,7 @@
             </div>
 
 		<div class="navbar-collapse collapse" id="bs-example-navbar-collapse-1" aria-expanded="false" style="height: 1px;">
-		
+
             <ul class="nav navbar-nav navbar-right text-uppercase">
                     {% if user.is_authenticated %}
                         {% if user.administrator %}
@@ -60,8 +60,7 @@
                         </li>
                       </ul>
 
-                        {% endif %}
-                        {% if user.volunteer %}
+                        {% elif user.volunteer %}
                             <li><a href="{% url 'shift:view_volunteer_shifts' user.volunteer.id %}">{% trans "Upcoming Shifts" %}</a></li>
                             <li><a href="{% url 'shift:view_hours' user.volunteer.id %}">{% trans "Completed Shifts" %}</a></li>
                             <li><a href="{% url 'event:list_sign_up' user.volunteer.id %}">{% trans "Shift Sign Up" %}</a></li>
@@ -80,7 +79,10 @@
                         </li>
              </ul>
 
+                        {% else %}
+                            <li><a href="{% url 'authentication:logout_process' %}">{% trans "Log Out" %}</a></li>
                         {% endif %}
+
                     {% else %}
                         <li><a href="{% url 'registration:signup_volunteer' %}">{% trans "Sign Up" %}</a></li>
                         <li><a href="{% url 'authentication:login_process' %}">{% trans "Log In" %}</a></li>

--- a/vms/volunteer/views.py
+++ b/vms/volunteer/views.py
@@ -174,8 +174,11 @@ class ShowFormView(LoginRequiredMixin, FormView):
     def get(self, request, *args, **kwargs):
         volunteer_id = self.kwargs['volunteer_id']
         event_list = get_signed_up_events_for_volunteer(volunteer_id)
+        job_list = get_signed_up_jobs_for_volunteer(volunteer_id)
+
         return render(request, 'volunteer/report.html', {
-            'event_list': event_list
+            'event_list': event_list,
+            'job_list': job_list,
         })
 
 


### PR DESCRIPTION
# Description
- Job list can now be seen when logged in as a volunteer, allowing them to select one of their jobs to generate the report.

- Added a logout button for the Django-admin.


Fixes #572 #579 

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?
Logged in as Volunteer to see the report in the local development system.


# Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 