### PR TITLE
Past events not editable

### DIFF
--- a/vms/event/templates/event/list.html
+++ b/vms/event/templates/event/list.html
@@ -190,7 +190,11 @@
                             <a href="{% url 'event:details' event.id %}" class="btn btn-default btn-sm">{% trans "Details" %}</a>
                         </td>
                         <td>
+                            {% if event.start_date >= today %}
                             <a href="{% url 'event:edit' event.id %}" class="btn btn-primary btn-sm">{% trans "Edit" %}</a>
+                            {% else %} 
+                            <a href="{% url 'event:edit' event.id %}" class="btn btn-primary btn-sm" disabled/>{% trans "Edit" %}</a>
+                            {% endif %}
                         </td>
                         <td>
                             <a href="{% url 'event:delete' event.id %}" class="btn btn-danger btn-sm">{% trans "Delete" %}</a>

--- a/vms/event/views.py
+++ b/vms/event/views.py
@@ -261,6 +261,7 @@ def list_events(request):
     :return: SearchEventForm
     """
     search_result_list = get_events_ordered_by_name()
+    today = datetime.date.today()
     if request.method == 'POST':
         form = SearchEventForm(request.POST)
         if form.is_valid():
@@ -279,7 +280,8 @@ def list_events(request):
     return render(
         request, 'event/list.html', {
             'form': form,
-            'search_result_list': search_result_list
+            'search_result_list': search_result_list,
+            'today': today
         })
 
 class ApiForVolaView(APIView):


### PR DESCRIPTION
# Description
Past events can not be edited.

Fixes #784

# Type of Change:
- Code
- Quality Assurance
- User Interface
- Outreach
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



# How Has This Been Tested?
![image](https://user-images.githubusercontent.com/22369767/43711911-f21a4af2-9991-11e8-8e31-93b616b6b6a3.png)




# Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules