### PR TITLE
Volunteer's organization changed from none and organization list added in edit profile

### DIFF
--- a/vms/volunteer/views.py
+++ b/vms/volunteer/views.py
@@ -25,8 +25,7 @@ from organization.services import get_organization_by_id, get_organizations_orde
 from shift.services import get_volunteer_report, calculate_total_report_hours
 from volunteer.forms import ReportForm, SearchVolunteerForm, VolunteerForm
 from volunteer.models import Volunteer
-from volunteer.services import (delete_volunteer_resume, search_volunteers, get_volunteer_resume_file_url,
-get_volunteer_by_id,delete_volunteer_resume, has_resume_file)
+from volunteer.services import delete_volunteer_resume, search_volunteers, get_volunteer_resume_file_url
 from volunteer.validation import validate_file
 from volunteer.utils import vol_id_check
 from vms.utils import check_correct_volunteer

--- a/vms/volunteer/views.py
+++ b/vms/volunteer/views.py
@@ -25,7 +25,8 @@ from organization.services import get_organization_by_id, get_organizations_orde
 from shift.services import get_volunteer_report, calculate_total_report_hours
 from volunteer.forms import ReportForm, SearchVolunteerForm, VolunteerForm
 from volunteer.models import Volunteer
-from volunteer.services import delete_volunteer_resume, search_volunteers, get_volunteer_resume_file_url
+from volunteer.services import delete_volunteer_resume, search_volunteers, get_volunteer_resume_file_url,
+get_volunteer_by_id,delete_volunteer_resume, has_resume_file
 from volunteer.validation import validate_file
 from volunteer.utils import vol_id_check
 from vms.utils import check_correct_volunteer
@@ -83,6 +84,11 @@ class VolunteerUpdateView(LoginRequiredMixin, UpdateView, FormView):
         volunteer_id = self.kwargs['volunteer_id']
         obj = Volunteer.objects.get(pk=volunteer_id)
         return obj
+
+    def get_context_data(self,**kwargs):
+        context = super(VolunteerUpdateView, self).get_context_data(**kwargs)
+        context['organization_list']=get_organizations_ordered_by_name()
+        return context
 
     def form_valid(self, form):
         volunteer_id = self.kwargs['volunteer_id']

--- a/vms/volunteer/views.py
+++ b/vms/volunteer/views.py
@@ -25,8 +25,8 @@ from organization.services import get_organization_by_id, get_organizations_orde
 from shift.services import get_volunteer_report, calculate_total_report_hours
 from volunteer.forms import ReportForm, SearchVolunteerForm, VolunteerForm
 from volunteer.models import Volunteer
-from volunteer.services import delete_volunteer_resume, search_volunteers, get_volunteer_resume_file_url,
-get_volunteer_by_id,delete_volunteer_resume, has_resume_file
+from volunteer.services import (delete_volunteer_resume, search_volunteers, get_volunteer_resume_file_url,
+get_volunteer_by_id,delete_volunteer_resume, has_resume_file)
 from volunteer.validation import validate_file
 from volunteer.utils import vol_id_check
 from vms.utils import check_correct_volunteer


### PR DESCRIPTION
# Description
Previously, when the user wanted to edit his profile he was not shown organization list and his organization was set to none. Organization list is now passed as a context data in form to show organizations list

Issue #581, #582 

# Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
![image](https://user-images.githubusercontent.com/22369767/35765565-72219fe8-08ec-11e8-94ad-8a07d51309d7.png)
![image](https://user-images.githubusercontent.com/22369767/35765567-7904e7ac-08ec-11e8-882b-4c5bb9a71027.png)


# Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
