### PR TITLE
Displaying only valid list of upcoming events/jobs/shifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Travis](https://img.shields.io/travis/rust-lang/rust.svg?style=plastic)](https://github.com/systers/vms)
-
 Systers Portal - VMS project
 ============================
 

--- a/vms/event/services.py
+++ b/vms/event/services.py
@@ -1,6 +1,9 @@
 # Django
 from django.core.exceptions import ObjectDoesNotExist
 
+#standard library
+from datetime import date
+
 # local Django
 from event.models import Event
 from job.services import get_jobs_by_event_id, remove_empty_jobs_for_volunteer
@@ -37,7 +40,7 @@ def get_event_by_shift_id(shift_id):
 
 
 def delete_event(event_id):
-    """ 
+    """
     Deletes an event if no jobs are associated with it
     """
 
@@ -161,5 +164,13 @@ def remove_empty_events_for_volunteer(event_list, volunteer_id):
         job_list = get_jobs_by_event_id(event.id)
         job_list = remove_empty_jobs_for_volunteer(job_list, volunteer_id)
         if job_list:
+            new_event_list.append(event)
+    return new_event_list
+
+def remove_invalid_events(event_list):
+    """Removes all the events from an event list which have been occured already(expired)"""
+    new_event_list = []
+    for event in event_list:
+        if event.start_date <= date.today() and date.today() <= event.end_date:
             new_event_list.append(event)
     return new_event_list

--- a/vms/event/services.py
+++ b/vms/event/services.py
@@ -168,9 +168,13 @@ def remove_empty_events_for_volunteer(event_list, volunteer_id):
     return new_event_list
 
 def remove_invalid_events(event_list):
-    """Removes all the events from an event list which have been occured already(expired)"""
+    """
+    Removes all the events from an event list which
+    have been occured already(expired)
+    """
     new_event_list = []
+    current_date = date.today()
     for event in event_list:
-        if date.today() <= event.end_date:
+        if current_date <= event.end_date:
             new_event_list.append(event)
     return new_event_list

--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -19,7 +19,7 @@ from django.views.generic import ListView
 # local Django
 from event.forms import EventForm, EventDateForm
 from event.models import Event
-from event.services import check_edit_event, get_event_by_id, get_events_by_date, get_events_ordered_by_name, remove_empty_events_for_volunteer
+from event.services import check_edit_event, get_event_by_id, get_events_by_date, get_events_ordered_by_name, remove_empty_events_for_volunteer,remove_invalid_events
 from job.services import get_jobs_by_event_id
 from volunteer.utils import vol_id_check
 from vms.utils import check_correct_volunteer_shift_sign_up
@@ -163,6 +163,7 @@ def list_sign_up(request, volunteer_id):
             event_list = get_events_by_date(start_date, end_date)
             event_list = remove_empty_events_for_volunteer(
                 event_list, volunteer_id)
+            event_list = remove_invalid_events(event_list)
             return render(
                 request, 'event/list_sign_up.html', {
                     'form': form,
@@ -173,6 +174,7 @@ def list_sign_up(request, volunteer_id):
         event_list = get_events_ordered_by_name()
         event_list = remove_empty_events_for_volunteer(event_list,
                                                        volunteer_id)
+        event_list = remove_invalid_events(event_list)
         return render(request, 'event/list_sign_up.html', {
             'event_list': event_list,
             'volunteer_id': volunteer_id

--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -19,7 +19,7 @@ from django.views.generic import ListView
 # local Django
 from event.forms import EventForm, EventDateForm
 from event.models import Event
-from event.services import check_edit_event, get_event_by_id, get_events_by_date, get_events_ordered_by_name, remove_empty_events_for_volunteer,remove_invalid_events
+from event.services import check_edit_event, get_event_by_id, get_events_by_date, get_events_ordered_by_name, remove_empty_events_for_volunteer, remove_invalid_events
 from job.services import get_jobs_by_event_id
 from volunteer.utils import vol_id_check
 from vms.utils import check_correct_volunteer_shift_sign_up

--- a/vms/job/services.py
+++ b/vms/job/services.py
@@ -1,6 +1,9 @@
 # Django
 from django.core.exceptions import ObjectDoesNotExist
 
+#standard library
+from datetime import date
+
 # local Django
 from job.models import Job
 from shift.services import (get_shifts_with_open_slots_for_volunteer,
@@ -117,5 +120,13 @@ def remove_empty_jobs_for_volunteer(job_list, volunteer_id):
         shift_list = get_shifts_with_open_slots_for_volunteer(
             job.id, volunteer_id)
         if shift_list:
+            new_job_list.append(job)
+    return new_job_list
+
+def remove_invalid_jobs(job_list):
+    """ Removes all jobs from a job list which have already ended """
+    new_job_list = []
+    for job in job_list:
+        if job.start_date <= date.today() and date.today() <= job.end_date:
             new_job_list.append(job)
     return new_job_list

--- a/vms/job/services.py
+++ b/vms/job/services.py
@@ -126,7 +126,8 @@ def remove_empty_jobs_for_volunteer(job_list, volunteer_id):
 def remove_invalid_jobs(job_list):
     """ Removes all jobs from a job list which have already ended """
     new_job_list = []
+    current_date = date.today()
     for job in job_list:
-        if date.today() <= job.end_date:
+        if current_date <= job.end_date:
             new_job_list.append(job)
     return new_job_list

--- a/vms/job/views.py
+++ b/vms/job/views.py
@@ -17,7 +17,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from event.services import get_events_ordered_by_name, get_event_by_id
 from job.forms import JobForm
 from job.models import Job
-from job.services import get_job_by_id, check_edit_job, get_jobs_by_event_id, remove_empty_jobs_for_volunteer,remove_invalid_jobs
+from job.services import get_job_by_id, check_edit_job, get_jobs_by_event_id, remove_empty_jobs_for_volunteer, remove_invalid_jobs
 
 
 class AdministratorLoginRequiredMixin(object):

--- a/vms/job/views.py
+++ b/vms/job/views.py
@@ -17,7 +17,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from event.services import get_events_ordered_by_name, get_event_by_id
 from job.forms import JobForm
 from job.models import Job
-from job.services import get_job_by_id, check_edit_job, get_jobs_by_event_id, remove_empty_jobs_for_volunteer
+from job.services import get_job_by_id, check_edit_job, get_jobs_by_event_id, remove_empty_jobs_for_volunteer,remove_invalid_jobs
 
 
 class AdministratorLoginRequiredMixin(object):
@@ -170,6 +170,7 @@ def list_sign_up(request, event_id, volunteer_id):
         if event:
             job_list = get_jobs_by_event_id(event_id)
             job_list = remove_empty_jobs_for_volunteer(job_list, volunteer_id)
+            job_list = remove_invalid_jobs(job_list)
             return render(request, 'job/list_sign_up.html', {
                 'event': event,
                 'job_list': job_list,


### PR DESCRIPTION
# Description
Currently whenever a volunteer tries to sign up for an event/job/shift older(completed/ended) events/jobs/shifts were also shown. Fixing this by only showing the valid upcoming one's.

Fixes #659

# Type of Change:

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Successfully tested on the local development system. Refer screenshots.

**before**
![before](https://user-images.githubusercontent.com/17281037/37628046-7a0f56b2-2bfd-11e8-9bea-ef7c415f3af6.png)


**after**
![events](https://user-images.githubusercontent.com/17281037/37627950-f14884ac-2bfc-11e8-8442-3f429ae55c97.png)

![jobs](https://user-images.githubusercontent.com/17281037/37627960-fb684a1c-2bfc-11e8-9e5f-23008f807a1a.png)

![upcoming](https://user-images.githubusercontent.com/17281037/37627968-038b61c0-2bfd-11e8-94ac-a671073b560e.png)


# Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
