### PR TITLE
Reporting Functionality added

### DIFF
--- a/vms/administrator/templates/administrator/report.html
+++ b/vms/administrator/templates/administrator/report.html
@@ -1,221 +1,40 @@
 {% extends "vms/base.html" %}
 {% load i18n %}
 {% block content %}
-    <div class="spacer"></div>
-    <div class="alert alert-info">
-        {% trans "Please enter any of the fields below to generate a report." %}
-    </div>
-    <div class="well">
-        <form class="form-horizontal" action="" method="post">
-            {% csrf_token %}
-            <fieldset>
-                <legend>{% trans "Report" %}</legend>
-                {% if form.first_name.errors %}
-                    <div class="form-group has-error">
-                        <label class="col-md-3 control-label">{% trans "Volunteer First Name" %}</label>
-                        <div class="col-md-8">
-                            <input class="form-control" type="text" name="first_name" value="{% if form.first_name.value %}{{ form.first_name.value }}{% endif %}">
-                            <p class="help-block">
-                                <strong>
-                                    {% for error in form.first_name.errors %}
-                                        {{ error }}
-                                    {% endfor %}
-                                </strong>
-                            </p>
-                        </div>
-                    </div>
-                {% else %}
-                    <div class="form-group">
-                        <label class="col-md-3 control-label">{% trans "Volunteer First Name" %}</label>
-                        <div class="col-md-8">
-                            <input class="form-control" type="text" name="first_name" value="{% if form.first_name.value %}{{ form.first_name.value }}{% endif %}">
-                        </div>
-                    </div>
-                {% endif %}
-                {% if form.last_name.errors %}
-                    <div class="form-group has-error">
-                        <label class="col-md-3 control-label">{% trans "Volunteer Last Name" %}</label>
-                        <div class="col-md-8">
-                            <input class="form-control" type="text" name="last_name" value="{% if form.last_name.value %}{{ form.last_name.value }}{% endif %}">
-                            <p class="help-block">
-                                <strong>
-                                    {% for error in form.last_name.errors %}
-                                        {{ error }}
-                                    {% endfor %}
-                                </strong>
-                            </p>
-                        </div>
-                    </div>
-                {% else %}
-                    <div class="form-group">
-                        <label class="col-md-3 control-label">{% trans "Volunteer Last Name" %}</label>
-                        <div class="col-md-8">
-                            <input class="form-control" type="text" name="last_name" value="{% if form.last_name.value %}{{ form.last_name.value }}{% endif %}">
-                        </div>
-                    </div>
-                {% endif %}
-                {% if form.organization.errors %}
-                    <div class="form-group has-error">
-                        <label class="col-md-3 control-label">{% trans "Volunteer Organization" %}</label>
-                        <div class="col-md-8">
-							
-                            <select id="select" class="form-control" name="organization">
-								<option value="">-- {% trans "Select Organization" %} --</option>
-								{% for organization in organization_list %}
-								<option value="{{ organization.name }}" {% if selected_organization == organization.name %}selected{% endif %}>{{ organization.name }}</option>
-								{% endfor %}
-							</select>
-							
-                            <p class="help-block">
-                                <strong>
-                                    {% for error in form.organization.errors %}
-                                        {{ error }}
-                                    {% endfor %}
-                                </strong>
-                            </p>
-                        </div>
-                    </div>
-                {% else %}
-                    <div class="form-group">
-                        <label class="col-md-3 control-label">{% trans "Volunteer Organization" %}</label>
-                        <div class="col-md-8">
-                            <select id="select" class="form-control" name="organization">
-								<option value="">-- {% trans "Select Organization" %} --</option>
-								{% for organization in organization_list %}
-									<option value="{{ organization.name }}" {% if selected_organization == organization.name %}selected{% endif %}>{{ organization.name }}</option>
-								{% endfor %}
-							</select>
-                        </div>
-                    </div>
-                {% endif %}
-                {% if form.event_name.errors %}
-                    <div class="form-group has-error">
-                        <label class="col-md-3 control-label">{% trans "Event Name" %}</label>
-                        <div class="col-md-8">
-                            <select id="select" class="form-control" name="event_name">
-								<option value="">-- {% trans "Select Event" %} --</option>
-								{% for event in event_list %}
-									<option value="{{ event.name }}" {% if selected_event == event.name %}selected{% endif %}>{{ event.name }}</option>
-								{% endfor %}
-							</select>
-                            <p class="help-block">
-                                <strong>
-                                    {% for error in form.event_name.errors %}
-                                        {{ error }}
-                                    {% endfor %}
-                                </strong>
-                            </p>
-                        </div>
-                    </div>
-                {% else %}
-                    <div class="form-group">
-                        <label class="col-md-3 control-label">{% trans "Event Name" %}</label>
-                        <div class="col-md-8">
-                            <select id="select" class="form-control" name="event_name">
-								<option value="">-- {% trans "Select Event" %} --</option>
-								{% for event in event_list %}
-									<option value="{{ event.name }}" {% if selected_event == event.name %}selected{% endif %}>{{ event.name }}</option>
-								{% endfor %}
-							</select>
-                        </div>
-                    </div>
-                {% endif %}
-                {% if form.job_name.errors %}
-                    <div class="form-group has-error">
-                        <label class="col-md-3 control-label">{% trans "Job Name" %}</label>
-                        <div class="col-md-8">
-                            	<select id="select_job" class="form-control" name="job_name">  
-					<option value="">-- {% trans "Select Job" %} --</option>  
-					{% for job in job_list %}  
- 					<option value="{{ job.name }}">{{ job.name }}</option>  
- 					{% endfor %}  
- 				</select>  
-                            <p class="help-block">
-                                <strong>
-                                    {% for error in form.job_name.errors %}
-                                        {{ error }}
-                                    {% endfor %}
-                                </strong>
-                            </p>
-                        </div>
-                    </div>
-                {% else %}
-                    <div class="form-group">
-                        <label class="col-md-3 control-label">{% trans "Job Name" %}</label>
-                        <div class="col-md-8">
-                        	<select id="select_job" class="form-control" name="job_name">  
-					<option value="">-- {% trans "Select Job" %} --</option>  
-					{% for job in job_list %}  
- 					<option value="{{ job.name }}">{{ job.name }}</option>  
- 					{% endfor %}  
- 				</select>  
-                        </div>
-                    </div>
-                {% endif %}                
-				<div class="form-group">
-                    <label class="col-md-3 control-label">{% trans "Start Date" %}</label>
-                    <div class="col-md-8">
-                        <input class="form-control" type="text" name="start_date" id="from" name="from" value="{% if form.start_date.value %}{{ form.start_date.value }}{% endif %}">
-                    </div>
-                </div>
-				<div class="form-group">
-                    <label class="col-md-3 control-label">{% trans "End Date" %}</label>
-                    <div class="col-md-8">
-                        <input class="form-control" type="text" name="end_date" id="to" name="to" value="{% if form.end_date.value %}{{ form.end_date.value }}{% endif %}">
-                    </div>
-                </div>
-            </fieldset>
-            <div class="form-group">
-                <div class="col-md-12 col-md-offset-3">
-                    <button class="btn btn-primary" type="submit">{% trans "Generate Report" %}</button>
-                </div>
-            </div>
-        </form>
-    </div>
-    {% if report_list %}
-        <div class="well">
-            <legend>{% trans "Report Statistics" %}</legend>
-            <label><h4><span class="label label-default">{% trans "Total Number of Shifts" %}</span></h4></label>&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp{{ report_list|length }}
-            <br>
-            <label><h4><span class="label label-default">{% trans "Total Hours" %}</span></h4></label>&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp{{ total_hours }}
-        </div>
-        <div class="well">
-            <table class="table table-striped table-hover">
-                <thead>
-                    <tr>
-                        <th>{% trans "First Name" %}</th>
-                        <th>{% trans "Last Name" %}</th>
-                        <th>{% trans "Volunteer Organization"%}</th>
-                        <th>{% trans "Event Name" %}</th>
-                        <th>{% trans "Job Name" %}</th>
-                        <th>{% trans "Date" %}</th>
-                        <th>{% trans "Logged Start Time" %}</th>
-                        <th>{% trans "Logged End Time" %}</th>
-                        <th>{% trans "Duration" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for report in report_list %}
-                        <tr>
-                            <td>{{ report.first_name }}</td>
-                            <td>{{ report.last_name }}</td>
-                            <td>{{ report.organization }}</td>
-                            <td>{{ report.event_name }}</td>
-                            <td>{{ report.job_name }}</td>
-                            <td>{{ report.date }}</td>
-                            <td>{{ report.logged_start_time }}</td>
-                            <td>{{ report.logged_end_time }}</td>
-                            <td>{{ report.duration }}</td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    {% else %}
-        {% if notification %}
-            <div class="alert alert-danger">
-                {% trans "Your criteria did not return any results." %}
-            </div>
-        {% endif %}
-    {% endif %}
+<div class="spacer"></div>
+<h2>{% trans "Manage Reports" %}</h2>
+<hr>
+{% if report_list %}
+<table class="table table-striped table-hover">
+   <thead>
+      <tr>
+         <th>{% trans "Date Submitted" %}</th>
+         <th>{% trans "Volunteer Name" %}</th>
+         <th>{% trans "Organization" %}</th>
+         <th>{% trans "Hours" %}</th>
+         <th>{% trans "View Report" %}</th>
+         <th>{% trans "Reject Requests" %}</th>
+      </tr>
+   <thead>
+   <tbody>
+      {% for report in report_list %}
+      <tr>
+         <td> {{report.date_submitted}}</td>
+         <td>{{report.volunteer}}</td>
+         <td>{{report.volunteer.organization}}</td>
+         <td>{{report.total_hrs}}</td>
+         <td>
+            <a href="{% url 'administrator:show_report' report.id %}" class="btn btn-info btn-sm">{% trans "View" %}</a>
+         </td>
+         <td>
+            <a href="{% url 'administrator:reject_report' report.id %}" class="btn btn-danger btn-sm">{% trans "Reject" %}</a>
+         </td>
+      </tr>
+      {% endfor %}
+      {% else %}
+      No reports requested
+      {% endif %}
+   </tbody>
+</table>
 {% endblock %}
+

