### PR TITLE
Hide textbox for unlisted organisation in edit profile form if an organisation is selected from given list

### DIFF
--- a/vms/volunteer/templates/volunteer/edit.html
+++ b/vms/volunteer/templates/volunteer/edit.html
@@ -214,7 +214,7 @@
                         {% trans "Select your organization:" %}
                     </label>
                     <div class="col-md-8">
-                        <select id="select" class="form-control" name="organization_name">
+                        <select id="select" class="form-control" name="organization_name" onchange="hide_organisation()">
                             <option value="0">-- {% trans "None" %} --</option>
                             {% for organization in organization_list %}
                                 {% if volunteer.organization_id %}

--- a/vms/volunteer/templates/volunteer/edit.html
+++ b/vms/volunteer/templates/volunteer/edit.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% load static %}
+
 {% block content %}
     <div class="spacer"></div>
     <div class="well">
@@ -249,6 +251,7 @@
                             <input class="form-control" type="text" placeholder="{% blocktrans %}Organization{% endblocktrans %}" name="unlisted_organization" value="{% if form.unlisted_organization.value %}{{ form.unlisted_organization.value }}{% endif %}">
                         </div>
                     </div>
+                <script type="text/javascript" src="{% static 'vms/js/hide_organization.js' %}"></script>                 
                 {% endif %}
                 {% if form.websites.errors %}
                     <div class="form-group has-error">

--- a/vms/volunteer/templates/volunteer/edit.html
+++ b/vms/volunteer/templates/volunteer/edit.html
@@ -234,7 +234,7 @@
                     <div id="div_id_unlisted_organization" class="form-group has-error">
                         <label class="col-md-2 control-label">{% trans "If your organization is not listed, please provide it here:" %}</label>
                         <div id="div_id_unlisted_organization" class="col-md-8">
-                            <input id="id_unlisted_organization" class="form-control" type="text" placeholder="{% blocktrans %}Organization{% endblocktrans %}" name="unlisted_organization" value="{% if form.unlisted_organization.value %}{{ form.unlisted_organization.value }}{% endif %}">
+                            <input class="form-control" type="text" placeholder="{% blocktrans %}Organization{% endblocktrans %}" name="unlisted_organization" value="{% if form.unlisted_organization.value %}{{ form.unlisted_organization.value }}{% endif %}">
                             <p class="help-block">
                                 <strong>
                                     {% for error in form.unlisted_organization.errors %}
@@ -248,7 +248,7 @@
                     <div id="div_id_unlisted_organization" class="form-group">
                         <label class="col-md-2 control-label">{% trans "If your organization is not listed, please provide it here:" %}</label>
                         <div class="col-md-8">
-                            <input id="id_unlisted_organization" class="form-control" type="text" placeholder="{% blocktrans %}Organization{% endblocktrans %}" name="unlisted_organization" value="{% if form.unlisted_organization.value %}{{ form.unlisted_organization.value }}{% endif %}">
+                            <input class="form-control" type="text" placeholder="{% blocktrans %}Organization{% endblocktrans %}" name="unlisted_organization" value="{% if form.unlisted_organization.value %}{{ form.unlisted_organization.value }}{% endif %}">
                         </div>
                     </div>
                 <script type="text/javascript" src="{% static 'vms/js/hide_organization.js' %}"></script>                 

--- a/vms/volunteer/templates/volunteer/edit.html
+++ b/vms/volunteer/templates/volunteer/edit.html
@@ -214,7 +214,7 @@
                         {% trans "Select your organization:" %}
                     </label>
                     <div class="col-md-8">
-                        <select class="form-control" name="organization_name">
+                        <select id="select" class="form-control" name="organization_name">
                             <option value="0">-- {% trans "None" %} --</option>
                             {% for organization in organization_list %}
                                 {% if volunteer.organization_id %}
@@ -231,10 +231,10 @@
                     </div>
                 </div>
                 {% if form.unlisted_organization.errors %}
-                    <div class="form-group has-error">
+                    <div id="div_id_unlisted_organization" class="form-group has-error">
                         <label class="col-md-2 control-label">{% trans "If your organization is not listed, please provide it here:" %}</label>
-                        <div class="col-md-8">
-                            <input class="form-control" type="text" placeholder="{% blocktrans %}Organization{% endblocktrans %}" name="unlisted_organization" value="{% if form.unlisted_organization.value %}{{ form.unlisted_organization.value }}{% endif %}">
+                        <div id="div_id_unlisted_organization" class="col-md-8">
+                            <input id="id_unlisted_organization" class="form-control" type="text" placeholder="{% blocktrans %}Organization{% endblocktrans %}" name="unlisted_organization" value="{% if form.unlisted_organization.value %}{{ form.unlisted_organization.value }}{% endif %}">
                             <p class="help-block">
                                 <strong>
                                     {% for error in form.unlisted_organization.errors %}
@@ -245,10 +245,10 @@
                         </div>
                     </div>
                 {% else %}
-                    <div class="form-group">
+                    <div id="div_id_unlisted_organization" class="form-group">
                         <label class="col-md-2 control-label">{% trans "If your organization is not listed, please provide it here:" %}</label>
                         <div class="col-md-8">
-                            <input class="form-control" type="text" placeholder="{% blocktrans %}Organization{% endblocktrans %}" name="unlisted_organization" value="{% if form.unlisted_organization.value %}{{ form.unlisted_organization.value }}{% endif %}">
+                            <input id="id_unlisted_organization" class="form-control" type="text" placeholder="{% blocktrans %}Organization{% endblocktrans %}" name="unlisted_organization" value="{% if form.unlisted_organization.value %}{{ form.unlisted_organization.value }}{% endif %}">
                         </div>
                     </div>
                 <script type="text/javascript" src="{% static 'vms/js/hide_organization.js' %}"></script>                 


### PR DESCRIPTION
# Description
If the user has selected from the listed organisations , then the unlisted organisation textbox doesn't appear.

Fixes #622 

# Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

# How Has This Been Tested?
![screenshot from 2018-02-14 10-50-33](https://user-images.githubusercontent.com/22369767/36278350-9a77c9be-12b9-11e8-99b4-525b4a1e6b6f.png)

# Checklist
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
