### PR TITLE
Add full clean checks for event, job and volunteer

### DIFF
--- a/vms/event/tests/test_model.py
+++ b/vms/event/tests/test_model.py
@@ -38,14 +38,31 @@ class EventModelTests(TestCase):
         self.assertEqual(str(event_in_db.start_date), event[1])
         self.assertEqual(str(event_in_db.end_date), event[2])
 
-    def test_invalid_model_create(self):
-        event = ['event~name', '2050-05-21', '2050-05-24']
-        event = create_event_with_details(event)
-
+    def test_invalid_name_in_model_create(self):
+        """
+        Database test for model creation with invalid name.
+        """
+        event_data = ['event~name', '2050-05-21', '2050-05-24']
+        event = create_event_with_details(event_data)
         self.assertRaisesRegexp(ValidationError, EventsPage.ENTER_VALID_VALUE, event.full_clean)
 
-        # Check database for instance creation
-        self.assertNotEqual(len(Event.objects.all()), 0)
+    # def test_invalid_start_date_in_model_create(self):
+    #     """
+    #      Database test for model creation with invalid start date.
+    #     """
+    #     This test need to be uncommented after clean method is defined for model.
+    #     event_data = ['event-name', '2013-05-21', '2050-05-24']
+    #     event = create_event_with_details(event_data)
+    #     self.assertRaisesRegexp(ValidationError, EventsPage.ENTER_VALID_VALUE, event.full_clean)
+
+    # def test_invalid_start_date_in_model_create(self):
+    #     """
+    #      Database test for model creation with invalid end date.
+    #     """
+    #     This test need to be uncommented after clean method is defined for model.
+    #     event_data = ['event-name', '2050-05-21', '2013-05-24']
+    #     event = create_event_with_details(event_data)
+    #     self.assertRaisesRegexp(ValidationError, EventsPage.ENTER_VALID_VALUE, event.full_clean)
 
     def test_model_edit_with_valid_values(self):
         created_event = EventModelTests.create_event()

--- a/vms/job/tests/test_model.py
+++ b/vms/job/tests/test_model.py
@@ -50,15 +50,46 @@ class JobModelTests(TestCase):
         self.assertEqual(job_in_db.description, job[3])
 
     def test_invalid_model_create(self):
-        job = ['job~name', '2016-05-25', '2016-05-26', 'job-description', self.event]
+        """
+        Database test for model creation with invalid name.
+        """
+        job = ['job~name', '2050-05-25', '2050-05-26', 'job description', self.event]
         created_job = create_job_with_details(job)
-
         self.assertRaisesRegexp(ValidationError,
                                 JobDetailsPage.ENTER_VALID_VALUE,
                                 created_job.full_clean)
 
-        # Check database for instance creation
-        self.assertNotEqual(len(Job.objects.all()), 0)
+    # def test_invalid_start_date_in_model_create(self):
+    #     """
+    #      Database test for model creation with invalid start date.
+    #     """
+    #     This test need to be uncommented after clean method is defined for model.
+    #     job = ['job name', '2016-05-25', '2050-05-26', 'job description', self.event]
+    #     created_job = create_job_with_details(job)
+    #     self.assertRaisesRegexp(ValidationError,
+    #                             JobDetailsPage.ENTER_VALID_VALUE,
+    #                             created_job.full_clean)
+
+    # def test_invalid_start_date_in_model_create(self):
+    #     """
+    #      Database test for model creation with invalid end date.
+    #     """
+    #     This test need to be uncommented after clean method is defined for model.
+    #     job = ['job name', '2050-05-25', '2016-05-26', 'job description', self.event]
+    #     created_job = create_job_with_details(job)
+    #     self.assertRaisesRegexp(ValidationError,
+    #                             JobDetailsPage.ENTER_VALID_VALUE,
+    #                             created_job.full_clean)
+
+    def test_invalid_description_in_model_create(self):
+        """
+         Database test for model creation with invalid description.
+        """
+        job = ['job name', '2050-05-25', '2050-05-26', 'job@description@', self.event]
+        created_job = create_job_with_details(job)
+        self.assertRaisesRegexp(ValidationError,
+                                JobDetailsPage.ENTER_VALID_VALUE,
+                                created_job.full_clean)
 
     def test_model_edit_with_valid_values(self):
         job = self.create_job()

--- a/vms/volunteer/tests/test_unit.py
+++ b/vms/volunteer/tests/test_unit.py
@@ -74,12 +74,104 @@ class VolunteerModelTests(TestCase):
         self.assertEqual(valid_volunteer.email, volunteer_in_db.email)
         self.assertEqual(valid_volunteer.phone_number, volunteer_in_db.phone_number)
 
-    def test_invalid_model_create(self):
+    def test_invalid_username_in_model_create(self):
         """
-        Database test for model creation with invalid values.
+        Database test for model creation with invalid username.
         """