--- a/vms/administrator/templates/administrator/view_report.html
+++ b/vms/administrator/templates/administrator/view_report.html
@@ -1,0 +1,44 @@
+{% extends "vms/base.html" %}
+{% load i18n %}
+{% block content %}
+<div class="spacer"></div>
+{% if report.confirm_status is 0 %}
+<div class="well well-sm">
+   <a href="{% url 'administrator:approve_report' report.id %}" class="btn btn-success btn-sm">{% trans "Approve Report" %}</a>
+</div>
+{% endif %}
+<div class="well">
+   <legend>{% trans "Report Statistics" %}</legend>
+   <label>
+      <h4><span class="label label-default">{% trans "Total Hours" %}</span></h4>
+   </label>
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{total_hours }}
+</div>
+<div class="well">
+   <table class="table table-striped table-hover">
+      <thead>
+         <tr>
+            <th>{% trans "Event Name" %}</th>
+            <th>{% trans "Job Name" %}</th>
+            <th>{% trans "Date" %}</th>
+            <th>{% trans "Logged Start Time" %}</th>
+            <th>{% trans "Logged End Time" %}</th>
+            <th>{% trans "Duration" %}</th>
+         </tr>
+      </thead>
+      <tbody>
+         {% for report in report_list %}
+         <tr>
+            <td>{{ report.event_name }}</td>
+            <td>{{ report.job_name }}</td>
+            <td>{{ report.date }}</td>
+            <td>{{ report.logged_start_time }}</td>
+            <td>{{ report.logged_end_time }}</td>
+            <td>{{ report.duration }}</td>
+         </tr>
+         {% endfor %}
+      </tbody>
+   </table>
+</div>
+{% endblock %}
+

--- a/vms/administrator/tests/test_report.py
+++ b/vms/administrator/tests/test_report.py
@@ -1,5 +1,6 @@
 # third party
 import json
+import datetime
 
 from selenium import webdriver
 
@@ -18,8 +19,9 @@ from shift.utils import (create_admin, create_volunteer,
                          create_organization_with_details,
                          create_event_with_details, create_job_with_details,
                          create_shift_with_details, log_hours_with_details,
-                         register_volunteer_for_shift_utility, create_volunteer_with_details_dynamic_password)
-
+                         register_volunteer_for_shift_utility, create_volunteer_with_details_dynamic_password,
+                         register_past_event_utility, register_past_job_utility, register_past_shift_utility,
+                         create_report_with_details, create_volunteer_with_details)
 
 class Report(LiveServerTestCase):
 
@@ -52,176 +54,99 @@ class Report(LiveServerTestCase):
             'password': 'admin'
         })
 
-    def verify_shift_details(self, total_shifts, hours):
-        total_no_of_shifts = self.report_page.get_shift_summary().split(' ')[10].strip('\nTotal')
+    def verify_shift_details(self, hours):
+        """
+        Utility function to verify the shift details.
+        :param total_shifts: Total number of shifts as filled in form.
+        :param hours: Total number of hours as filled in form.
+        """
         total_no_of_hours = self.report_page.get_shift_summary().split(' ')[-1].strip('\n')
-        self.assertEqual(total_no_of_shifts, total_shifts)
         self.assertEqual(total_no_of_hours, hours)
 
-    def test_null_values_with_dataset(self):
+
+    def test_check_report_hours(self):
         self.report_page.go_to_admin_report()
-        # Register dataset
-        org = create_organization_with_details('organization-one')
-        volunteer = create_volunteer()
-        volunteer.organization = org
-        volunteer.save()
-
-        # Create Shift and Log hours
-        # Create Event
-        event = ['Hackathon', '2050-05-24', '2050-05-28']
-        created_event = create_event_with_details(event)
-
-        # Create Job
-        job = ['Developer', '2050-05-24', '2050-05-28', '', created_event]
-        created_job = create_job_with_details(job)
-
-        # Create Shift
-        shift = ['2050-05-24', '09:00', '15:00', '10', created_job]
-        created_shift = create_shift_with_details(shift)
-
-        log_hours_with_details(volunteer, created_shift, "09:00", "12:00")
-
+        vol = create_volunteer()
+        register_past_event_utility()
+        register_past_job_utility()
+        shift = register_past_shift_utility()
+        start=datetime.time(hour=10, minute=0)
+        end=datetime.time(hour=11, minute=0)
+        logged_shift = log_hours_with_details(vol, shift, start, end)
+        create_report_with_details(vol, logged_shift)
         report_page = self.report_page
         report_page.get_page(self.live_server_url, PageUrls.administrator_report_page)
+        self.assertEqual(report_page.get_hours(), '1.00')
 
-        # Check admin report with null fields, should return the above shift
-        report_page.fill_report_form(['', '', '', '', ''])
-        self.verify_shift_details('1', '3.0')
 
-        self.assertEqual(report_page.element_by_xpath(self.elements.NAME).text, created_event.name)
-        self.assertEqual(report_page.element_by_xpath(self.elements.DATE).text, 'May 24, 2050')
-        self.assertEqual(report_page.element_by_xpath(self.elements.START_TIME).text, '9 a.m.')
-        self.assertEqual(report_page.element_by_xpath(self.elements.END_TIME).text, 'noon')
-        self.assertEqual(report_page.element_by_xpath(self.elements.HOURS).text, '3.0')
-
-    def test_null_values_with_empty_dataset(self):
-        # Should return no entries
+    def test_check_report_volunteer(self):
         self.report_page.go_to_admin_report()
+        credentials = [
+            'volunteer-username', 'VOLUNTEER-FIRST-NAME',
+            'volunteer-last-name', 'volunteer-address', 'volunteer-city',
+            'volunteer-state', 'volunteer-country', '9999999999',
+            'volunteer-email@systers.org', 'volunteer-organization'
+        ]
+        vol = create_volunteer_with_details(credentials)
+        register_past_event_utility()
+        register_past_job_utility()
+        shift = register_past_shift_utility()
+        start=datetime.time(hour=10, minute=0)
+        end=datetime.time(hour=11, minute=0)
+        logged_shift = log_hours_with_details(vol, shift, start, end)
+        create_report_with_details(vol, logged_shift)
         report_page = self.report_page
         report_page.get_page(self.live_server_url, PageUrls.administrator_report_page)
+        self.assertEqual(report_page.get_volunteer_name(), 'VOLUNTEER-FIRST-NAME volunteer-last-name')
 
-        report_page.fill_report_form(['', '', '', '', ''])
-        self.assertEqual(report_page.get_alert_box_text(), report_page.no_results_message)
 
-    def test_only_logged_shifts_are_reported(self):
+    def test_reject_report(self):
+        self.report_page.go_to_admin_report()
+        vol = create_volunteer()
+        register_past_event_utility()
+        register_past_job_utility()
+        shift = register_past_shift_utility()
+        start=datetime.time(hour=10, minute=0)
+        end=datetime.time(hour=11, minute=0)
+        logged_shift = log_hours_with_details(vol, shift, start, end)
+        create_report_with_details(vol, logged_shift)
         report_page = self.report_page
-        # Register dataset
-        org = create_organization_with_details('organization-one')
-        volunteer = create_volunteer()
-        volunteer.organization = org
-        volunteer.save()
-
-        # Create Event
-        event = ['Hackathon', '2050-05-24', '2050-05-28']
-        created_event = create_event_with_details(event)
-
-        # Create Job
-        job = ['Developer', '2050-05-24', '2050-05-28', '', created_event]
-        created_job = create_job_with_details(job)
-
-        # Create Shift
-        shift = ['2050-05-24', '09:00', '15:00', '10', created_job]
-        created_shift = create_shift_with_details(shift)
-
-        # Shift is assigned to volunteer-one, but hours have not been logged
-        report_page.go_to_admin_report()
-        register_volunteer_for_shift_utility(created_shift, volunteer)
         report_page.get_page(self.live_server_url, PageUrls.administrator_report_page)
-        # Check admin report with null fields, should not return the above shift
-        # Using multiple tries so to cater to late loading of page.
-        for _ in range(3):
-            try:
-                report_page.fill_report_form(['', '', '', '', ''])
-                break
-            except NoSuchElementException:
-                pass
-        self.assertEqual(report_page.get_alert_box_text(), report_page.no_results_message)
+        self.assertEqual(report_page.get_rejection_context(), 'Reject')
+        report_page.reject_report()
+        with self.assertRaises(NoSuchElementException):
+            report_page.get_report()
 
-    @staticmethod
-    def register_dataset(parameters):
-        # Register dataset
-        # Register dataset
-        volunteer = create_volunteer_with_details_dynamic_password(parameters['volunteer'])
-        volunteer.organization = parameters['org']
-        volunteer.save()
-
-        # Create Event
-        event = parameters['event']
-        created_event = create_event_with_details(event)
-
-        # Create Job
-        job = parameters['job'] + [created_event]
-        created_job = create_job_with_details(job)
-
-        # Create Shift
-        shift = parameters['shift'] + [created_job]
-        created_shift = create_shift_with_details(shift)
-
-        # Create VolunteerShift
-        log_hours_with_details(volunteer, created_shift, parameters['vshift'][0], parameters['vshift'][0])
-
-    def create_dataset(self):
-        orgs = Organization.create_multiple_organizations(4)
-
-        test_data = open('test_data.json').read()
-        parameters = json.loads(test_data)
-
-        parameters[0]["org"] = orgs[0]
-        self.register_dataset(parameters[0])
-
-        parameters[1]["org"] = orgs[0]
-        self.register_dataset(parameters[1])
-
-        parameters[2]["org"] = orgs[0]
-        self.register_dataset(parameters[2])
-
-        parameters[3]["org"] = orgs[1]
-        self.register_dataset(parameters[3])
-
-        parameters[4]["org"] = orgs[1]
-        self.register_dataset(parameters[4])
-
-        parameters[5]["org"] = orgs[2]
-        self.register_dataset(parameters[5])
-
-        parameters[6]["org"] = orgs[3]
-        self.register_dataset(parameters[6])
-
-        parameters[7]["org"] = orgs[3]
-        self.register_dataset(parameters[7])
-
-    """
-    Test giving inconsistent results for log hours and total shifts
-    For log hours: Possibly https://github.com/systers/vms/issues/327 wasn't fixed correctly.
-
-    def test_check_intersection_of_fields(self):
-        self.create_dataset()
-
+    def test_view_report(self):
+        self.report_page.go_to_admin_report()
+        vol = create_volunteer()
+        register_past_event_utility()
+        register_past_job_utility()
+        shift = register_past_shift_utility()
+        start=datetime.time(hour=10, minute=0)
+        end=datetime.time(hour=11, minute=0)
+        logged_shift = log_hours_with_details(vol, shift, start, end)
+        create_report_with_details(vol, logged_shift)
         report_page = self.report_page
-        time.sleep(0.5)
-
         report_page.get_page(self.live_server_url, PageUrls.administrator_report_page)
-        search_parameters_1 = ['tom-fname', '', '', '', '']
-        report_page.fill_report_form(search_parameters_1)
-        self.verify_shift_details('2','2.0')
+        report_page.go_to_view_report_page()
+        self.verify_shift_details('1.00')
 
+    def test_approve_report(self):
+        self.report_page.go_to_admin_report()
+        vol = create_volunteer()
+        register_past_event_utility()
+        register_past_job_utility()
+        shift = register_past_shift_utility()
+        start=datetime.time(hour=10, minute=0)
+        end=datetime.time(hour=11, minute=0)
+        logged_shift = log_hours_with_details(vol, shift, start, end)
+        create_report_with_details(vol, logged_shift)
+        report_page = self.report_page
         report_page.get_page(self.live_server_url, PageUrls.administrator_report_page)
-        search_parameters_2 = ['', '', '', '', 'org-one']
-        report_page.fill_report_form(search_parameters_2)
-        self.verify_shift_details('3','3.0')
-
-        report_page.get_page(self.live_server_url, PageUrls.administrator_report_page)
-        search_parameters_3 = ['', '', 'event-four', 'Two', '']
-        report_page.fill_report_form(search_parameters_3)
-        self.verify_shift_details('1','1.5')
-
-        report_page.get_page(self.live_server_url, PageUrls.administrator_report_page)
-        search_parameters_4 = ['', '', 'one', '', '']
-        report_page.fill_report_form(search_parameters_4)
-        self.verify_shift_details('3','2.5')
-
-        report_page.get_page(self.live_server_url, PageUrls.administrator_report_page)
-        search_parameters_5 = ['', 'sherlock', 'two', '', '']
-        report_page.fill_report_form(search_parameters_5)
-        self.verify_shift_details('1','2.0')
-    """
+        report_page.go_to_view_report_page()
+        self.assertEqual(report_page.get_approval_context(), 'Approve Report')
+        report_page.approve_report()
+        self.assertEqual(report_page.remove_i18n(self.driver.current_url), self.live_server_url + report_page.administrator_report_page)
+        with self.assertRaises(NoSuchElementException):
+            report_page.get_report()

--- a/vms/administrator/urls.py
+++ b/vms/administrator/urls.py
@@ -3,10 +3,13 @@ from django.conf.urls import  url
 
 # local Django
 from administrator import views
-from administrator.views import GenerateReportView, AdminUpdateView, ProfileView
+from administrator.views import AdminUpdateView, ProfileView, ReportListView
 
 urlpatterns = [
-    url(r'^report/$', GenerateReportView.as_view(), name='report'),
+    url(r'^report/$', ReportListView.as_view(), name='report'),
+    url(r'^report/view/(?P<report_id>\d+)$', views.show_report, name='show_report'),
+    url(r'^report/approve/(?P<report_id>\d+)$', views.approve, name='approve_report'),
+    url(r'^report/reject/(?P<report_id>\d+)$', views.reject, name='reject_report'),
     url(r'^settings/$', views.settings, name='settings'),
     url(r'^edit/(?P<admin_id>\d+)$', AdminUpdateView.as_view(), name='edit'),
     url(r'^profile/(?P<admin_id>\d+)$', ProfileView.as_view(), name='profile'),

--- a/vms/pom/locators/administratorReportPageLocators.py
+++ b/vms/pom/locators/administratorReportPageLocators.py
@@ -1,19 +1,8 @@
 class AdministratorReportPageLocators(object):
-
-    REPORT_SHIFT_SUMMARY_PATH = '//div[2]/div[4]'
-    REPORT_START_DATE = '//input[@name = "start_date"]'
-    REPORT_END_DATE = '//input[@name = "end_date"]'
-    REPORT_EVENT_SELECTOR = '//select[@name = "event_name"]'
-    REPORT_JOB_SELECTOR = '//select[@name = "job_name"]'
-    REPORT_ORG_SELECTOR = '//select[@name = "organization"]'
-    FIRST_NAME_SELECTOR = '//input[@name = "first_name"]'
-    LAST_NAME_SELECTOR = '//input[@name = "last_name"]'
-
-    NAME = '//table//tbody//tr[1]//td[4]'
-    DATE = '//table//tbody//tr[1]//td[6]'
-    START_TIME = '//table//tbody//tr[1]//td[7]'
-    END_TIME = '//table//tbody//tr[1]//td[8]'
-    HOURS = '//table//tbody//tr[1]//td[9]'
-
-    SUBMIT_PATH = '//form[1]'
-    NO_RESULT_BOX = 'alert-danger'
+    VOLUNTEER_NAME = '//table//tbody//tr[1]//td[2]'
+    HOURS = '//table//tbody//tr[1]//td[4]'
+    VIEW_REPORT = '//table//tbody//tr[1]//td[5]//a'
+    REJECT_REPORT = '//table//tbody//tr[1]//td[6]'
+    APPROVE_REPORT = '//div[2]//div[2]'
+    REPORT_SHIFT_SUMMARY_PATH = '//div[2]/div[3]'
+    REPORT = '//table//tbody//tr[1]'

--- a/vms/pom/locators/volunteerSearchPageLocators.py
+++ b/vms/pom/locators/volunteerSearchPageLocators.py
@@ -11,3 +11,6 @@ class VolunteerSearchPageLocators(object):
     RESULT_BODY = '//table//tbody'
     HELP_BLOCK = 'help-block'
     SUBMIT_PATH = 'btn'
+    VIEW_REPORTS = '//table//tbody//tr[1]//td[10]'
+    TOTAL_REPORTS = '//div[2]//div[4]'
+

--- a/vms/pom/pageUrls.py
+++ b/vms/pom/pageUrls.py
@@ -15,6 +15,7 @@ class PageUrls(object):
     volunteer_report_page = '/volunteer/report/'
     volunteer_registration_page = '/registration/signup_volunteer/'
     volunteer_search_page = '/volunteer/search/'
+    volunteer_history_page = '/volunteer/view_history/'
     manage_volunteer_shift_page = '/shift/volunteer_search/'
     upcoming_shifts_page = '/shift/view_volunteer_shifts/'
     completed_shifts_page = '/shift/view_hours/'
@@ -22,3 +23,4 @@ class PageUrls(object):
     volunteer_profile_page = '/volunteer/profile/'
     password_reset_page = '/authentication/password_reset/'
     password_reset_done_page = '/authentication/password_reset/done/'
+

--- a/vms/pom/pages/administratorReportPage.py
+++ b/vms/pom/pages/administratorReportPage.py
@@ -5,11 +5,11 @@ from selenium.webdriver.support.ui import Select
 from pom.pages.basePage import BasePage
 from pom.locators.administratorReportPageLocators import AdministratorReportPageLocators
 from pom.pages.homePage import HomePage
-
+from pom.pageUrls import PageUrls
 
 class AdministratorReportPage(BasePage):
+    administrator_report_page = PageUrls.administrator_report_page
 
-    no_results_message = 'Your criteria did not return any results.'
 
     def __init__(self, driver):
         self.driver = driver
@@ -20,33 +20,31 @@ class AdministratorReportPage(BasePage):
     def go_to_admin_report(self):
         self.home_page.get_admin_report_link().click()
 
-    def fill_report_form(self, info):
-        first_name = self.element_by_xpath(self.elements.FIRST_NAME_SELECTOR)
-        last_name = self.element_by_xpath(self.elements.LAST_NAME_SELECTOR)
+    def go_to_view_report_page(self):
+        return self.element_by_xpath(self.elements.VIEW_REPORT).click()
 
-        first_name.clear()
-        last_name.clear()
-        [select1, select2, select3] = self.get_event_job_organization_selectors()
+    def get_volunteer_name(self):
+        return self.element_by_xpath(self.elements.VOLUNTEER_NAME).text
 
-        first_name.send_keys(info[0])
-        last_name.send_keys(info[1])
-        """select1.select_by_visible_text(info[2])
-        select2.select_by_visible_text(info[3])
-        select3.select_by_visible_text(info[4])"""
-
-        self.submit_form()
-
-    def get_event_job_organization_selectors(self):
-        select1 = Select(self.element_by_xpath(self.elements.REPORT_EVENT_SELECTOR))
-        select2 = Select(self.element_by_xpath(self.elements.REPORT_JOB_SELECTOR))
-        select3 = Select(self.element_by_xpath(self.elements.REPORT_ORG_SELECTOR))
-        return select1, select2, select3
-
-    def submit_form(self):
-        self.element_by_xpath(self.elements.SUBMIT_PATH).submit()
-
-    def get_alert_box_text(self):
-        return self.element_by_class_name(self.elements.NO_RESULT_BOX).text
+    def get_hours(self):
+        return self.element_by_xpath(self.elements.HOURS).text
 
     def get_shift_summary(self):
-        return self.element_by_xpath(self.elements.REPORT_SHIFT_SUMMARY_PATH).text
+        return self.element_by_xpath(
+            self.elements.REPORT_SHIFT_SUMMARY_PATH).text
+
+    def get_rejection_context(self):
+        return self.element_by_xpath(self.elements.REJECT_REPORT).text
+
+    def reject_report(self):
+        self.element_by_xpath(self.elements.REJECT_REPORT + '//a').click()
+
+    def get_report(self):
+         return self.element_by_xpath(self.elements.REPORT)
+
+    def get_approval_context(self):
+        return self.element_by_xpath(self.elements.APPROVE_REPORT).text
+
+    def approve_report(self):
+        self.element_by_xpath(self.elements.APPROVE_REPORT + '//a').click()
+

--- a/vms/pom/pages/volunteerReportPage.py
+++ b/vms/pom/pages/volunteerReportPage.py
@@ -5,10 +5,11 @@ from selenium.webdriver.support.ui import Select
 from pom.pages.basePage import BasePage
 from pom.locators.volunteerReportPageLocators import VolunteerReportPageLocators
 from pom.pages.homePage import HomePage
-
+from pom.pageUrls import PageUrls
 
 class VolunteerReportPage(BasePage):
-
+    volunteer_history_page = PageUrls.volunteer_history_page
+    volunteer_report_page = PageUrls.volunteer_report_page
     no_results_message = 'Your criteria did not return any results.'
     live_server_url = ''
 

--- a/vms/pom/pages/volunteerSearchPage.py
+++ b/vms/pom/pages/volunteerSearchPage.py
@@ -69,3 +69,6 @@ class VolunteerSearchPage(BasePage):
             result.append(row)
 
         return result
+
+    def get_shift_summary(self):
+        return self.element_by_xpath(self.elements.TOTAL_SHIFTS).text

--- a/vms/shift/admin.py
+++ b/vms/shift/admin.py
@@ -2,7 +2,7 @@
 from django.contrib import admin
 
 # local Django
-from shift.models import Shift, VolunteerShift, EditRequest
+from shift.models import Shift, VolunteerShift, EditRequest, Report
 
 
 class ShiftAdmin(admin.ModelAdmin):
@@ -24,4 +24,11 @@ class EditRequestAdmin(admin.ModelAdmin):
 
 
 admin.site.register(EditRequest, EditRequestAdmin)
+
+
+class ReportAdmin(admin.ModelAdmin):
+    pass
+
+
+admin.site.register(Report, ReportAdmin)
 

--- a/vms/shift/models.py
+++ b/vms/shift/models.py
@@ -2,6 +2,7 @@
 from django.core.validators import (MaxValueValidator, MinValueValidator,
                                     RegexValidator)
 from django.db import models
+from django.utils import timezone
 
 # local Django
 from job.models import Job
@@ -66,7 +67,6 @@ class Shift(models.Model):
     def __str__(self):
         return '{0} - {1}'.format(self.job.name, self.date)
 
-
 class VolunteerShift(models.Model):
     # Volunteer  to VolunteerShift is a one-to-many relationship
     volunteer = models.ForeignKey(Volunteer)
@@ -77,6 +77,9 @@ class VolunteerShift(models.Model):
     date_logged = models.DateTimeField(null=True, blank=True)
     edit_requested = models.BooleanField(default=False)
     # assigned_by_manager = models.BooleanField()
+    STATUS_CHOICES = ((False, "Not reported"),
+                      (True, "Reported"),)
+    report_status = models.BooleanField(choices=STATUS_CHOICES, default=False)
 
     def __str__(self):
         return '{0} - {1}'.format(self.shift, self.volunteer.first_name)
@@ -89,3 +92,17 @@ class EditRequest(models.Model):
 
     def __str__(self):
         return '{0} - {1}'.format(self.volunteer_shift.shift, self.volunteer_shift.volunteer)
+
+
+class Report(models.Model):
+    total_hrs = models.DecimalField(max_digits=20, decimal_places=2)
+    volunteer_shifts = models.ManyToManyField(VolunteerShift)
+    # confirm_status divides reports into three categories namely
+    # pending:0, approved:1 and rejected:2
+    confirm_status = models.IntegerField(default=0)
+    date_submitted = models.DateField(default=timezone.now)
+    volunteer = models.ForeignKey(Volunteer)
+
+    def get_volunteer_shifts(self):
+       return self.volunteer_shifts.all()
+

--- a/vms/shift/services.py
+++ b/vms/shift/services.py
@@ -1,11 +1,10 @@
 # standard library
 from datetime import date, timedelta
-from django.utils import timezone
-from django.db.models import Q
 
 # Django
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import send_mail
+from django.db.models import Q
 from django.utils import timezone
 
 # local Django
@@ -84,7 +83,6 @@ def get_report_by_id(report_id):
         result = report
 
     return result
-
 
 def send_reminder():
     """
@@ -352,7 +350,8 @@ def get_volunteer_shift_by_id(v_id, s_id):
 def get_volunteer_shifts(v_id, event_name, job_name, start_date, end_date):
 
     volunteer_shift_list = get_volunteer_shifts_with_hours(v_id)
-    volunteer_shift_list = volunteer_shift_list.filter(report_status=False)
+    volunteer_shift_list = volunteer_shift_list.filter(Q(report_status=False)&Q(shift__date__lte=timezone.now().date())|
+                                                Q(shift__date=timezone.now().date(), shift__end_time__lte=timezone.now().time()))
     # filter based on criteria provided
     if event_name:
         volunteer_shift_list = volunteer_shift_list.filter(
@@ -373,9 +372,7 @@ def get_volunteer_shifts(v_id, event_name, job_name, start_date, end_date):
 def get_volunteer_shifts_with_hours(v_id):
 
     # get shifts that the volunteer is signed up for
-    volunteer_shift_list = VolunteerShift.objects.filter(volunteer_id=v_id,
-                                                         shift__date__lte=timezone.now(),
-                                                         shift__end_time__lte=timezone.now())
+    volunteer_shift_list = VolunteerShift.objects.filter(volunteer_id=v_id)
 
     # get shifts that have logged hours only
     volunteer_shift_list = volunteer_shift_list.filter(

--- a/vms/shift/tests/test_services.py
+++ b/vms/shift/tests/test_services.py
@@ -1,4 +1,5 @@
 # standard library
+import datetime
 import unittest
 from datetime import date, timedelta
 
@@ -135,7 +136,6 @@ class ShiftTests(unittest.TestCase):
             calculate_total_report_hours(report_list), total_hours)
 
     def test_calculate_duration(self):
-
         start_time = datetime.time(hour=1, minute=0)
         end_time = datetime.time(hour=2, minute=0)
         delta_time_hours = 1

--- a/vms/shift/tests/test_services.py
+++ b/vms/shift/tests/test_services.py
@@ -1,5 +1,4 @@
 # standard library
-import datetime
 import unittest
 from datetime import date, timedelta
 
@@ -15,11 +14,10 @@ from shift.services import (
     get_shift_by_id, get_shifts_by_job_id, get_shifts_ordered_by_date,
     get_shift_slots_remaining, get_shifts_with_open_slots,
     get_unlogged_shifts_by_volunteer_id, get_volunteer_shift_by_id,
-    get_volunteer_shifts_with_hours, get_volunteers_by_shift_id,
+    get_volunteer_shifts, get_volunteer_shifts_with_hours, get_volunteers_by_shift_id,
     get_logged_volunteers_by_shift_id, is_signed_up, register, send_reminder,
-    get_shifts_with_open_slots_for_volunteer, get_volunteer_report,
-    get_administrator_report)
-from shift.utils import create_event_with_details, create_job_with_details, create_shift_with_details, clear_objects, get_report_list, create_volunteer_with_details, register_event_utility, register_job_utility, register_shift_utility,  set_shift_location
+    get_shifts_with_open_slots_for_volunteer, get_report_by_id)
+from shift.utils import create_event_with_details, create_job_with_details, create_shift_with_details, create_report_with_details, clear_objects, get_report_list, create_volunteer_with_details, register_event_utility, register_job_utility, register_shift_utility,  set_shift_location, log_hours_with_details
 
 
 def setUpModule():
@@ -260,6 +258,25 @@ class ShiftWithVolunteerTest(unittest.TestCase):
         # remove all registered volunteers
         VolunteerShift.objects.all().delete()
 
+    def test_get_report_by_id(self):
+        start = datetime.time(hour=10, minute=0)
+        end = datetime.time(hour=12, minute=0)
+        logged_shift_1 = log_hours_with_details(self.v1, self.s1, start, end)
+        r1 = create_report_with_details(self.v1, logged_shift_1)
+
+        logged_shift_2 = log_hours_with_details(self.v2, self.s2, start, end)
+        r2 = create_report_with_details(self.v2, logged_shift_2)
+
+        self.assertIsNotNone(get_report_by_id(r1.id))
+        self.assertIsNotNone(get_report_by_id(r2.id))
+
+        self.assertEqual(get_report_by_id(r1.id), r1)
+        self.assertEqual(get_report_by_id(r2.id), r2)
+
+        # test non-existant cases
+        self.assertIsNone(get_report_by_id(100))
+        self.assertIsNone(get_report_by_id(200))
+
     def test_get_shifts_with_open_slots_for_volunteer(self):
         """ Uses volunteer v1, v2 """
 
@@ -288,10 +305,13 @@ class ShiftWithVolunteerTest(unittest.TestCase):
         end_time = datetime.time(hour=10, minute=0)
         add_shift_hours(self.v1.id, self.s1.id, start_time, end_time)
 
-        report_1 = get_volunteer_report(self.v1.id, self.e1.name, self.j1.name,
+        volunteer_shift_list_1 = get_volunteer_shifts(self.v1.id, self.e1.name, self.j1.name,
                                         "2012-10-22", "2012-10-30")
-        report_2 = get_volunteer_report(self.v1.id, self.e1.name, self.j2.name,
+        report_1 = generate_report(volunteer_shift_list_1)
+
+        volunteer_shift_list_2 = get_volunteer_shifts(self.v1.id, self.e1.name, self.j2.name,
                                         "2012-9-1", "2012-10-26")
+        report_2 = generate_report(volunteer_shift_list_2)
 
         # verify that report for logged shift appears
         self.assertEqual(len(report_1), 1)
@@ -303,40 +323,6 @@ class ShiftWithVolunteerTest(unittest.TestCase):
         # self.assertEqual(start_time, report_1[0]["logged_start_time"])
         # self.assertEqual(end_time, report_1[0]["logged_end_time"])
         # self.assertEqual(1.0, report_1[0]["duration"])
-
-    def test_get_administrator_report(self):
-
-        register(self.v1.id, self.s1.id)
-        register(self.v2.id, self.s3.id)
-
-        start_time = datetime.time(hour=11, minute=0)
-        end_time = datetime.time(hour=12, minute=0)
-        add_shift_hours(self.v1.id, self.s1.id, start_time, end_time)
-        add_shift_hours(self.v2.id, self.s3.id, start_time, end_time)
-
-        report_1 = get_administrator_report(self.v1.first_name, "", "",
-                                            self.e1.name, self.j1.name,
-                                            "2012-10-22", "2012-10-30")
-        report_2 = get_administrator_report(self.v1.first_name, "", "",
-                                            self.e1.name, self.j2.name,
-                                            "2012-9-1", "2012-10-26")
-        report_3 = get_administrator_report("", "", "", self.e1.name,
-                                            self.j2.name, "", "")
-
-        # verify that report for logged shift appears
-        self.assertEqual(len(report_1), 1)
-        self.assertEqual(len(report_2), 0)
-        self.assertEqual(len(report_3), 1)
-        self.assertEqual(self.v1.first_name, report_1[0]["first_name"])
-        self.assertEqual(self.v2.first_name, report_3[0]["first_name"])
-
-        # commented out due to bug #327
-        # self.assertEqual(start_time, report_1[0]["logged_start_time"])
-        # self.assertEqual(start_time, report_3[0]["logged_start_time"])
-        # self.assertEqual(end_time, report_1[0]["logged_end_time"])
-        # self.assertEqual(end_time, report_3[0]["logged_end_time"])
-        # self.assertEqual(1.0, report_1[0]["duration"])
-        # self.assertEqual(1.0, report_3[0]["duration"])
 
     def test_add_shift_hours(self):
         """ Uses shifts s1, s2, s3 and volunteers v1,v2,v3 """

--- a/vms/shift/tests/test_shiftHours.py
+++ b/vms/shift/tests/test_shiftHours.py
@@ -168,7 +168,6 @@ class ShiftHours(LiveServerTestCase):
         self.register_dataset()
         completed_shifts_page = self.completed_shifts_page
         completed_shifts_page.go_to_completed_shifts()
-
         self.assertEqual(completed_shifts_page.get_shift_job(), 'job')
         self.assertEqual(completed_shifts_page.get_clear_shift_hours(), 'Clear Hours')
         completed_shifts_page.click_to_clear_hours()

--- a/vms/shift/tests/test_unit.py
+++ b/vms/shift/tests/test_unit.py
@@ -6,10 +6,10 @@ from django.db.models import Q
 from django.test.testcases import TestCase
 
 # local Django
-from shift.models import Shift, VolunteerShift, EditRequest
+from shift.models import Shift, VolunteerShift, Report, EditRequest
 from shift.utils import create_event_with_details, create_job_with_details, create_shift_with_details, \
     create_volunteer_with_details, register_volunteer_for_shift_utility, create_edit_request_with_details, \
-    log_hours_with_details
+    log_hours_with_details, create_report_with_details
 from volunteer.models import Volunteer
 
 
@@ -289,6 +289,7 @@ class VolunteerShiftModelTests(TestCase):
         self.assertEqual(str(vol_shift_in_db.shift.end_time), vol_shift.shift.end_time)
         self.assertEqual(vol_shift_in_db.volunteer.first_name, vol_shift.volunteer.first_name)
         self.assertEqual(vol_shift_in_db.volunteer.last_name, vol_shift.volunteer.last_name)
+        self.assertEqual(vol_shift_in_db.report_status, vol_shift.report_status)
 
     def test_invalid_model_create(self):
         """
@@ -323,11 +324,13 @@ class VolunteerShiftModelTests(TestCase):
         self.assertEqual(str(vol_shift_in_db.shift.end_time), vol_shift.shift.end_time)
         self.assertEqual(vol_shift_in_db.volunteer.first_name, vol_shift.volunteer.first_name)
         self.assertEqual(vol_shift_in_db.volunteer.last_name, vol_shift.volunteer.last_name)
+        self.assertEqual(vol_shift_in_db.report_status, vol_shift.report_status)
 
         volunteer_in_db.first_name = 'Prince'
         volunteer_in_db.last_name = 'Vegeta'
         volunteer_in_db.save()
         vol_shift_in_db.volunteer = volunteer_in_db
+        vol_shift_in_db.report_status = True
         vol_shift_in_db.save()
 
         # Check single instance
@@ -340,6 +343,8 @@ class VolunteerShiftModelTests(TestCase):
         self.assertEqual(str(vol_shift_in_db.shift.end_time), vol_shift.shift.end_time)
         self.assertEqual(vol_shift_in_db.volunteer.first_name, 'Prince')
         self.assertEqual(vol_shift_in_db.volunteer.last_name, 'Vegeta')
+        self.assertEqual(vol_shift_in_db.report_status, True)
+
 
     def test_model_edit_with_invalid_values(self):
         """
@@ -361,6 +366,7 @@ class VolunteerShiftModelTests(TestCase):
         self.assertEqual(str(vol_shift_in_db.shift.end_time), vol_shift.shift.end_time)
         self.assertEqual(vol_shift_in_db.volunteer.first_name, vol_shift.volunteer.first_name)
         self.assertEqual(vol_shift_in_db.volunteer.last_name, vol_shift.volunteer.last_name)
+        self.assertEqual(vol_shift_in_db.report_status, vol_shift.report_status)
 
         vol_shift_in_db.volunteer.first_name = 'Son~'
 
@@ -390,6 +396,7 @@ class VolunteerShiftModelTests(TestCase):
         self.assertEqual(vol_shift_in_db.volunteer.last_name, vol_shift.volunteer.last_name)
         self.assertEqual(vol_shift_in_db.volunteer.email, vol_shift.volunteer.email)
         self.assertEqual(vol_shift_in_db.volunteer.phone_number, vol_shift.volunteer.phone_number)
+        self.assertEqual(vol_shift_in_db.report_status, vol_shift.report_status)
 
         vol_shift_in_db.delete()
         # Check no instance in db
@@ -604,3 +611,149 @@ class EditRequestModelTests(TestCase):
         # Check correctness
         self.assertEqual(str(edit_request_in_db), 'job-name - 2015-05-24 - Son Goku')
 
+
+class ReportVolunteerShiftModelTests(TestCase):
+
+    def setUp(self):
+        self.event = self.create_event()
+        self.job = self.create_job()
+
+    def tearDown(self):
+        pass
+
+    @staticmethod
+    def create_event():
+        event = ['event-name', '2015-05-24', '2015-05-28']
+        created_event = create_event_with_details(event)
+        return created_event
+
+    def create_job(self):
+        job = ['job-name', '2015-05-24', '2015-05-28', 'job-description', self.event]
+        created_job = create_job_with_details(job)
+        return created_job
+
+    def create_shift(self):
+        shift = ['2015-05-24', '09:00:00', '12:00:00', '10', self.job]
+        created_shift = create_shift_with_details(shift)
+        return created_shift
+
+    @staticmethod
+    def create_volunteer():
+        vol = [
+            "Goku", "Son", "Goku", "Kame House", "East District",
+            "East District", "East District", "9999999999", "idonthave@gmail.com"
+        ]
+        return create_volunteer_with_details(vol)
+
+    @staticmethod
+    def create_report(volunteer, shift):
+        start = datetime.time(hour=9, minute=0)
+        end = datetime.time(hour=12, minute=0)
+        logged_shift = log_hours_with_details(volunteer, shift, start, end)
+        return create_report_with_details(volunteer, logged_shift)
+
+    def test_valid_model_create(self):
+        shift = self.create_shift()
+        volunteer = self.create_volunteer()
+
+        report = self.create_report(volunteer, shift)
+
+        # Check db instance creation
+        self.assertEqual(len(Report.objects.all()), 1)
+
+        shift_in_db = Shift.objects.get(Q(job=self.job))
+        vol_shift_in_db = VolunteerShift.objects.get(Q(shift=shift_in_db))
+        report_in_db= Report.objects.get(Q(volunteer_shifts=vol_shift_in_db))
+
+        # Verify correctness
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].shift.start_time, report.volunteer_shifts.all()[0].shift.start_time)
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].shift.end_time, report.volunteer_shifts.all()[0].shift.end_time)
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].report_status, report.volunteer_shifts.all()[0].report_status)
+        self.assertEqual(report_in_db.volunteer.first_name, report.volunteer.first_name)
+        self.assertEqual(report_in_db.volunteer.last_name, report.volunteer.last_name)
+        self.assertEqual(report_in_db.confirm_status, report.confirm_status)
+
+    def test_model_edit_with_valid_values(self):
+        shift = self.create_shift()
+        volunteer = self.create_volunteer()
+
+        report = self.create_report(volunteer, shift)
+
+        # Check db instance creation
+        self.assertEqual(len(Report.objects.all()), 1)
+
+        shift_in_db = Shift.objects.get(Q(job=self.job))
+        volunteer_in_db = Volunteer.objects.get(Q(first_name='Son'))
+        vol_shift_in_db = VolunteerShift.objects.get(Q(shift=shift_in_db))
+        report_in_db= Report.objects.get(Q(volunteer_shifts=vol_shift_in_db))
+
+        # Verify correctness
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].shift.start_time, report.volunteer_shifts.all()[0].shift.start_time)
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].shift.end_time, report.volunteer_shifts.all()[0].shift.end_time)
+        self.assertEqual(report_in_db.volunteer.first_name, report.volunteer.first_name)
+        self.assertEqual(report_in_db.volunteer.last_name, report.volunteer.last_name)
+        self.assertEqual(report_in_db.confirm_status, report.confirm_status)
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].report_status, report.volunteer_shifts.all()[0].report_status)
+
+        volunteer_in_db.first_name = 'Prince'
+        volunteer_in_db.last_name = 'Vegeta'
+        volunteer_in_db.save()
+        vol_shift_in_db.volunteer = volunteer_in_db
+        vol_shift_in_db.report_status = True
+        vol_shift_in_db.save()
+        report_in_db.volunteer = volunteer_in_db
+        report_in_db.volunteer_shifts.clear()
+        report_in_db.volunteer_shifts.add(vol_shift_in_db)
+        report_in_db.confirm_status = 1
+        report_in_db.save()
+
+        self.assertEqual(len(Report.objects.all()), 1)
+
+        report_in_db= Report.objects.get(Q(volunteer_shifts=vol_shift_in_db))
+        # Verify correctness
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].shift.start_time, report.volunteer_shifts.all()[0].shift.start_time)
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].shift.end_time, report.volunteer_shifts.all()[0].shift.end_time)
+        self.assertEqual(report_in_db.volunteer.first_name, 'Prince')
+        self.assertEqual(report_in_db.volunteer.last_name, 'Vegeta')
+        self.assertEqual(report_in_db.confirm_status, 1)
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].report_status, True)
+
+    def test_model_delete(self):
+        shift = self.create_shift()
+        volunteer = self.create_volunteer()
+
+        report = self.create_report(volunteer, shift)
+
+        # Check db instance creation
+        self.assertEqual(len(Report.objects.all()), 1)
+
+        shift_in_db = Shift.objects.get(Q(job=self.job))
+        vol_shift_in_db = VolunteerShift.objects.get(Q(shift=shift_in_db))
+        report_in_db= Report.objects.get(Q(volunteer_shifts=vol_shift_in_db))
+        # Verify correctness
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].shift.start_time, report.volunteer_shifts.all()[0].shift.start_time)
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].shift.end_time, report.volunteer_shifts.all()[0].shift.end_time)
+        self.assertEqual(report_in_db.volunteer_shifts.all()[0].report_status, report.volunteer_shifts.all()[0].report_status)
+        self.assertEqual(report_in_db.volunteer.first_name, report.volunteer.first_name)
+        self.assertEqual(report_in_db.volunteer.last_name, report.volunteer.last_name)
+        self.assertEqual(report_in_db.confirm_status, report.confirm_status)
+
+        report_in_db.delete()
+        # Check no instance in db
+        self.assertEqual(len(Report.objects.all()), 0)
+
+    def test_model_representation(self):
+        shift = self.create_shift()
+        volunteer = self.create_volunteer()
+
+        self.create_report(volunteer, shift)
+
+        # Check db instance creation
+        self.assertEqual(len(Report.objects.all()), 1)
+
+        shift_in_db = Shift.objects.get(Q(job=self.job))
+        vol_shift_in_db = VolunteerShift.objects.get(Q(shift=shift_in_db))
+        report_in_db= Report.objects.get(Q(volunteer_shifts=vol_shift_in_db))
+
+        # Check correctness
+        self.assertEqual(str(report_in_db), 'Report object')

--- a/vms/shift/utils.py
+++ b/vms/shift/utils.py
@@ -8,10 +8,10 @@ from django.contrib.auth.models import User
 from administrator.models import Administrator
 from event.models import Event
 from job.models import Job
-from shift.models import Shift, VolunteerShift, EditRequest
+from shift.models import Shift, VolunteerShift, EditRequest, Report
+from shift.services import calculate_duration
 from volunteer.models import Volunteer
 from organization.models import Organization
-
 
 # Contains common functions which need to be frequently called by tests
 
@@ -44,6 +44,14 @@ def create_event_with_details(event):
     e1 = Event(name=event[0], start_date=event[1], end_date=event[2])
     e1.save()
     return e1
+
+
+def create_report_with_details(vol, logged_shift):
+     total_hours = calculate_duration(logged_shift.start_time, logged_shift.end_time)
+     r1 = Report.objects.create(volunteer=vol, total_hrs=total_hours)
+     r1.volunteer_shifts.add(logged_shift)
+     r1.save()
+     return r1
 
 
 def create_job_with_details(job):
@@ -255,6 +263,7 @@ def register_past_shift_utility():
         job=Job.objects.get(name='job'))
 
     return shift
+
 
 def register_event_utility():
     event = Event.objects.create(

--- a/vms/volunteer/forms.py
+++ b/vms/volunteer/forms.py
@@ -4,7 +4,7 @@ from django.forms import ModelForm
 
 # local Django
 from volunteer.models import Volunteer
-
+from shift.models import Report
 
 class ReportForm(forms.Form):
     event_name = forms.RegexField(
@@ -15,6 +15,9 @@ class ReportForm(forms.Form):
         regex=r'^[(A-Z)|(a-z)|(\s)]+$', max_length=75, required=False)
     start_date = forms.DateField(required=False)
     end_date = forms.DateField(required=False)
+
+    class Meta:
+        model = Report
 
 
 class SearchVolunteerForm(forms.Form):

--- a/vms/volunteer/models.py
+++ b/vms/volunteer/models.py
@@ -99,3 +99,4 @@ class Volunteer(models.Model):
 
     def __str__(self):
         return '{0} {1}'.format(self.first_name, self.last_name)
+

--- a/vms/volunteer/templates/volunteer/report.html
+++ b/vms/volunteer/templates/volunteer/report.html
@@ -106,9 +106,7 @@
     {% if report_list %}
         <div class="well">
             <legend>{% trans "Report Statistics" %}</legend>
-            <label><h4><span class="label label-default">{% trans "Total Number of Shifts" %}</span></h4></label>&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp{{ report_list|length }}
-            <br>
-            <label><h4><span class="label label-default">{% trans "Total Hours" %}</span></h4></label>&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp{{ total_hours }}
+            <label><h4><span class="label label-default">{% trans "Total Hours" %}</span></h4></label>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{ total_hours }}
         </div>
         <div class="well">
             <table class="table table-striped table-hover">

--- a/vms/volunteer/templates/volunteer/search.html
+++ b/vms/volunteer/templates/volunteer/search.html
@@ -212,6 +212,7 @@
                         <th>{% trans "Organization" %}</th>
                         <th>{% trans "Phone Number" %}</th>
                         <th>{% trans "Email" %}</th>
+                        <th>{% trans "Reports" %}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -233,6 +234,7 @@
                             </td>
                             <td>{{ volunteer.phone_number }}</td>
                             <td>{{ volunteer.email }}</td>
+                            <td><a href="{% url 'volunteer:view_history' volunteer.id %}" class="btn btn-info btn-sm">{% trans "View" %}</a></td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/vms/volunteer/templates/volunteer/view_history.html
+++ b/vms/volunteer/templates/volunteer/view_history.html
@@ -1,0 +1,46 @@
+{% extends "vms/base.html" %}
+{% load i18n %}
+{% block content %}
+<div class="spacer"></div>
+<a href="{% url 'volunteer:search' %}" class="btn btn-default">{% trans "Return to Volunteer Search" %}</a>
+<div class="spacer"></div>
+<h3>
+   Volunteer Name:&nbsp;&nbsp;&nbsp;{{volunteer.first_name}} {{volunteer.last_name}}
+</h3>
+<h3>
+   Organization:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{organization}}
+</h3>
+<div class="spacer"></div>
+<div class="well">
+   <legend>{% trans "Report Statistics" %}</legend>
+   <label>
+      <h4><span class="label label-default">{% trans "Total Reports" %}</span></h4>
+   </label>
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{ report_list|length }}
+</div>
+<table class="table table-striped table-hover">
+   <thead>
+      <tr>
+         <th>{% trans "Date submitted" %}</th>
+         <th>{% trans "Total hours" %}</th>
+         <th>{% trans "View Report" %}</th>
+      </tr>
+   </thead>
+   <tbody>
+      {% for report in report_list %}
+      <tr>
+         <td>
+            {{report.date_submitted}}
+         </td>
+         <td>
+            {{report.total_hrs}}
+         </td>
+         <td>
+            <a href="{% url 'administrator:show_report' report.id %}" class="btn btn-info btn-sm">{% trans "View" %}</a>
+         </td>
+      </tr>
+      {% endfor %}
+   </tbody>
+</table>
+{% endblock %}
+

--- a/vms/volunteer/tests/test_searchVolunteer.py
+++ b/vms/volunteer/tests/test_searchVolunteer.py
@@ -1,4 +1,5 @@
 # third party
+import datetime
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import WebDriverWait
@@ -11,7 +12,13 @@ from django.contrib.staticfiles.testing import LiveServerTestCase
 # local Django
 from pom.pages.authenticationPage import AuthenticationPage
 from pom.pages.volunteerSearchPage import VolunteerSearchPage
-from shift.utils import (create_admin, create_volunteer_with_details, create_organization_with_details, register_volunteer_for_shift_utility, register_event_utility, register_job_utility, register_shift_utility)
+from pom.pages.volunteerReportPage import VolunteerReportPage
+from pom.locators.volunteerSearchPageLocators import VolunteerSearchPageLocators
+from pom.pageUrls import PageUrls
+from shift.utils import (create_admin, create_volunteer_with_details, create_organization_with_details,
+                         register_past_event_utility, register_past_shift_utility, register_past_job_utility,
+                         create_report_with_details, log_hours_with_details, register_volunteer_for_shift_utility,
+                         register_event_utility, register_job_utility, register_shift_utility)
 
 
 class SearchVolunteer(LiveServerTestCase):
@@ -43,7 +50,9 @@ class SearchVolunteer(LiveServerTestCase):
         cls.driver.maximize_window()
         cls.search_page = VolunteerSearchPage(cls.driver)
         cls.authentication_page = AuthenticationPage(cls.driver)
+        cls.report_page = VolunteerReportPage(cls.driver)
         cls.wait = WebDriverWait(cls.driver, 10)
+        cls.elements = VolunteerSearchPageLocators()
         super(SearchVolunteer, cls).setUpClass()
 
     def setUp(self):
@@ -81,6 +90,16 @@ class SearchVolunteer(LiveServerTestCase):
             'password': 'admin'
         })
 
+    def verify_report_details(self, reports):
+        """
+        Utility function to verify the shift details.
+        :param total_reports: Total number of reports as filled in form.
+        :param reports: Total number of reports as filled in form.
+        """
+        total_no_of_reports = self.report_page.get_shift_summary().split(' ')[-1].strip('\n')
+        self.assertEqual(total_no_of_reports, reports)
+
+
     def wait_for_home_page(self):
         """
         Utility function to perform explicit wait for home page.
@@ -117,8 +136,11 @@ class SearchVolunteer(LiveServerTestCase):
 
         volunteer_2 = create_volunteer_with_details(credentials_2)
 
-        expected_result_one = credentials_1[1:-1]
-        expected_result_two = credentials_2[1:-1]
+        expected_result_one = ['VOLUNTEER-FIRST-NAME', 'volunteer-last-name', 'volunteer-address', 'volunteer-city',
+                               'volunteer-state', 'volunteer-country', '9999999999', 'volunteer-email@systers.org', 'View']
+
+        expected_result_two = ['volunteer-first-name', 'volunteer-last-nameq', 'volunteer-addressq', 'volunteer-cityq',
+                               'volunteer-stateq', 'volunteer-countryq', '9999999999', 'volunteer-email2@systers.orgq', 'View']
 
         search_page.search_first_name_field('volunteer')
         search_page.submit_form()
@@ -180,8 +202,11 @@ class SearchVolunteer(LiveServerTestCase):
         ]
         volunteer_2 = create_volunteer_with_details(credentials_2)
 
