### PR TITLE
Hide textbox for resume link if resume file is uploaded in sign up form

### DIFF
--- a/vms/registration/templates/registration/signup_volunteer.html
+++ b/vms/registration/templates/registration/signup_volunteer.html
@@ -374,7 +374,7 @@
                 </div>
             </div>
         {% endif %}
-        <div id="div_id_resume_file" class="form-group">
+        <div id="div_id_resume_file" class="form-group" onchange="hide_resume_textbox()">
             <label class="control-label">{% trans "Upload a Resume" %}</label>
             {{ volunteer_form.resume_file }}
         </div>

--- a/vms/vms/static/vms/js/hide_resume_textbox.js
+++ b/vms/vms/static/vms/js/hide_resume_textbox.js
@@ -1,0 +1,7 @@
+function hide_resume_textbox() {
+var fileLength = $("#id_vol-resume_file")[0].files.length;
+if (fileLength!==0){
+$("#div_id_resume").hide();}
+else
+{$("div_id_resume").show();}
+}

--- a/vms/vms/templates/vms/base.html
+++ b/vms/vms/templates/vms/base.html
@@ -24,6 +24,7 @@
     <script src="{% static "vms/jquery-ui-1.11.4.custom/jquery-ui.min.js" %}"></script>
     <script src="{% static "vms/jquery-custom/activate-datepicker.js" %}"></script>
     <script src="{% static "vms/datetimepicker/bootstrap-datetimepicker.min.js" %}"></script>
+    <script src="{% static "vms/js/hide_resume_textbox.js" %}"></script>
   </head>
   <body>
     <div class="navbar navbar-default navbar-fixed-top" role="navigation">


### PR DESCRIPTION
# Description
The textbox for resume link hides if volunteer uploads a resume file.
 
Fixes #624 

# Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

# How Has This Been Tested?
![screenshot from 2018-02-16 12-04-23](https://user-images.githubusercontent.com/22369767/36296426-3db542d8-1313-11e8-8d47-2024828730e8.png)

# Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
