### PR TITLE
Closes #877 Changes in documentation

### DIFF
--- a/docs/Installation_Guide.md
+++ b/docs/Installation_Guide.md
@@ -116,7 +116,7 @@ To shut down the VM, run the command:
 To start up the VM again, run the command:
 
     vagrant up
-    
+
 
 ## Install PostgreSQL
 
@@ -223,7 +223,7 @@ To generate the database tables that correspond to the Django models, run the co
 NOTE: In case, you get the following error django.db.utils.ProgrammingError: relation "auth_user" does not exist, while running the above command do the following
     python manage.py migrate auth
     python manage.py migrate
-Now again try running the command 
+Now again try running the command
     python manage.py syncdb
 
 
@@ -233,10 +233,10 @@ We do not want to create a superuser at this time, so when it asks you to create
     Would you like to create one now? (yes/no): no
 
 Use the secret_key by running this command:
-    
+
     export DJANGO_SECRET_KEY='foobarbaz'
-    
-    
+
+
 In addition to this, you would also have to populate the database for django-cities-light. Run the following to do so:
 
     python manage.py migrate
@@ -255,7 +255,7 @@ You will be prompted to enter a password, which is `0xdeadbeef`
 ```
 There needs to be at least one organization in the `organization_organization` table in order to register for an account (this be changed later). Add Google as an organization:
 
-    insert into organization_organization values (1, 'Google');
+    insert into organization_organization values (1, 'Google', 1);
 
 Make sure to exit the postgres client before proceeding to the next steps:
 


### PR DESCRIPTION
# Description
Changes the documentation to  remove the error as mentioned in issue #877.
The following command throws an error because it is missing initialization of an extra field in the model which cant be set as null so changed the command from this so that no error is thrown.
`insert into organization_organization values (1, 'Google');`
`insert into organization_organization values (1, 'Google',1);`

Fixes #877 

# Type of Change:

- Documentation


# Checklist:
**Delete irrelevant options.**

- [X] My PR follows the style guidelines of this project
- [X] I have made corresponding changes to the documentation


