### PR TITLE
Fixed Resume upload issues

### DIFF
--- a/aut_docs/Documented_Failures.md
+++ b/aut_docs/Documented_Failures.md
@@ -8,8 +8,6 @@ There are a few tests which have been commented out currently to avoid Travis CI
 | test_formFields.py           | Administrator     | test_field_value_retention_for_job                                  | [#742](https://github.com/systers/vms/issues/742) |
 | test_formFields.py           | Administrator     | test_field_value_retention_for_shift                                | [#742](https://github.com/systers/vms/issues/742) |
 | test_report.py               | Administrator     | test_check_intersection_of_fields                                   | Test is giving inconsistent results, probably issue in logic|
-| test_volunteerProfile.py     | Volunteer         | test_valid_upload_resume                                            | [#776](https://github.com/systers/vms/issues/776)|
-| test_volunteerProfile.py     | Volunteer         | test_corrupt_resume_uploaded                                        | [#776](https://github.com/systers/vms/issues/776)|
 | test_functional_admin.py     | Registration      | test_field_value_retention_in_first_name_state_phone_organization   | [#763](https://github.com/systers/vms/issues/763)|
 | test_functional_admin.py     | Registration      | test_field_value_retention_in_last_name_address_city_country        | [#763](https://github.com/systers/vms/issues/763)|
 | test_functional_volunteer.py | Registration      | test_field_value_retention_in_first_name_state_phone_organization   | [#763](https://github.com/systers/vms/issues/763)|

--- a/aut_docs/Installation_Setup.md
+++ b/aut_docs/Installation_Setup.md
@@ -93,3 +93,11 @@ Following points are needed to start a testing session:
 - For automated tests, if any of the tests fail its not necessary that there is something wrong. To confirm if the the test is actually wrong you have to test it in headless mode.
 
 :Note: For automated testing, currently VMS uses the Firefox version 60, selenium version 3.4.0 and geckodriver version 0.20.1
+
+:Note : Some of the test may be failing due to the incorrect permission given to the media folder ,If media folder(srv directory) is already created on your system , then change its permissions by the following command:
+   ```bash
+     sudo chmod -R 740 /srv
+   ```
+In case you can the error "/srv: No such file or directory" while running the above comment do the following sudo mkdir /srv
+
+After creating the directory, then try to change the permissions i.e., run the following command (sudo chmod 740 /srv)

--- a/vms/vms/settings.py
+++ b/vms/vms/settings.py
@@ -115,9 +115,9 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'srv')
 MEDIA_URL = '/srv/'
 
 # Uploaded files have read and write permissions to the owner only
-FILE_UPLOAD_PERMISSIONS = 0o600
+FILE_UPLOAD_PERMISSIONS = 0o740
 
-FILE_UPLOAD_DIRECTORY_PERMISSIONS = 0o600
+FILE_UPLOAD_DIRECTORY_PERMISSIONS = 0o740
 
 # Instead of sending out real email, during development the emails will be sent
 # to stdout, where from they can be inspected.

--- a/vms/volunteer/tests/test_volunteerProfile.py
+++ b/vms/volunteer/tests/test_volunteerProfile.py
@@ -2,8 +2,8 @@
 import re
 from urllib.request import urlretrieve
 import os
-# import PyPDF2
-# from PyPDF2.utils import PdfReadError
+import PyPDF2
+from PyPDF2.utils import PdfReadError
 
 # third party
 from selenium import webdriver
@@ -241,15 +241,12 @@ class VolunteerProfile(LiveServerTestCase):
             'Uploaded file is invalid.'
         )
 
-# Resume Upload is buggy, it is taking too long to be uploaded on travis.
-# https://github.com/systers/vms/issues/776
-
-
-'''
     def test_valid_upload_resume(self):
         """
         Test upload of valid resume to profile.
         """
+        if(os.path.isdir((os.getcwd() + '/srv/'))):
+            os.chmod(os.getcwd() + '/srv/', 0o740)
         self.wait_for_home_page()
 
         path = os.getcwd() + '/DummyResume.pdf'
@@ -302,7 +299,7 @@ class VolunteerProfile(LiveServerTestCase):
         try:
             PyPDF2.PdfFileReader(open(path, 'rb'))
         except PdfReadError:
-            print('Some error while upload/download')
+            self.fail('Uploaded resume is corrupted')
         else:
             pass
-'''
+


### PR DESCRIPTION
# Description
"Permission denied error" were removed by changing access permission to media folders and PyPDF was imported as the test_corrupt_resume_uploaded method required that to run.

Fixes #776 #744 

# Type of Change:
**Delete irrelevant options.**

- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Locally


# Checklist:
**Delete irrelevant options.**
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
areas


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes

