### PR TITLE
Execute automated tests in headless mode by default

### DIFF
--- a/vms/administrator/tests/test_formFields.py
+++ b/vms/administrator/tests/test_formFields.py
@@ -1,5 +1,6 @@
 # third party
 from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
@@ -25,7 +26,9 @@ class FormFields(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.settings = EventsPage(cls.driver)

--- a/vms/administrator/tests/test_report.py
+++ b/vms/administrator/tests/test_report.py
@@ -2,13 +2,13 @@
 import json
 
 from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
+from selenium.common.exceptions import NoSuchElementException
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
 
 # local Django
-from selenium.common.exceptions import NoSuchElementException
-
 from organization.models import Organization
 from pom.locators.administratorReportPageLocators import AdministratorReportPageLocators
 from pom.pages.administratorReportPage import AdministratorReportPage
@@ -25,7 +25,9 @@ class Report(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.authentication_page = AuthenticationPage(cls.driver)

--- a/vms/administrator/tests/test_settings.py
+++ b/vms/administrator/tests/test_settings.py
@@ -1,6 +1,7 @@
 # third party
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -61,7 +62,9 @@ class Settings(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.settings = EventsPage(cls.driver)

--- a/vms/authentication/tests/test_login.py
+++ b/vms/authentication/tests/test_login.py
@@ -4,6 +4,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -33,7 +34,9 @@ class TestAccessControl(LiveServerTestCase):
         This method initiates Firefox WebDriver, WebDriverWait and
         the corresponding POM objects for this Test Class
         """
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.maximize_window()
         cls.authentication_page = AuthenticationPage(cls.driver)
         cls.wait = WebDriverWait(cls.driver, 5)

--- a/vms/event/tests/test_event.py
+++ b/vms/event/tests/test_event.py
@@ -1,5 +1,6 @@
 # third party
 from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -18,7 +19,9 @@ class EventDetails(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.event_details_page = EventsPage(cls.driver)

--- a/vms/event/tests/test_shiftSignUp.py
+++ b/vms/event/tests/test_shiftSignUp.py
@@ -4,6 +4,7 @@ from django.contrib.staticfiles.testing import LiveServerTestCase
 # third party
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.firefox.options import Options
 
 # local Django
 from job.models import Job
@@ -23,7 +24,9 @@ class ShiftSignUp(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.sign_up_page = EventSignUpPage(cls.driver)

--- a/vms/home/tests/test_functional.py
+++ b/vms/home/tests/test_functional.py
@@ -4,6 +4,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -31,7 +32,9 @@ class CheckURLAccess(LiveServerTestCase):
         This method initiates Firefox WebDriver, WebDriverWait and
         the corresponding POM objects for this Test Class
         """
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.home_page = HomePage(cls.driver)

--- a/vms/job/tests/test_jobDetails.py
+++ b/vms/job/tests/test_jobDetails.py
@@ -1,5 +1,6 @@
 # third party
 from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -18,7 +19,9 @@ class JobDetails(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.job_details_page = JobDetailsPage(cls.driver)

--- a/vms/organization/tests/test_organization.py
+++ b/vms/organization/tests/test_organization.py
@@ -1,6 +1,7 @@
 # third party
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -26,7 +27,9 @@ class OrganizationTest(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.organization_page = EventsPage(cls.driver)

--- a/vms/registration/tests/test_functional_admin.py
+++ b/vms/registration/tests/test_functional_admin.py
@@ -4,8 +4,9 @@ import re
 # third party
 from selenium import webdriver
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.common.by import By
+from selenium.webdriver.firefox.options import Options
+# from selenium.webdriver.support import expected_conditions as EC
+# from selenium.webdriver.common.by import By
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -55,7 +56,9 @@ class SignUpAdmin(LiveServerTestCase):
         This method initiates Firefox WebDriver, WebDriverWait and
         the corresponding POM objects for this Test Class
         """
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.page = AdminRegistrationPage(cls.driver)

--- a/vms/registration/tests/test_functional_volunteer.py
+++ b/vms/registration/tests/test_functional_volunteer.py
@@ -4,8 +4,9 @@ import re
 # third party
 from selenium import webdriver
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.common.by import By
+from selenium.webdriver.firefox.options import Options
+# from selenium.webdriver.support import expected_conditions as EC
+# from selenium.webdriver.common.by import By
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -55,7 +56,9 @@ class SignUpVolunteer(LiveServerTestCase):
         This method initiates Firefox WebDriver, WebDriverWait and
         the corresponding POM objects for this Test Class
         """
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.page = VolunteerRegistrationPage(cls.driver)

--- a/vms/shift/tests/test_manageVolunteerShift.py
+++ b/vms/shift/tests/test_manageVolunteerShift.py
@@ -7,6 +7,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
+from selenium.webdriver.firefox.options import Options
 
 # local Django
 from pom.pages.authenticationPage import AuthenticationPage
@@ -63,7 +64,9 @@ class ManageVolunteerShift(LiveServerTestCase):
             'volunteer-email2@systers.org', 'volunteer-two'
         ]
 
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.sign_up_page = EventSignUpPage(cls.driver)

--- a/vms/shift/tests/test_shiftDetails.py
+++ b/vms/shift/tests/test_shiftDetails.py
@@ -3,6 +3,7 @@ from selenium import webdriver
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -39,7 +40,9 @@ class ShiftDetails(LiveServerTestCase):
             'organization'
         ]
 
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.shift_details_page = ShiftDetailsPage(cls.driver)

--- a/vms/shift/tests/test_shiftHours.py
+++ b/vms/shift/tests/test_shiftHours.py
@@ -1,6 +1,7 @@
 # third party
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -30,7 +31,9 @@ class ShiftHours(LiveServerTestCase):
         This method initiates Firefox WebDriver, WebDriverWait and
         the corresponding POM objects for this Test Class
         """
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.completed_shifts_page = CompletedShiftsPage(cls.driver)

--- a/vms/shift/tests/test_viewVolunteerShift.py
+++ b/vms/shift/tests/test_viewVolunteerShift.py
@@ -7,7 +7,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
-
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -41,7 +41,9 @@ class ViewVolunteerShift(LiveServerTestCase):
         This method initiates Firefox WebDriver, WebDriverWait and
         the corresponding POM objects for this Test Class
         """
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.manage_shift_page = ManageShiftPage(cls.driver)

--- a/vms/volunteer/tests/test_searchVolunteer.py
+++ b/vms/volunteer/tests/test_searchVolunteer.py
@@ -4,6 +4,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -36,7 +37,9 @@ class SearchVolunteer(LiveServerTestCase):
         This method initiates Firefox WebDriver, WebDriverWait and
         the corresponding POM objects for this Test Class
         """
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.search_page = VolunteerSearchPage(cls.driver)

--- a/vms/volunteer/tests/test_volunteerProfile.py
+++ b/vms/volunteer/tests/test_volunteerProfile.py
@@ -2,15 +2,15 @@
 import re
 from urllib.request import urlretrieve
 import os
-
-import PyPDF2
-from PyPDF2.utils import PdfReadError
+# import PyPDF2
+# from PyPDF2.utils import PdfReadError
 
 # third party
 from selenium import webdriver
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -38,7 +38,9 @@ class VolunteerProfile(LiveServerTestCase):
         This method initiates Firefox WebDriver, WebDriverWait and
         the corresponding POM objects for this Test Class
         """
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.profile_page = VolunteerProfilePage(cls.driver)

--- a/vms/volunteer/tests/test_volunteerReport.py
+++ b/vms/volunteer/tests/test_volunteerReport.py
@@ -1,5 +1,6 @@
 # third party
 from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
 
 # Django
 from django.contrib.staticfiles.testing import LiveServerTestCase
@@ -29,7 +30,9 @@ class VolunteerReport(LiveServerTestCase):
         This method initiates Firefox WebDriver, WebDriverWait and
         the corresponding POM objects for this Test Class
         """
-        cls.driver = webdriver.Firefox()
+        firefox_options = Options()
+        firefox_options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(firefox_options=firefox_options)
         cls.driver.implicitly_wait(5)
         cls.driver.maximize_window()
         cls.report_page = VolunteerReportPage(cls.driver)


### PR DESCRIPTION
# Description
This PR modifies the existing automated tests to be executed in headless mode by default.

Fixes #803 

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



# How Has This Been Tested?
Pull this branch locally and run
```
python manage.py test -v 2
```
you can see that now the browser won't open when tests start.


# Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
