### PR TITLE
Change admin email id on edit hours

### DIFF
--- a/vms/shift/views.py
+++ b/vms/shift/views.py
@@ -446,7 +446,7 @@ class EditHoursView(LoginRequiredMixin, FormView):
                                                'domain': site.domain,
                                                })
                     try:
-                        send_mail("Edit request", message, "messanger@localhost.com", ["admin@admin.com"])
+                        send_mail("Edit request", message, "messanger@localhost.com", ["systerskeeper@gmail.com"])
                     except:
                         raise Exception("There was an error in sending the email.")
                     volunteer_shift.edit_requested = True


### PR DESCRIPTION
# Description
systerskeeper@gmail.com should be sent the email for editing hours.

Fixes # [ISSUE]

# Type of Change:
- Code
- Quality Assurance
- User Interface
- Outreach
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

# How Has This Been Tested?
![image](https://user-images.githubusercontent.com/22369767/43869100-7dec5162-9b8e-11e8-9130-61efe7ffa301.png)

# Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
