### PR TITLE
Displaying Organisation List in the volunteer profile edit form.

### DIFF
--- a/vms/volunteer/views.py
+++ b/vms/volunteer/views.py
@@ -79,6 +79,12 @@ class VolunteerUpdateView(LoginRequiredMixin, UpdateView, FormView):
     template_name = 'volunteer/edit.html'
     success_url = reverse_lazy('volunteer:profile')
 
+    def get_context_data(self, **kwargs):
+        context = super(VolunteerUpdateView,self).get_context_data(**kwargs)
+        organization_list = get_organizations_ordered_by_name()
+        context['organization_list'] = organization_list
+        return context
+
     def get_object(self, queryset=None):
         volunteer_id = self.kwargs['volunteer_id']
         obj = Volunteer.objects.get(pk=volunteer_id)


### PR DESCRIPTION
# Description
Organisations are now displayed in the volunteer profile edit form.
Fixes #580 #581 

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested on a local development system. Refer the screenshots.

![image](https://user-images.githubusercontent.com/17281037/35758595-def7236a-089a-11e8-940d-d2e15150d697.png)

**Organisations** appear in the list.

![image](https://user-images.githubusercontent.com/17281037/35758326-7a1cc554-0899-11e8-80de-b7c579ea7977.png)


# Checklist:
**Delete irrelevant options.**
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes
