### PR TITLE
Comment out retention tests of registration app

### DIFF
--- a/vms/registration/tests/test_functional_admin.py
+++ b/vms/registration/tests/test_functional_admin.py
@@ -460,6 +460,10 @@ class SignUpAdmin(LiveServerTestCase):
         self.assertEqual(page.get_organization_error_text(),
                          page.ENTER_VALID_VALUE)
 
+
+# Retention test are buggy and unstable, issue is open to fix them
+# https://github.com/systers/vms/pull/794
+'''
     def test_field_value_retention_in_first_name_state_phone_organization(self):
         """
         Test field values are retained in first name, state, phone and organization when
@@ -517,4 +521,4 @@ class SignUpAdmin(LiveServerTestCase):
         ]
         self.wait.until(EC.presence_of_element_located((By.ID, "id_username")))
         self.verify_field_values(details)
-
+'''

--- a/vms/registration/tests/test_functional_volunteer.py
+++ b/vms/registration/tests/test_functional_volunteer.py
@@ -449,6 +449,10 @@ class SignUpVolunteer(LiveServerTestCase):
         self.assertEqual(page.get_organization_error_text(),
                          page.ENTER_VALID_VALUE)
 
+
+# Retention test are buggy and unstable, issue is open to fix them
+# https://github.com/systers/vms/pull/794
+'''
     def test_field_value_retention_in_first_name_state_phone_organization(self):
         """
         Test field values are retained in first name, state and phone when entered
@@ -510,4 +514,4 @@ class SignUpVolunteer(LiveServerTestCase):
         self.wait.until(EC.presence_of_element_located((By.ID, "id_username")))
         self.wait.until(EC.presence_of_element_located((By.ID, "id_first_name")))
         self.verify_field_values(details)
-
+'''


### PR DESCRIPTION
# Description
The retention tests of registration app are buggy and unstable thus like retention tests of administrator app thus we need to comment them out and document them. This PR comments them out and the documentation PR documents them.

Fixes #787 

# Type of Change:
**Delete irrelevant options.**

- Quality Assurance
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



# How Has This Been Tested?
N/A


# Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