-        expected_result_one = credentials_1[1:-1]
-        expected_result_two = credentials_2[1:-1]
+        expected_result_one = ['volunteer-first-name', 'VOLUNTEER-LAST-NAME', 'volunteer-address', 'volunteer-city',
+                               'volunteer-state', 'volunteer-country', '9999999999', 'volunteer-email@systers.org', 'View']
+
+        expected_result_two = ['volunteer-first-nameq', 'volunteer-last-name', 'volunteer-addressq', 'volunteer-cityq',
+                               'volunteer-stateq', 'volunteer-countryq', '9999999999', 'volunteer-email2@systers.orgq', 'View']
 
         search_page.search_last_name_field('volunteer')
         search_page.submit_form()
@@ -245,8 +270,11 @@ class SearchVolunteer(LiveServerTestCase):
 
         volunteer_2 = create_volunteer_with_details(credentials_2)
 
-        expected_result_one = credentials_1[1:-1]
-        expected_result_two = credentials_2[1:-1]
+        expected_result_one = ['volunteer-first-name', 'volunteer-last-name', 'volunteer-address', 'VOLUNTEER-CITY',
+                               'volunteer-state', 'volunteer-country', '9999999999', 'volunteer-email@systers.org', 'View']
+
+        expected_result_two = ['volunteer-first-nameq', 'volunteer-last-nameq', 'volunteer-addressq', 'volunteer-city',
+                               'volunteer-stateq', 'volunteer-countryq', '9999999999', 'volunteer-email2@systers.orgq', 'View']
 
         search_page.search_city_field('volunteer')
         search_page.submit_form()
@@ -310,8 +338,11 @@ class SearchVolunteer(LiveServerTestCase):
 
         volunteer_2 = create_volunteer_with_details(credentials_2)
 
-        expected_result_one = credentials_1[1:-1]
-        expected_result_two = credentials_2[1:-1]
+        expected_result_one = ['volunteer-first-name', 'volunteer-last-name', 'volunteer-address', 'volunteer-city',
+                               'VOLUNTEER-STATE', 'volunteer-country', '9999999999', 'volunteer-email@systers.org', 'View']
+
+        expected_result_two = ['volunteer-first-nameq', 'volunteer-last-nameq', 'volunteer-addressq', 'volunteer-cityq',
+                               'volunteer-state', 'volunteer-countryq', '9999999999', 'volunteer-email2@systers.orgq', 'View']
 
         search_page.search_state_field('volunteer')
         search_page.submit_form()
@@ -375,8 +406,11 @@ class SearchVolunteer(LiveServerTestCase):
 
         volunteer_2 = create_volunteer_with_details(credentials_2)
 
-        expected_result_one = credentials_1[1:-1]
-        expected_result_two = credentials_2[1:-1]
+        expected_result_one = ['volunteer-first-name', 'volunteer-last-name', 'volunteer-address', 'volunteer-city',
+                               'volunteer-state', 'VOLUNTEER-COUNTRY', '9999999999', 'volunteer-email@systers.org', 'View']
+
+        expected_result_two = ['volunteer-first-nameq', 'volunteer-last-nameq', 'volunteer-addressq', 'volunteer-cityq',
+                               'volunteer-stateq', 'volunteer-country', '9999999999', 'volunteer-email2@systers.orgq', 'View']
 
         search_page.search_country_field('volunteer')
         search_page.submit_form()
@@ -446,19 +480,11 @@ class SearchVolunteer(LiveServerTestCase):
         volunteer_1.save()
         volunteer_2.save()
 
-        expected_result_one = [
-            'volunteer-first-nameq', 'volunteer-last-nameq',
-            'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq',
-            'volunteer-countryq', 'volunteer-organization', '9999999999',
-            'volunteer-email2@systers.orgq'
-        ]
+        expected_result_one = ['volunteer-first-name', 'volunteer-last-name', 'volunteer-address', 'volunteer-city',
+                               'volunteer-state', 'volunteer-country', 'VOLUNTEER-ORGANIZATION', '9999999999', 'volunteer-email@systers.org', 'View']
 
-        expected_result_two = [
-            'volunteer-first-name', 'volunteer-last-name', 'volunteer-address',
-            'volunteer-city', 'volunteer-state', 'volunteer-country',
-            'VOLUNTEER-ORGANIZATION', '9999999999',
-            'volunteer-email@systers.org'
-        ]
+        expected_result_two = ['volunteer-first-nameq', 'volunteer-last-nameq', 'volunteer-addressq', 'volunteer-cityq',
+                               'volunteer-stateq', 'volunteer-countryq', 'volunteer-organization', '9999999999', 'volunteer-email2@systers.orgq', 'View']
 
         search_page.navigate_to_volunteer_search_page()
         search_page.search_organization_field('volunteer')
