### PR TITLE
Volunteer profile: Restrict file type in resume

### DIFF
--- a/vms/volunteer/models.py
+++ b/vms/volunteer/models.py
@@ -6,7 +6,7 @@ from django.db import models
 
 # local Django
 from organization.models import Organization
-
+from volunteer.validators import validate_file_extension
 
 class Volunteer(models.Model):
     id = models.AutoField(primary_key=True)
@@ -88,7 +88,7 @@ class Volunteer(models.Model):
     )
     # all resumes are stored in /srv/vms/resume/
     resume_file = models.FileField(
-        upload_to='vms/resume/', max_length=75, blank=True)
+        upload_to='vms/resume/',validators=[validate_file_extension], max_length=75, blank=True)
     reminder_days = models.IntegerField(
         default=1,
         validators=[MaxValueValidator(50),

--- a/vms/volunteer/validators.py
+++ b/vms/volunteer/validators.py
@@ -1,0 +1,7 @@
+def validate_file_extension(value):
+	import os
+	from django.core.exceptions import ValidationError
+	ext = os.path.splitext(value.name)[1]  # [0] returns path+filename
+	valid_extensions = ['.pdf', '.doc', '.docx']
+	if not ext.lower() in valid_extensions:
+		raise ValidationError(u'Unsupported file extension.')


### PR DESCRIPTION
# Description
The upload_resume field in profile form accepts
files having extensions like .pdf, .doc, and .docx only.

Closes https://github.com/systers/vms/issues/565

# Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes