### PR TITLE
Fix search event test by breaking it into 3 checks

### DIFF
--- a/vms/event/tests/test_shiftSignUp.py
+++ b/vms/event/tests/test_shiftSignUp.py
@@ -185,7 +185,7 @@ class ShiftSignUp(LiveServerTestCase):
         # on event page
         self.assertEqual(sign_up_page.get_info_box().text, sign_up_page.no_event_message)
 
-    def test_search_event(self):
+    def test_search_event_both_date_present(self):
         register_event_utility()
         register_job_utility()
         register_shift_utility()
@@ -200,7 +200,13 @@ class ShiftSignUp(LiveServerTestCase):
         # Verify that the event shows up
         self.assertEqual(sign_up_page.get_event_name(), 'event')
 
-        # a = input()
+    def test_search_event_start_date_presesnt(self):
+        register_event_utility()
+        register_job_utility()
+        register_shift_utility()
+
+        sign_up_page = self.sign_up_page
+        sign_up_page.live_server_url = self.live_server_url
         # Enter only correct starting date
         sign_up_page.go_to_sign_up_page()
         date = ['05/10/2050', '']
@@ -208,9 +214,18 @@ class ShiftSignUp(LiveServerTestCase):
         # Verify that the event shows up
         self.assertEqual(sign_up_page.get_event_name(), 'event')
 
+    def test_search_event_end_date_present(self):
+        register_event_utility()
+        register_job_utility()
+        register_shift_utility()
+
+        sign_up_page = self.sign_up_page
+        sign_up_page.live_server_url = self.live_server_url
+
         # Enter correct ending date
         sign_up_page.go_to_sign_up_page()
         date = ['', '06/15/2050']
         sign_up_page.fill_search_form(date)
         # Verify that the event shows up
         self.assertEqual(sign_up_page.get_event_name(), 'event')
+


### PR DESCRIPTION
# Description
search event consisted of 3 checks; both date present, only start, only end. Since for all those 3 checks we were clicking on the same link it created instability and raised StaleElementException. Thus we need to break it in 3 different tests.

Fixes #747 

# Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



# How Has This Been Tested?
This was working fine locally but it creates issues on travis, so we need to check travis logs mainly. Otherwise local testing can be done using
```
python manage.py test event/ -v 2
```


# Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