@@ -492,8 +518,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-username', 'volunteer-first-name',
             'volunteer-last-name', 'volunteer-address', 'volunteer-city',
             'volunteer-state', 'volunteer-country', '9999999999',
-            'volunteer-email@systers.org', 'volunteer-organization'
-        ]
+            'volunteer-email@systers.org', 'volunteer-organization']
 
         volunteer_1 = create_volunteer_with_details(credentials_1)
 
@@ -501,8 +526,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-usernameq', 'volunteer-first-nameq',
             'volunteer-last-nameq', 'volunteer-addressq', 'volunteer-cityq',
             'volunteer-stateq', 'volunteer-countryq', '9999999999',
-            'volunteer-email2@systers.orgq', 'volunteer-organizationq'
-        ]
+            'volunteer-email2@systers.orgq', 'volunteer-organizationq']
 
         volunteer_2 = create_volunteer_with_details(credentials_2)
 
@@ -510,8 +534,12 @@ class SearchVolunteer(LiveServerTestCase):
         register_job_utility()
         shift = register_shift_utility()
 
-        expected_result_one = credentials_1[1:-1]
-        expected_result_two = credentials_2[1:-1]
+        expected_result_one = ['volunteer-first-name', 'volunteer-last-name', 'volunteer-address', 'volunteer-city',
+                               'volunteer-state', 'volunteer-country', '9999999999', 'volunteer-email@systers.org', 'View']
+
+        expected_result_two = ['volunteer-first-nameq', 'volunteer-last-nameq', 'volunteer-addressq', 'volunteer-cityq',
+                               'volunteer-stateq', 'volunteer-countryq', '9999999999', 'volunteer-email2@systers.orgq', 'View']
+
 
         # search events with no volunteers
         search_page.search_event_field("event")
@@ -545,7 +573,7 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-last-name', 'volunteer-address', 'volunteer-city',
             'volunteer-state', 'volunteer-country', '9999999999',
             'volunteer-email@systers.org', 'volunteer-organization'
-        ]
+            'View']
 
         volunteer_1 = create_volunteer_with_details(credentials_1)
 
@@ -554,16 +582,18 @@ class SearchVolunteer(LiveServerTestCase):
             'volunteer-last-nameq', 'volunteer-addressq', 'volunteer-cityq',
             'volunteer-stateq', 'volunteer-countryq', '9999999999',
             'volunteer-email2@systers.orgq', 'volunteer-organizationq'
-        ]
+            'View']
 
         volunteer_2 = create_volunteer_with_details(credentials_2)
 
         register_event_utility()
         register_job_utility()
         shift = register_shift_utility()
+        expected_result_one = ['volunteer-first-name', 'volunteer-last-name', 'volunteer-address', 'volunteer-city',
+                               'volunteer-state', 'volunteer-country', '9999999999', 'volunteer-email@systers.org', 'View']
 
-        expected_result_one = credentials_1[1:-1]
-        expected_result_two = credentials_2[1:-1]
+        expected_result_two = ['volunteer-first-nameq', 'volunteer-last-nameq', 'volunteer-addressq', 'volunteer-cityq',
+                               'volunteer-stateq', 'volunteer-countryq', '9999999999', 'volunteer-email2@systers.orgq', 'View']
 
         # volunteer_1 and volunteer_2 registered for job
         register_volunteer_for_shift_utility(shift, volunteer_1)
@@ -622,19 +652,9 @@ class SearchVolunteer(LiveServerTestCase):
         register_volunteer_for_shift_utility(shift, volunteer_1)
         register_volunteer_for_shift_utility(shift, volunteer_2)
 
-        expected_result_one = [
-            'volunteer-first-nameq', 'volunteer-last-nameq',
-            'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq',
-            'volunteer-countryq', 'volunteer-organization', '9999999999',
-            'volunteer-email2@systers.orgq'
-        ]
+        expected_result_one = ['volunteer-first-name', 'volunteer-last-name', 'volunteer-address', 'volunteer-city', 'volunteer-state', 'volunteer-country', 'VOLUNTEER-ORGANIZATION', '9999999999', 'volunteer-email@systers.org', 'View']
 
-        expected_result_two = [
-            'volunteer-first-name', 'volunteer-last-name', 'volunteer-address',
-            'volunteer-city', 'volunteer-state', 'volunteer-country',
-            'VOLUNTEER-ORGANIZATION', '9999999999',
-            'volunteer-email@systers.org'
-        ]
+        expected_result_two = ['volunteer-first-nameq', 'volunteer-last-nameq', 'volunteer-addressq', 'volunteer-cityq', 'volunteer-stateq', 'volunteer-countryq', 'volunteer-organization', '9999999999', 'volunteer-email2@systers.orgq', 'View']
 
         search_page.navigate_to_volunteer_search_page()
 
@@ -667,4 +687,33 @@ class SearchVolunteer(LiveServerTestCase):
         self.assertRaisesRegexp(NoSuchElementException,
                                 'Unable to locate element: //table//tbody',
                                 search_page.get_search_results)
+
+    def test_check_volunteer_reports(self):
+        search_page = self.search_page
+        search_page.live_server_url = self.live_server_url
+        credentials_1 = [
+            'volunteer-username', 'volunteer-first-name',
+            'VOLUNTEER-LAST-NAME', 'volunteer-address', 'volunteer-city',
+            'volunteer-state', 'volunteer-country', '9999999999',
+            'volunteer-email@systers.org', 'volunteer-organization'
+        ]
+        vol = create_volunteer_with_details(credentials_1)
+
+        register_past_event_utility()
+        register_past_job_utility()
+        shift = register_past_shift_utility()
+        start=datetime.time(hour=10, minute=0)
+        end=datetime.time(hour=11, minute=0)
+        logged_shift = log_hours_with_details(vol, shift, start, end)
+        report = create_report_with_details(vol, logged_shift)
+        report.confirm_status = 1
+        report.save()
+
+        search_page.navigate_to_volunteer_search_page()
+        search_page.submit_form()
+
+        self.assertEqual(search_page.element_by_xpath(self.elements.VIEW_REPORTS).text, 'View')
+        search_page.element_by_xpath(self.elements.VIEW_REPORTS + '//a').click()
+        self.assertEqual(search_page.remove_i18n(self.driver.current_url), self.live_server_url + PageUrls.volunteer_history_page + str(vol.id))
+        self.verify_report_details('1')
 

--- a/vms/volunteer/tests/test_volunteerReport.py
+++ b/vms/volunteer/tests/test_volunteerReport.py
@@ -7,10 +7,9 @@ from django.contrib.staticfiles.testing import LiveServerTestCase
 # local Django
 from pom.pages.authenticationPage import AuthenticationPage
 from pom.pages.volunteerReportPage import VolunteerReportPage
