### PR TITLE
Add checks for extra field in model create

### DIFF
--- a/vms/administrator/tests/test_formFields.py
+++ b/vms/administrator/tests/test_formFields.py
@@ -77,7 +77,7 @@ class FormFields(LiveServerTestCase):
 
     def test_null_values_in_create_event(self):
         self.settings.go_to_events_page()
-        event = ['', '', '']
+        event = ['', '', '', 'in!valid', 'in!valid']
         settings = self.settings
         settings.go_to_create_event_page()
         settings.fill_event_form(event)
@@ -87,10 +87,12 @@ class FormFields(LiveServerTestCase):
         # Error messages appear
         self.assertEqual(settings.remove_i18n(self.driver.current_url),
                          self.live_server_url + settings.create_event_page)
-        self.assertEqual(len(settings.get_help_blocks()), 3)
-        self.assertEqual(settings.get_event_name_error(), 'This field is required.')
-        self.assertEqual(settings.get_event_start_date_error(), 'This field is required.')
-        self.assertEqual(settings.get_event_end_date_error(), 'This field is required.')
+        self.assertEqual(len(settings.get_help_blocks()), 5)
+        self.assertEqual(settings.get_event_name_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_event_start_date_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_event_end_date_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_event_address_error(), settings.ENTER_VALID_VALUE)
+        self.assertEqual(settings.get_event_venue_error(), settings.ENTER_VALID_VALUE)
 
     def test_null_values_in_edit_event(self):
         event = ['event-name', '2018-05-24', '2018-05-28']
@@ -111,9 +113,9 @@ class FormFields(LiveServerTestCase):
         # Error messages appear
         self.assertNotEqual(self.driver.current_url, self.live_server_url + settings.event_list_page)
         self.assertEqual(len(settings.get_help_blocks()), 3)
-        self.assertEqual(settings.get_event_name_error(), 'This field is required.')
-        self.assertEqual(settings.get_event_start_date_error(), 'This field is required.')
-        self.assertEqual(settings.get_event_end_date_error(), 'This field is required.')
+        self.assertEqual(settings.get_event_name_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_event_start_date_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_event_end_date_error(), settings.FIELD_REQUIRED)
 
     def test_null_values_in_create_job(self):
         # Register Event
@@ -136,9 +138,9 @@ class FormFields(LiveServerTestCase):
         self.assertEqual(settings.remove_i18n(self.driver.current_url), self.live_server_url + settings.create_job_page)
         self.assertEqual(len(settings.get_help_blocks()), 3)
 
-        self.assertEqual(settings.get_job_name_error(), 'This field is required.')
-        self.assertEqual(settings.get_job_start_date_error(), 'This field is required.')
-        self.assertEqual(settings.get_job_end_date_error(), 'This field is required.')
+        self.assertEqual(settings.get_job_name_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_job_start_date_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_job_end_date_error(), settings.FIELD_REQUIRED)
 
     def test_null_values_in_edit_job(self):
         # Register Event
@@ -164,9 +166,9 @@ class FormFields(LiveServerTestCase):
         # Error messages appear
         self.assertNotEqual(self.driver.current_url, self.live_server_url + settings.job_list_page)
         self.assertEqual(len(settings.get_help_blocks()), 3)
-        self.assertEqual(settings.get_job_name_error(), 'This field is required.')
-        self.assertEqual(settings.get_job_start_date_error(), 'This field is required.')
-        self.assertEqual(settings.get_job_end_date_error(), 'This field is required.')
+        self.assertEqual(settings.get_job_name_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_job_start_date_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_job_end_date_error(), settings.FIELD_REQUIRED)
 
     def test_null_values_in_create_shift(self):
         # Register Event
@@ -184,18 +186,20 @@ class FormFields(LiveServerTestCase):
         settings.go_to_create_shift_page()
 
         # Create Shift
-        shift = ['', '', '', '']
+        shift = ['', '', '', '', 'in!valid', 'in!valid']
         settings.fill_shift_form(shift)
 
         # Checks:
         # Shift not created
         # Error messages appear
-        self.assertEqual(len(settings.get_help_blocks()), 4)
+        self.assertEqual(len(settings.get_help_blocks()), 6)
 
-        self.assertEqual(settings.get_shift_date_error(), 'This field is required.')
-        self.assertEqual(settings.get_shift_start_time_error(), 'This field is required.')
-        self.assertEqual(settings.get_shift_end_time_error(), 'This field is required.')
-        self.assertEqual(settings.get_shift_max_volunteer_error(), 'This field is required.')
+        self.assertEqual(settings.get_shift_date_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_shift_start_time_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_shift_end_time_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_shift_max_volunteer_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_shift_address_error(), settings.ENTER_VALID_VALUE)
+        self.assertEqual(settings.get_shift_venue_error(), settings.ENTER_VALID_VALUE)
 
     def test_null_values_in_edit_shift(self):
         # Register Event
@@ -224,10 +228,10 @@ class FormFields(LiveServerTestCase):
         # expected
         self.assertEqual(len(settings.get_help_blocks()), 4)
 
-        self.assertEqual(settings.get_shift_date_error(), 'This field is required.')
-        self.assertEqual(settings.get_shift_start_time_error(), 'This field is required.')
-        self.assertEqual(settings.get_shift_end_time_error(), 'This field is required.')
-        self.assertEqual(settings.get_shift_max_volunteer_error(), 'This field is required.')
+        self.assertEqual(settings.get_shift_date_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_shift_start_time_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_shift_end_time_error(), settings.FIELD_REQUIRED)
+        self.assertEqual(settings.get_shift_max_volunteer_error(), settings.FIELD_REQUIRED)
 
     def test_max_volunteer_field(self):
         self.settings.go_to_events_page()

--- a/vms/event/tests/test_model.py
+++ b/vms/event/tests/test_model.py
@@ -26,7 +26,7 @@ class EventModelTests(TestCase):
         return created_event
 
     def test_valid_model_create(self):
-        event = ['event-name', '2050-05-24', '2050-05-28']
+        event = ['event-name', '2050-05-24', '2050-05-28', 'event address', 'event venue']
         create_event_with_details(event)
 
         # Check database for instance creation
@@ -37,6 +37,8 @@ class EventModelTests(TestCase):
         self.assertEqual(event_in_db.name, event[0])
         self.assertEqual(str(event_in_db.start_date), event[1])
         self.assertEqual(str(event_in_db.end_date), event[2])
+        self.assertEqual(event_in_db.address, event[3])
+        self.assertEqual(event_in_db.venue, event[4])
 
     def test_invalid_model_create(self):
         event = ['event~name', '2050-05-21', '2050-05-24']

--- a/vms/pom/locators/eventsPageLocators.py
+++ b/vms/pom/locators/eventsPageLocators.py
@@ -38,6 +38,8 @@ class EventsPageLocators(object):
     CREATE_EVENT_START_DATE = '//input[@name = "start_date"]'
     CREATE_EVENT_END_DATE = '//input[@name = "end_date"]'
     CREATE_EVENT_ID = '//select[@name = "event_id"]'
+    CREATE_EVENT_ADDRESS = '//input[@name = "address"]'
+    CREATE_EVENT_VENUE = '//input[@name = "venue"]'
     CREATE_JOB_NAME = '//input[@placeholder = "Job Name"]'
     CREATE_JOB_DESCRIPTION = '//textarea[@name = "description"]'
     CREATE_JOB_START_DATE = '//input[@name = "start_date"]'
@@ -46,11 +48,15 @@ class EventsPageLocators(object):
     CREATE_SHIFT_START_TIME = '//input[@name = "start_time"]'
     CREATE_SHIFT_END_TIME = '//input[@name = "end_time"]'
     CREATE_SHIFT_MAX_VOLUNTEER = '//input[@name = "max_volunteers"]'
+    CREATE_SHIFT_ADDRESS = '//input[@name = "address"]'
+    CREATE_SHIFT_VENUE = '//input[@name = "venue"]'
     ORG_NAME = '//input[@name = "name"]'
 
     EVENT_NAME_ERROR = "//form//div[1]/div/p/strong"
     EVENT_START_DATE_ERROR = "//form//div[2]/div/p/strong"
     EVENT_END_DATE_ERROR = "//form//div[3]/div/p/strong"
+    EVENT_ADDRESS_ERROR = "//form//div[7]/div/p/strong"
+    EVENT_VENUE_ERROR = "//form//div[8]/div/p/strong"
     JOB_NAME_ERROR = "//form//div[3]/div/p/strong"
     JOB_START_DATE_ERROR = "//form//div[5]/div/p/strong"
     JOB_END_DATE_ERROR = "//form//div[6]/div/p/strong"
