### PR TITLE
Restrict start date and end dates of event to upcoming ones

### DIFF
--- a/vms/vms/static/vms/jquery-custom/activate-datepicker.js
+++ b/vms/vms/static/vms/jquery-custom/activate-datepicker.js
@@ -9,6 +9,7 @@ $(function() {
         changeMonth: true,
         numberOfMonths: 1,
         dateFormat: 'yy-mm-dd',
+        minDate: 0,
         onClose: function( selectedDate ) {
             $( "#to" ).datepicker( "option", "minDate", selectedDate );
         }


### PR DESCRIPTION
# Description
The administrator can only select the upcoming or today's date as start and end dates while creating an event.

Fixes #651 

# Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

# How Has This Been Tested?
![screenshot from 2018-03-06 02-48-45](https://user-images.githubusercontent.com/22369767/37000667-1e7d9566-20ea-11e8-855a-73185576c687.png)

# Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
