### PR TITLE
Upcoming shifts filtered out

### DIFF
--- a/vms/pom/pages/upcomingShiftsPage.py
+++ b/vms/pom/pages/upcomingShiftsPage.py
@@ -43,18 +43,9 @@ class UpcomingShiftsPage(BasePage):
     def get_shift_end_time(self):
         return self.element_by_xpath(self.elements.SHIFT_ETIME_PATH).text
 
-    def get_log_hours(self):
-        return self.element_by_xpath(self.elements.LOG_SHIFT_HOURS_PATH).text
-
-    def click_to_log_hours(self):
-        self.element_by_xpath(
-            self.elements.LOG_SHIFT_HOURS_PATH + "//a").click()
-
-    def log_shift_timings(self, stime, etime):
-        self.completed_shifts_page.log_shift_timings(stime, etime)
-
     def get_cancel_shift(self):
         return self.element_by_xpath(self.elements.SHIFT_CANCEL_PATH)
 
     def cancel_shift(self):
         self.element_by_xpath(self.elements.SHIFT_CANCEL_PATH + "//a").click()
+

--- a/vms/shift/services.py
+++ b/vms/shift/services.py
@@ -323,6 +323,15 @@ def get_shifts_with_open_slots_for_volunteer(j_id, v_id):
 
     return shift_list
 
+def get_future_shifts_by_volunteer_id(v_id):
+    shift_signed_up_list = Shift.objects.filter(
+        volunteershift__volunteer_id=v_id,
+        date__gte=timezone.now(),
+        )
+    shift_signed_up_list = shift_signed_up_list.order_by('date')
+
+    return shift_signed_up_list
+
 
 def get_unlogged_shifts_by_volunteer_id(v_id):
 

--- a/vms/shift/services.py
+++ b/vms/shift/services.py
@@ -1,6 +1,7 @@
 # standard library
 from datetime import date, timedelta
 from django.utils import timezone
+from django.db.models import Q
 
 # Django
 from django.core.exceptions import ObjectDoesNotExist
@@ -324,10 +325,8 @@ def get_shifts_with_open_slots_for_volunteer(j_id, v_id):
     return shift_list
 
 def get_future_shifts_by_volunteer_id(v_id):
-    shift_signed_up_list = Shift.objects.filter(
-        volunteershift__volunteer_id=v_id,
-        date__gte=timezone.now(),
-        )
+    shift_signed_up_list = Shift.objects.filter(Q(volunteershift__volunteer_id=v_id)&Q(date__gte=timezone.now().date())|
+                                                Q(date=timezone.now().date(), start_time__gte=timezone.now().time()))
     shift_signed_up_list = shift_signed_up_list.order_by('date')
 
     return shift_signed_up_list

