### PR TITLE
Fixed address field regex parameters to allow some special charecters

### DIFF
--- a/vms/administrator/models.py
+++ b/vms/administrator/models.py
@@ -21,7 +21,7 @@ class Administrator(models.Model):
     address = models.CharField(
         max_length=75,
         validators=[
-            RegexValidator(r'^[(A-Z)|(a-z)|(0-9)|(\s)|(\-)]+$', ),
+            RegexValidator(r'^[(A-Z)|(a-z)|(0-9)|(\s)|(\-)|(\.)|(,)|(\:)]+$', ),
         ],
     )
     city = models.CharField(

--- a/vms/volunteer/models.py
+++ b/vms/volunteer/models.py
@@ -25,7 +25,7 @@ class Volunteer(models.Model):
     address = models.CharField(
         max_length=75,
         validators=[
-            RegexValidator(r'^[(A-Z)|(a-z)|(0-9)|(\s)|(\-)]+$', ),
+            RegexValidator(r'^[(A-Z)|(a-z)|(0-9)|(\s)|(\-)|(\.)|(,)|(\:)]+$', ),
         ],
     )
     city = models.CharField(


### PR DESCRIPTION
# Description
The signup form for both administrators and volunteers were not accepting some special characters( like . or , or : ) which are often required in addresses. I have fixed the regex formats to correct this.

Fixes #645 

# Type of Change:

- Code
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I ran the changes on local server : Here are the mocks -
![x](https://user-images.githubusercontent.com/24635701/36936682-5dc75828-1f2e-11e8-8531-0347fcb0d998.png)
![xyz](https://user-images.githubusercontent.com/24635701/36936683-5e45a750-1f2e-11e8-9173-bd04c282f217.png)

# Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes
