### PR TITLE
Fix error in a test of administrator app

### DIFF
--- a/vms/administrator/tests/test_formFields.py
+++ b/vms/administrator/tests/test_formFields.py
@@ -1,5 +1,8 @@
 # third party
 from selenium import webdriver
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -27,6 +30,7 @@ class FormFields(LiveServerTestCase):
         cls.driver.maximize_window()
         cls.settings = EventsPage(cls.driver)
         cls.authentication_page = AuthenticationPage(cls.driver)
+        cls.wait = WebDriverWait(cls.driver, 5)
         super(FormFields, cls).setUpClass()
 
     def setUp(self):
@@ -239,6 +243,12 @@ class FormFields(LiveServerTestCase):
         settings.fill_shift_form(invalid_shift)
 
         # Check error message
+        self.wait.until(
+            EC.presence_of_element_located(
+                (By.XPATH, "//form//div[7]/div/p/strong[contains(text(),"
+                           "'Ensure this value is greater than or equal to 1.')]")
+            )
+        )
         self.assertEqual(settings.get_shift_max_volunteer_error(), 'Ensure this value is greater than or equal to 1.')
 
         # Create shift and edit with 0 value
@@ -250,6 +260,12 @@ class FormFields(LiveServerTestCase):
         settings.fill_shift_form(invalid_shift)
 
         # Check error message
+        self.wait.until(
+            EC.presence_of_element_located(
+                (By.XPATH, "//form//div[7]/div/p/strong[contains(text(),"
+                           "'Ensure this value is greater than or equal to 1.')]")
+            )
+        )
         self.assertEqual(settings.get_shift_max_volunteer_error(), 'Ensure this value is greater than or equal to 1.')
 
     def test_simplify_shift(self):


### PR DESCRIPTION
# Description
Test was failing multiple time while testing shift app because of the DOM not being rendered correctly thus needing an explicit wait for DOM render.

Fixes #730 

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
```
python manage.py test -v 2
```
and 
```
python manage.py test administrator -v 2
```


# Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
