### PR TITLE
assertRaises -> assertRaisesRegexp

### DIFF
--- a/vms/administrator/tests/test_report.py
+++ b/vms/administrator/tests/test_report.py
@@ -137,7 +137,7 @@ class Report(LiveServerTestCase):
         )
         self.assertEqual(report_page.get_rejection_context(), 'Reject')
         report_page.reject_report()
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             report_page.get_report()
 
     def test_view_report(self):
@@ -180,7 +180,7 @@ class Report(LiveServerTestCase):
             report_page.remove_i18n(self.driver.current_url),
             self.live_server_url + report_page.administrator_report_page
         )
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             report_page.get_report()
 
     def test_email_on_report_approval(self):

--- a/vms/administrator/tests/test_settings.py
+++ b/vms/administrator/tests/test_settings.py
@@ -488,7 +488,7 @@ class Settings(LiveServerTestCase):
             settings.remove_i18n(self.driver.current_url),
             self.live_server_url + settings.event_list_page
         )
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             settings.get_results()
 
     def test_delete_event_with_associated_job(self):
@@ -865,7 +865,7 @@ class Settings(LiveServerTestCase):
             settings.remove_i18n(self.driver.current_url),
             self.live_server_url + settings.job_list_page
         )
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             settings.get_results()
 
     def test_delete_job_with_associated_shifts(self):
@@ -969,7 +969,7 @@ class Settings(LiveServerTestCase):
 
         # verify that shift was created
         self.assertNotEqual(settings.get_results(), None)
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             settings.get_help_block()
 
     def test_create_shift_with_invalid_timings(self):
@@ -1244,7 +1244,7 @@ class Settings(LiveServerTestCase):
         }
         settings.fill_shift_form(shift)
 
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             settings.get_help_block()
 
         self.assertEqual(settings.get_shift_date(), 'Aug. 25, 2050')
@@ -1442,7 +1442,7 @@ class Settings(LiveServerTestCase):
         self.delete_organization_from_list()
 
         # check org deleted
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             settings.element_by_xpath('//*[@id="confirmed"]//tbody//tr[1]')
 
     def test_delete_org_with_associated_users(self):

--- a/vms/event/tests/test_shiftSignUp.py
+++ b/vms/event/tests/test_shiftSignUp.py
@@ -115,7 +115,7 @@ class ShiftSignUp(LiveServerTestCase):
 
         # Confirm shift assignment
         sign_up_page.submit_form()
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             sign_up_page.get_danger_box()
 
         # check shift signed up
@@ -141,7 +141,7 @@ class ShiftSignUp(LiveServerTestCase):
         sign_up_page.navigate_to_sign_up()
 
         # Events shown in table
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             sign_up_page.get_info_box()
         sign_up_page.click_to_view_jobs()
 
@@ -153,7 +153,7 @@ class ShiftSignUp(LiveServerTestCase):
 
         # Confirm on shift sign up
         sign_up_page.submit_form()
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             sign_up_page.get_danger_box()
 
         # Sign up same shift again
@@ -166,7 +166,7 @@ class ShiftSignUp(LiveServerTestCase):
             sign_up_page.no_event_message
         )
 
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             sign_up_page.find_table_tag()
 
     def test_empty_events(self):
@@ -184,7 +184,7 @@ class ShiftSignUp(LiveServerTestCase):
             sign_up_page.no_event_message
         )
 
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             sign_up_page.find_table_tag()
             sign_up_page.click_to_view_jobs()
 
@@ -195,7 +195,7 @@ class ShiftSignUp(LiveServerTestCase):
             sign_up_page.no_event_message
         )
 
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             sign_up_page.find_table_tag()
 
     def test_shift_sign_up_with_outdated_shifts(self):

--- a/vms/organization/tests/test_organization.py
+++ b/vms/organization/tests/test_organization.py
@@ -309,7 +309,7 @@ class OrganizationTest(LiveServerTestCase):
         self.delete_organization_from_list()
 
         # Check Organization is deleted.
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             organization_page.get_org_name()
 
     def test_delete_org_with_users_linked(self):

--- a/vms/shift/tests/test_services.py
+++ b/vms/shift/tests/test_services.py
@@ -456,13 +456,13 @@ class ShiftWithVolunteerTest(unittest.TestCase):
         """ Uses shifts s1, s2, s3 and volunteers v1,v2 """
 
         # test cases when try to cancel when they aren't signed up for a shift
-        with self.assertRaises(ObjectDoesNotExist):
+        with self.assertRaisesRegexp(ObjectDoesNotExist):
             cancel_shift_registration(self.v1.id, self.s1.id)
 
-        with self.assertRaises(ObjectDoesNotExist):
+        with self.assertRaisesRegexp(ObjectDoesNotExist):
             cancel_shift_registration(self.v1.id, self.s2.id)
 
-        with self.assertRaises(ObjectDoesNotExist):
+        with self.assertRaisesRegexp(ObjectDoesNotExist):
             cancel_shift_registration(self.v2.id, self.s1.id)
 
         # register volunteers to shifts
@@ -473,7 +473,7 @@ class ShiftWithVolunteerTest(unittest.TestCase):
         # test typical cases
         cancel_shift_registration(self.v1.id, self.s1.id)
 
-        with self.assertRaises(ObjectDoesNotExist):
+        with self.assertRaisesRegexp(ObjectDoesNotExist):
             cancel_shift_registration(self.v2.id, self.s1.id)
 
         cancel_shift_registration(self.v2.id, self.s2.id)

--- a/vms/shift/tests/test_shiftHours.py
+++ b/vms/shift/tests/test_shiftHours.py
@@ -216,7 +216,7 @@ class ShiftHours(LiveServerTestCase):
         completed_shifts_page.go_to_completed_shifts()
         self.assertEqual(completed_shifts_page.get_unlogged_info_box(),
                          "You have no unlogged shifts.")
-        with self.assertRaises(NoSuchElementException):
+        with self.assertRaisesRegexp(NoSuchElementException):
             completed_shifts_page.get_result_container()
 
     def test_view_with_logged_shift(self):


### PR DESCRIPTION
# Description
Replace assertRaises with assertRaisesRegexp which provides an extra field for regex match with exception message. In some files assertRaises was used instead of assertRaisesRegexp

Fixes #781 

# Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Locally

# Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