-        invalid_volunteer = VolunteerModelTests.create_invalid_vol()
-        self.assertRaisesRegexp(ValidationError, BasePage.FIELD_CANNOT_LEFT_BLANK, invalid_volunteer.full_clean)
+        volunteer = [
+            'Goku~', "Son", "Goku", "Kame House", "East District",
+            "East District", "East District", "9999999999", "idonthave1@gmail.com"
+        ]
+        created_volunteer = create_volunteer_with_details(volunteer)
+        self.assertRaisesRegexp(ValidationError, BasePage.FIELD_CANNOT_LEFT_BLANK, created_volunteer.full_clean)
+
+    def test_invalid_first_name_in_model_create(self):
+        """
+        Database test for model creation with invalid first name.
+        """
+        volunteer = [
+            'Goku2', "Son~", "Goku", "Kame House", "East District",
+            "East District", "East District", "9999999999", "idonthave2@gmail.com"
+        ]
+        created_volunteer = create_volunteer_with_details(volunteer)
+        self.assertRaisesRegexp(ValidationError, BasePage.FIELD_CANNOT_LEFT_BLANK, created_volunteer.full_clean)
+
+    def test_invalid_last_name_in_model_create(self):
+        """
+        Database test for model creation with invalid last name.
+        """
+        volunteer = [
+            'Goku3', "Son", "Goku!", "Kame House", "East District",
+            "East District", "East District", "9999999999", "idonthave3@gmail.com"
+        ]
+        created_volunteer = create_volunteer_with_details(volunteer)
+        self.assertRaisesRegexp(ValidationError, BasePage.FIELD_CANNOT_LEFT_BLANK, created_volunteer.full_clean)
+
+    def test_invalid_address_in_model_create(self):
+        """
+        Database test for model creation with invalid address.
+        """
+        volunteer = [
+            'Goku4', "Son", "Goku", "Kame!House!", "East District",
+            "East District", "East District", "9999999999", "idonthave4@gmail.com"
+        ]
+        created_volunteer = create_volunteer_with_details(volunteer)
+        self.assertRaisesRegexp(ValidationError, BasePage.FIELD_CANNOT_LEFT_BLANK, created_volunteer.full_clean)
+
+    def test_invalid_city_in_model_create(self):
+        """
+        Database test for model creation with invalid city.
+        """
+        volunteer = [
+            'Goku5', "Son", "Goku", "Kame House", "East!District!",
+            "East District", "East District", "9999999999", "idonthave5@gmail.com"
+        ]
+        created_volunteer = create_volunteer_with_details(volunteer)
+        self.assertRaisesRegexp(ValidationError, BasePage.FIELD_CANNOT_LEFT_BLANK, created_volunteer.full_clean)
+
+    def test_invalid_state_in_model_create(self):
+        """
+        Database test for model creation with invalid state.
+        """
+        volunteer = [
+            'Goku6', "Son", "Goku", "Kame House", "East District",
+            "East!District!", "East District", "9999999999", "idonthave6@gmail.com"
+        ]
+        created_volunteer = create_volunteer_with_details(volunteer)
+        self.assertRaisesRegexp(ValidationError, BasePage.FIELD_CANNOT_LEFT_BLANK, created_volunteer.full_clean)
+
+    def test_invalid_country_in_model_create(self):
+        """
+        Database test for model creation with invalid country.
+        """
+        volunteer = [
+            'Goku7', "Son", "Goku", "Kame House", "East District",
+            "East District", "East!District!", "9999999999", "idonthave7@gmail.com"
+        ]
+        created_volunteer = create_volunteer_with_details(volunteer)
+        self.assertRaisesRegexp(ValidationError, BasePage.FIELD_CANNOT_LEFT_BLANK, created_volunteer.full_clean)
+
+    def test_invalid_phone_number_in_model_create(self):
+        """
+        Database test for model creation with invalid phone number.
+        """
+        volunteer = [
+            'Goku8', "Son", "Goku", "Kame House", "East District",
+            "East District", "East District", "99999999!9", "idonthave8@gmail.com"
+        ]
+        created_volunteer = create_volunteer_with_details(volunteer)
+        self.assertRaisesRegexp(ValidationError, 'Please enter a valid phone number', created_volunteer.full_clean)
+
+    def test_invalid_email_in_model_create(self):
+        """
+        Database test for model creation with invalid email.
+        """
+        volunteer = [
+            'Goku9', "Son", "Goku", "Kame House", "East District",
+            "East District", "East District", "9999999999", "idonthave9~gmail.com"
+        ]
+        created_volunteer = create_volunteer_with_details(volunteer)
+        self.assertRaisesRegexp(ValidationError, 'Enter a valid email address.', created_volunteer.full_clean)
 
     def test_model_edit_with_valid_values(self):
         """


### PR DESCRIPTION
# Description
This PR includes full clean checks on all fields of event, job and volunteer but we still need to wait for extra checks PR to avoid editing same thing in different PR (utils.py of shift app).
full clean of shift is done in #726 and for admin in #808 

Fixes #797 

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



# How Has This Been Tested?
```
python manage.py test event.tests.test_model -v 2
python manage.py test job.tests.test_model -v 2
python manage.py test volunteer.tests.test_unit -v 2
```


# Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