--- a/vms/shift/tests/test_services.py
+++ b/vms/shift/tests/test_services.py
@@ -11,7 +11,7 @@ from shift.models import VolunteerShift
 from shift.services import (
     add_shift_hours, calculate_duration, calculate_total_report_hours,
     cancel_shift_registration, clear_shift_hours, delete_shift,
-    edit_shift_hours, generate_report, get_all_volunteer_shifts_with_hours,
+    edit_shift_hours, generate_report, get_all_volunteer_shifts_with_hours, get_future_shifts_by_volunteer_id,
     get_shift_by_id, get_shifts_by_job_id, get_shifts_ordered_by_date,
     get_shift_slots_remaining, get_shifts_with_open_slots,
     get_unlogged_shifts_by_volunteer_id, get_volunteer_shift_by_id,
@@ -19,7 +19,7 @@ from shift.services import (
     get_logged_volunteers_by_shift_id, is_signed_up, register, send_reminder,
     get_shifts_with_open_slots_for_volunteer, get_volunteer_report,
     get_administrator_report)
-from shift.utils import create_event_with_details, create_job_with_details, create_shift_with_details, clear_objects, get_report_list, create_volunteer_with_details, set_shift_location
+from shift.utils import create_event_with_details, create_job_with_details, create_shift_with_details, clear_objects, get_report_list, create_volunteer_with_details, register_event_utility, register_job_utility, register_shift_utility,  set_shift_location
 
 
 def setUpModule():
@@ -623,6 +623,24 @@ class ShiftWithVolunteerTest(unittest.TestCase):
         self.assertIn(self.s2, shift_list)
         self.assertNotIn(self.s3, shift_list)
 
+    def test_get_future_shifts_by_volunteer_id(self):
+        """ Uses shifts s2, s4 and volunteer v1 """
+        register_event_utility()
+        register_job_utility()
+        s4 = register_shift_utility()
+        # sign up
+        register(self.v1.id, s4.id)
+        register(self.v1.id, self.s2.id)
+        start_time = datetime.time(hour=9, minute=0)
+        end_time = datetime.time(hour=10, minute=0)
+        # test typical case
+        shift_list = get_future_shifts_by_volunteer_id(self.v1.id)
+        self.assertIsNotNone(shift_list)
+        self.assertNotEqual(shift_list, False)
+        self.assertEqual(len(shift_list), 1)
+        self.assertNotIn(self.s2, shift_list)
+        self.assertIn(s4, shift_list)
+
     def test_get_volunteer_shift_by_id(self):
         """ Uses shifts s1,s2,s3 and volunteers v1,v2"""
 
@@ -934,3 +952,4 @@ class DeleteShiftTest(unittest.TestCase):
 
         register(self.v1.id, self.s2.id)
         self.assertFalse(delete_shift(self.s2.id))
+

--- a/vms/shift/utils.py
+++ b/vms/shift/utils.py
@@ -229,6 +229,33 @@ def create_volunteer():
     return volunteer
 
 
+def register_past_event_utility():
+    event = Event.objects.create(
+        name='event', start_date='2012-05-10', end_date='2012-06-16')
+
+    return event
+
+
+def register_past_job_utility():
+    job = Job.objects.create(
+        name='job',
+        start_date='2012-05-10',
+        end_date='2012-06-15',
+        event=Event.objects.get(name='event'))
+
+    return job
+
+
+def register_past_shift_utility():
+    shift = Shift.objects.create(
+        date='2012-06-15',
+        start_time='09:00',
+        end_time='15:00',
+        max_volunteers='6',
+        job=Job.objects.get(name='job'))
+
+    return shift
+
 def register_event_utility():
     event = Event.objects.create(
         name='event', start_date='2050-05-10', end_date='2050-06-16')

--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -25,7 +25,7 @@ from job.models import Job
 from job.services import get_job_by_id
 from shift.forms import HoursForm, ShiftForm, EditForm
 from shift.models import Shift, EditRequest
-from shift.services import get_shift_by_id, add_shift_hours, cancel_shift_registration, clear_shift_hours, edit_shift_hours, get_unlogged_shifts_by_volunteer_id, get_logged_volunteers_by_shift_id, get_shift_slots_remaining, get_volunteers_by_shift_id, get_volunteer_by_id, get_volunteer_shifts_with_hours, get_shifts_ordered_by_date, get_shifts_with_open_slots_for_volunteer, register, get_volunteer_shift_by_id, get_shifts_by_job_id, delete_shift
+from shift.services import get_shift_by_id, add_shift_hours, cancel_shift_registration, clear_shift_hours, get_future_shifts_by_volunteer_id, edit_shift_hours, get_unlogged_shifts_by_volunteer_id, get_logged_volunteers_by_shift_id, get_shift_slots_remaining, get_volunteers_by_shift_id, get_volunteer_by_id, get_volunteer_shifts_with_hours, get_shifts_ordered_by_date, get_shifts_with_open_slots_for_volunteer, register, get_volunteer_shift_by_id, get_shifts_by_job_id, delete_shift
 from volunteer.forms import SearchVolunteerForm
 from volunteer.models import Volunteer
 from volunteer.services import get_all_volunteers, search_volunteers
@@ -812,7 +812,7 @@ class ViewHoursView(LoginRequiredMixin, FormView, TemplateView):
 @check_correct_volunteer
 @vol_id_check
 def view_volunteer_shifts(request, volunteer_id):
-    shift_list = get_unlogged_shifts_by_volunteer_id(volunteer_id)
+    shift_list = get_future_shifts_by_volunteer_id(volunteer_id)
     return render(request, 'shift/volunteer_shifts.html', {
         'shift_list': shift_list,
         'volunteer_id': volunteer_id,


### PR DESCRIPTION
# Description
The upcoming shifts page only shows the present or going shifts.

Fixes #759 

# Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
![image](https://user-images.githubusercontent.com/22369767/42532474-a0ab0c80-84a4-11e8-9b20-15e1447d3c10.png)


# Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