-from shift.utils import (create_volunteer, register_event_utility,
-                         register_job_utility, register_shift_utility,
+from shift.utils import (create_volunteer, register_past_event_utility,
+                         register_past_job_utility, register_past_shift_utility,
                          log_hours_utility)
-
 
 class VolunteerReport(LiveServerTestCase):
     """
@@ -60,15 +59,13 @@ class VolunteerReport(LiveServerTestCase):
         cls.driver.quit()
         super(VolunteerReport, cls).tearDownClass()
 
-    def verify_shift_details(self, total_shifts, hours):
+    def verify_shift_details(self, hours):
         """
         Utility function to verify the shift details.
         :param total_shifts: Total number of shifts as filled in form.
         :param hours: Total number of hours as filled in form.
         """
-        total_no_of_shifts = self.report_page.get_shift_summary().split(' ')[10].strip('\nTotal')
         total_no_of_hours = self.report_page.get_shift_summary().split(' ')[-1].strip('\n')
-        self.assertEqual(total_no_of_shifts, total_shifts)
         self.assertEqual(total_no_of_hours, hours)
 
     def login(self):
@@ -97,14 +94,14 @@ class VolunteerReport(LiveServerTestCase):
         """
         report_page = self.report_page
         report_page.live_server_url = self.live_server_url
-        register_event_utility()
-        register_job_utility()
-        register_shift_utility()
+        register_past_event_utility()
+        register_past_job_utility()
+        register_past_shift_utility()
         log_hours_utility()
 
         report_page.navigate_to_report_page()
         report_page.submit_form()
-        self.verify_shift_details('1', '3.0')
+        self.verify_shift_details('3.0')
 
     def test_only_logged_shifts_appear_in_report(self):
         """
@@ -113,14 +110,36 @@ class VolunteerReport(LiveServerTestCase):
         report_page = self.report_page
         report_page.live_server_url = self.live_server_url
 
-        register_event_utility()
-        register_job_utility()
-        register_shift_utility()
+        register_past_event_utility()
+        register_past_job_utility()
+        register_past_shift_utility()
 
         report_page.navigate_to_report_page()
         report_page.submit_form()
         self.assertEqual(report_page.get_alert_box_text(),
                          report_page.no_results_message)
+
+    def test_shifts_appear_in_one_report(self):
+        """
+        Test only shifts with logged hours is shown in report.
+        """
+
+        report_page = self.report_page
+        report_page.live_server_url = self.live_server_url
+        register_past_event_utility()
+        register_past_job_utility()
+        register_past_shift_utility()
+        log_hours_utility()
+
+        report_page.navigate_to_report_page()
+        report_page.submit_form()
+        self.verify_shift_details('3.0')
+
+        # try to create report again
+        report_page.submit_form()
+        self.assertEqual(report_page.get_alert_box_text(),
+                         report_page.no_results_message)
+
 
     def test_date_field(self):
         """
@@ -129,22 +148,22 @@ class VolunteerReport(LiveServerTestCase):
         report_page = self.report_page
         report_page.live_server_url = self.live_server_url
 
-        register_event_utility()
-        register_job_utility()
-        register_shift_utility()
+        register_past_event_utility()
+        register_past_job_utility()
+        register_past_shift_utility()
         log_hours_utility()
 
         report_page.navigate_to_report_page()
         report_page.fill_report_form({
-            'start': '2048-06-11',
-            'end': '2050-06-16'
+            'start': '2012-06-11',
+            'end': '2012-06-16'
         })
-        self.verify_shift_details('1', '3.0')
+        self.verify_shift_details('3.0')
 
         # Incorrect date
         report_page.fill_report_form({
-            'start': '2050-05-10',
-            'end': '2050-06-01'
+            'start': '2015-05-10',
+            'end': '2015-06-01'
         })
         self.assertEqual(report_page.get_alert_box_text(), report_page.no_results_message)
 
@@ -155,9 +174,9 @@ class VolunteerReport(LiveServerTestCase):
         report_page = self.report_page
         report_page.live_server_url = self.live_server_url
 
-        register_event_utility()
-        register_job_utility()
-        register_shift_utility()
+        register_past_event_utility()
+        register_past_job_utility()
+        register_past_shift_utility()
         log_hours_utility()
 
         report_page.navigate_to_report_page()
@@ -165,7 +184,7 @@ class VolunteerReport(LiveServerTestCase):
         select1.select_by_visible_text('event')
 
         report_page.submit_form()
-        self.verify_shift_details('1', '3.0')
+        self.verify_shift_details('3.0')
 
     def test_job_field(self):
         """
@@ -174,16 +193,16 @@ class VolunteerReport(LiveServerTestCase):
         report_page = self.report_page
         report_page.live_server_url = self.live_server_url
 
-        register_event_utility()
-        register_job_utility()
-        register_shift_utility()
+        register_past_event_utility()
+        register_past_job_utility()
+        register_past_shift_utility()
         log_hours_utility()
 
         report_page.navigate_to_report_page()
         [select1, select2] = report_page.get_event_job_selectors()
         select2.select_by_visible_text('job')
         report_page.submit_form()
-        self.verify_shift_details('1', '3.0')
+        self.verify_shift_details('3.0')
 
     def test_intersection_of_fields(self):
         """
@@ -192,9 +211,9 @@ class VolunteerReport(LiveServerTestCase):
         report_page = self.report_page
         report_page.live_server_url = self.live_server_url
 
-        register_event_utility()
-        register_job_utility()
-        register_shift_utility()
+        register_past_event_utility()
+        register_past_job_utility()
+        register_past_shift_utility()
         log_hours_utility()
 
         report_page.navigate_to_report_page()
@@ -202,17 +221,17 @@ class VolunteerReport(LiveServerTestCase):
         select1.select_by_visible_text('event')
         select2.select_by_visible_text('job')
         report_page.fill_report_form({
-            'start': '2048-06-11',
-            'end': '2050-06-16'})
-        self.verify_shift_details('1', '3.0')
+            'start': '2012-06-11',
+            'end': '2012-06-16'})
+        self.verify_shift_details('3.0')
 
         # Event, Job correct and date incorrect
         [select1, select2] = report_page.get_event_job_selectors()
         select1.select_by_visible_text('event')
         select2.select_by_visible_text('job')
         report_page.fill_report_form({
-            'start': '2050-05-10',
-            'end': '2050-06-01'
+            'start': '2015-05-10',
+            'end': '2015-06-01'
         })
         self.assertEqual(report_page.get_alert_box_text(), report_page.no_results_message)
 

--- a/vms/volunteer/urls.py
+++ b/vms/volunteer/urls.py
@@ -3,7 +3,8 @@ from django.conf.urls import url
 
 # local Django
 from volunteer import views
-from volunteer.views import VolunteerUpdateView, ProfileView, GenerateReportView
+from volunteer.views import (VolunteerUpdateView, ProfileView,
+                            GenerateReportView, VolunteerHistoryView)
 
 urlpatterns = [
     url(r'^delete_resume/(?P<volunteer_id>\d+)$',
@@ -22,5 +23,8 @@ urlpatterns = [
         GenerateReportView.as_view(),
         name='report'),
     url(r'^search/$', views.search, name='search'),
+    url(r'^view_history/(?P<volunteer_id>\d+)$',
+        VolunteerHistoryView.as_view(),
+        name='view_history'),
 ]
 

--- a/vms/volunteer/views.py
+++ b/vms/volunteer/views.py
@@ -22,7 +22,8 @@ from administrator.utils import admin_required
 from event.services import get_signed_up_events_for_volunteer
 from job.services import get_signed_up_jobs_for_volunteer
 from organization.services import get_organization_by_id, get_organizations_ordered_by_name
-from shift.services import get_volunteer_report, calculate_total_report_hours
+from shift.models import Report
+from shift.services import calculate_total_report_hours, get_volunteer_shifts, generate_report
 from volunteer.forms import ReportForm, SearchVolunteerForm, VolunteerForm
 from volunteer.models import Volunteer
 from volunteer.services import (delete_volunteer_resume, search_volunteers,
@@ -65,6 +66,41 @@ def delete_resume(request, volunteer_id):
                 raise Http404
     else:
         return HttpResponse(status=403)
+
+
+class VolunteerHistoryView(LoginRequiredMixin, ListView):
+    """
+    Returns reports volunteerwise
+
+    Extends ListView which is a generic class-based view to display list
+    """
+    template_name = 'volunteer/view_history.html'
+    model = Report
+
+    def get_queryset(self):
+       """
+       returns confirmed reports of a volunteer
+
+       :return: confirmed reports of the selected volunteer
+       """
+       volunteer_id = self.kwargs['volunteer_id']
+       volunteer = get_volunteer_by_id(volunteer_id)
+       reports = Report.objects.filter(confirm_status=1, volunteer=volunteer).order_by('date_submitted')
+       return reports
+
+    def get_context_data(self, **kwargs):
+       """
+       displays volunteer information
+
+       :return: volunteer object and its organization
+       """
+       context = super(VolunteerHistoryView, self).get_context_data(**kwargs)
+       volunteer_id = self.kwargs['volunteer_id']
+       volunteer = get_volunteer_by_id(volunteer_id)
+       context['volunteer'] = volunteer
+       organization = volunteer.organization
+       context['organization'] = organization
+       return context
 
 
 '''
@@ -198,25 +234,36 @@ class ShowReportListView(LoginRequiredMixin, ListView):
 
     def post(self, request, *args, **kwargs):
         volunteer_id = self.kwargs['volunteer_id']
+        volunteer = get_volunteer_by_id(volunteer_id)
         event_list = get_signed_up_events_for_volunteer(volunteer_id)
         job_list = get_signed_up_jobs_for_volunteer(volunteer_id)
         event_name = self.request.POST['event_name']
         job_name = self.request.POST['job_name']
         start_date = self.request.POST['start_date']
-        end_date = self.request.POST['end_date']
-        report_list = get_volunteer_report(volunteer_id, event_name, job_name,
+        end_date = self.request.POST['end_date'] 
+        volunteer_shift_list = get_volunteer_shifts(volunteer_id, event_name, job_name,
                                            start_date, end_date)
-        total_hours = calculate_total_report_hours(report_list)
-        return render(
-            request, 'volunteer/report.html', {
-                'report_list': report_list,
-                'total_hours': total_hours,
-                'notification': True,
-                'job_list': job_list,
-                'event_list': event_list,
-                'selected_event': event_name,
-                'selected_job': job_name
-            })
+        if volunteer_shift_list:
+            report_list = generate_report(volunteer_shift_list)
+            total_hours = calculate_total_report_hours(report_list)
+            report = Report.objects.create(total_hrs=total_hours, volunteer=volunteer)
+            report.volunteer_shifts.add(*volunteer_shift_list)
+            report.save()
+            return render(request, 'volunteer/report.html', {
+                          'report_list': report_list,
+                          'total_hours': total_hours,
+                          'notification': True,
+                          'job_list': job_list,
+                          'event_list': event_list,
+                          'selected_event': event_name,
+                          'selected_job': job_name
+                          })
+        else:
+            return render(request, 'volunteer/report.html', {
+                          'job_list': job_list,
+                          'event_list': event_list,
+                          'notification': True,
+                          })
 
 
 @login_required

--- a/vms/volunteer/views.py
+++ b/vms/volunteer/views.py
@@ -240,7 +240,7 @@ class ShowReportListView(LoginRequiredMixin, ListView):
         event_name = self.request.POST['event_name']
         job_name = self.request.POST['job_name']
         start_date = self.request.POST['start_date']
-        end_date = self.request.POST['end_date'] 
+        end_date = self.request.POST['end_date']
         volunteer_shift_list = get_volunteer_shifts(volunteer_id, event_name, job_name,
                                            start_date, end_date)
         if volunteer_shift_list:


### PR DESCRIPTION
# Description
The volunteers can create their reports, administrators can confirm them and also they can view the past reports of the volunteers

Fixes #658 

# Type of Change: 
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

# How Has This Been Tested?
Volunteer side(volunteer can generate his report):
![image](https://user-images.githubusercontent.com/22369767/41819575-3e552960-77e0-11e8-953a-63da82a92421.png)

if the report has already been generated:
![image](https://user-images.githubusercontent.com/22369767/41733443-7cb6b7a0-75a1-11e8-9acb-5bb04d7e8aad.png)

Unconfirmed reports(admin can confirm them):
![image](https://user-images.githubusercontent.com/22369767/41748289-cf34cd0a-75ce-11e8-9516-654e060f7872.png)

![image](https://user-images.githubusercontent.com/22369767/41733283-0efdb2ae-75a1-11e8-9fd7-9f07a0474ca8.png)
Past reports volunteerwise:
![image](https://user-images.githubusercontent.com/22369767/41733297-18961a54-75a1-11e8-8a08-a6bce31b80a1.png)



# Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