@@ -58,6 +64,8 @@ class EventsPageLocators(object):
     SHIFT_START_TIME_ERROR = "//form//div[5]/div/p/strong"
     SHIFT_END_TIME_ERROR = "//form//div[6]/div/p/strong"
     SHIFT_MAX_VOLUNTEER_ERROR = "//form//div[7]/div/p/strong"
+    SHIFT_ADDRESS_ERROR = "//form//div[11]/div/p/strong"
+    SHIFT_VENUE_ERROR = "//form//div[12]/div/p/strong"
     ORGANIZATION_NAME_ERROR = "//form//div[1]/div/p/strong"
 
     GENERAL_SUBMIT_PATH = '//form[1]'

--- a/vms/pom/pages/eventsPage.py
+++ b/vms/pom/pages/eventsPage.py
@@ -33,10 +33,14 @@ class EventsPage(BasePage):
         self.element_by_xpath(self.elements.CREATE_EVENT_NAME).clear()
         self.element_by_xpath(self.elements.CREATE_EVENT_START_DATE).clear()
         self.element_by_xpath(self.elements.CREATE_EVENT_END_DATE).clear()
+        self.element_by_xpath(self.elements.CREATE_EVENT_ADDRESS).clear()
+        self.element_by_xpath(self.elements.CREATE_EVENT_VENUE).clear()
         self.send_value_to_xpath(self.elements.CREATE_EVENT_NAME, event[0])
-        self.send_value_to_xpath(self.elements.CREATE_EVENT_START_DATE,
-                                 event[1])
+        self.send_value_to_xpath(self.elements.CREATE_EVENT_START_DATE, event[1])
         self.send_value_to_xpath(self.elements.CREATE_EVENT_END_DATE, event[2])
+        if len(event) == 5:
+            self.send_value_to_xpath(self.elements.CREATE_EVENT_ADDRESS, event[3])
+            self.send_value_to_xpath(self.elements.CREATE_EVENT_VENUE, event[4])
         self.submit_form()
 
     def fill_job_form(self, job):
@@ -57,13 +61,16 @@ class EventsPage(BasePage):
         self.element_by_xpath(self.elements.CREATE_SHIFT_START_TIME).clear()
         self.element_by_xpath(self.elements.CREATE_SHIFT_END_TIME).clear()
         self.element_by_xpath(self.elements.CREATE_SHIFT_MAX_VOLUNTEER).clear()
+        self.element_by_xpath(self.elements.CREATE_SHIFT_ADDRESS).clear()
+        self.element_by_xpath(self.elements.CREATE_SHIFT_VENUE).clear()
 
         self.send_value_to_xpath(self.elements.CREATE_SHIFT_DATE, shift[0])
-        self.send_value_to_xpath(self.elements.CREATE_SHIFT_START_TIME,
-                                 shift[1])
+        self.send_value_to_xpath(self.elements.CREATE_SHIFT_START_TIME, shift[1])
         self.send_value_to_xpath(self.elements.CREATE_SHIFT_END_TIME, shift[2])
-        self.send_value_to_xpath(self.elements.CREATE_SHIFT_MAX_VOLUNTEER,
-                                 shift[3])
+        self.send_value_to_xpath(self.elements.CREATE_SHIFT_MAX_VOLUNTEER, shift[3])
+        if len(shift) == 6:
+            self.send_value_to_xpath(self.elements.CREATE_SHIFT_ADDRESS, shift[4])
+            self.send_value_to_xpath(self.elements.CREATE_SHIFT_VENUE, shift[5])
         self.submit_form()
 
     def fill_organization_form(self, org):
@@ -174,6 +181,12 @@ class EventsPage(BasePage):
     def get_event_end_date_error(self):
         return self.element_by_xpath(self.elements.EVENT_END_DATE_ERROR).text
 
+    def get_event_address_error(self):
+        return self.element_by_xpath(self.elements.EVENT_ADDRESS_ERROR).text
+
+    def get_event_venue_error(self):
+        return self.element_by_xpath(self.elements.EVENT_VENUE_ERROR).text
+
     def get_job_name_error(self):
         return self.element_by_xpath(self.elements.JOB_NAME_ERROR).text
 
@@ -194,6 +207,12 @@ class EventsPage(BasePage):
 
     def get_shift_max_volunteer_error(self):
         return self.element_by_xpath(self.elements.SHIFT_MAX_VOLUNTEER_ERROR).text
+
+    def get_shift_address_error(self):
+        return self.element_by_xpath(self.elements.SHIFT_ADDRESS_ERROR).text
+
+    def get_shift_venue_error(self):
+        return self.element_by_xpath(self.elements.SHIFT_VENUE_ERROR).text
 
     def get_organization_name_error(self):
         return self.element_by_xpath(self.elements.ORGANIZATION_NAME_ERROR).text

