### PR TITLE
Added jobs in the job list while viewing the report form as volunteers

### DIFF
--- a/vms/volunteer/views.py
+++ b/vms/volunteer/views.py
@@ -174,8 +174,11 @@ class ShowFormView(LoginRequiredMixin, FormView):
     def get(self, request, *args, **kwargs):
         volunteer_id = self.kwargs['volunteer_id']
         event_list = get_signed_up_events_for_volunteer(volunteer_id)
+        job_list = get_signed_up_jobs_for_volunteer(volunteer_id)
+
         return render(request, 'volunteer/report.html', {
-            'event_list': event_list
+            'event_list': event_list,
+            'job_list':job_list,
         })
 
 


### PR DESCRIPTION
# Description
When a user tries to check the report, nothing appears in job list dropdown.Added the job lists by including job list in context.

Fixes #572 

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested on a local development system. Refer screenshots.

Added a job.

![image](https://user-images.githubusercontent.com/17281037/35765834-8d937192-08f2-11e8-8249-69ee0ec4d8dc.png)


# Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project

**Code/Quality Assurance Only**
- [ ] My changes generate no new 