--- a/vms/shift/utils.py
+++ b/vms/shift/utils.py
@@ -35,7 +35,11 @@ def create_event_with_details(event):
     """
     Creates and returns event with passed name and dates
     """
-    e1 = Event(name=event[0], start_date=event[1], end_date=event[2])
+    if len(event) == 3:
+        e1 = Event(name=event[0], start_date=event[1], end_date=event[2])
+    elif len(event) == 5:
+        e1 = Event(name=event[0], start_date=event[1], end_date=event[2],
+                   address=event[3], venue=event[4])
     e1.save()
     return e1
 
@@ -81,17 +85,35 @@ def create_volunteer_with_details_dynamic_password(volunteer):
     Creates and returns volunteer with passed name and dates
     """
     u1 = User.objects.create_user(username=volunteer[0], password=volunteer[1])
-    v1 = Volunteer(
-        email=volunteer[2],
-        first_name=volunteer[3],
-        last_name=volunteer[4],
-        address=volunteer[5],
-        city=volunteer[6],
-        state=volunteer[7],
-        country=volunteer[8],
-        phone_number=volunteer[9],
-        user=u1
-    )
+    if len(volunteer) == 10:
+        v1 = Volunteer(
+            email=volunteer[2],
+            first_name=volunteer[3],
+            last_name=volunteer[4],
+            address=volunteer[5],
+            city=volunteer[6],
+            state=volunteer[7],
+            country=volunteer[8],
+            phone_number=volunteer[9],
+            user=u1
+        )
+    elif len(volunteer) == 15:
+        v1 = Volunteer(
+            email=volunteer[2],
+            first_name=volunteer[3],
+            last_name=volunteer[4],
+            address=volunteer[5],
+            city=volunteer[6],
+            state=volunteer[7],
+            country=volunteer[8],
+            phone_number=volunteer[9],
+            unlisted_organization=volunteer[10],
+            websites=volunteer[11],
+            description=volunteer[12],
+            resume=volunteer[13],
+            reminder_days=volunteer[14],
+            user=u1
+        )
 
     v1.save()
     return v1
@@ -157,11 +179,11 @@ def get_report_list(duration_list, report_list, total_hours):
 
     for duration in duration_list:
         total_hours += duration
-        report = {}
+        report = dict()
         report["duration"] = duration
         report_list.append(report)
 
-    return (report_list, total_hours)
+    return report_list, total_hours
 
 
 def create_organization():
@@ -225,7 +247,11 @@ def create_volunteer():
 
 def register_event_utility():
     event = Event.objects.create(
-        name='event', start_date='2050-05-10', end_date='2050-06-16')
+        name='event',
+        start_date='2050-05-10',
+        end_date='2050-06-16',
+        address='East Baker Street',
+        venue='Kame House')
 
     return event
 
@@ -235,6 +261,7 @@ def register_job_utility():
         name='job',
         start_date='2050-05-10',
         end_date='2050-06-15',
+        description='job description',
         event=Event.objects.get(name='event'))
 
     return job
@@ -246,6 +273,8 @@ def register_shift_utility():
         start_time='09:00',
         end_time='15:00',
         max_volunteers='6',
+        address='East Baker Street',
+        venue='Kame House',
         job=Job.objects.get(name='job'))
 
     return shift

--- a/vms/volunteer/tests/test_unit.py
+++ b/vms/volunteer/tests/test_unit.py
@@ -42,7 +42,9 @@ class VolunteerModelTests(TestCase):
         """
         vol = [
             'Goku', "Son", "Goku", "Kame House", "East District",
-            "East District", "East District", "9999999999", "idonthave@gmail.com"
+            "East District", "East District", "9999999999", "idonthave@gmail.com",
+            "dummy unlisted org", "https://www.dummy-website.com", "description",
+            "resume text", 10
         ]
         return create_volunteer_with_details(vol)
 


### PR DESCRIPTION
# Description
Until now only mandatory fields were being saved but we should add checks for other fields too, at least in 1 test. Since these are non-mandatory fields and we'll be shifting to using dicts instead of lists I've used a workaround for now (using length compare) while creating the event. In future we'll need to modify it 

Fixes #752 

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



# How Has This Been Tested?
```
python manage.py test event.tests.test_model -v 2
```


# Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
