### PR TITLE
Method to check Password constraints

### DIFF
--- a/vms/registration/forms.py
+++ b/vms/registration/forms.py
@@ -2,7 +2,8 @@
 from django import forms
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-
+from django.contrib.auth.password_validation import CommonPasswordValidator
+import re
 
 class UserForm(forms.ModelForm):
     # password not visible when user types it out
@@ -18,9 +19,17 @@ class UserForm(forms.ModelForm):
         checks['digit'] = any(char.isdigit() for char in password)
         # check if its length<=6
         checks['size'] = 6 <= len(password)
+        # check if it contains a space in between
+        checks['space'] = not any(char == " " for char in password)
         # check if it has special characters
         y = '[~!@#$%^&*()_+{}":;\']+$'
         checks['special'] = set(y).intersection(password)
+        #check for common passwords
+        pas = re.split(r"[^\w]", password)
+        for a in pas:
+            if not a.isdigit():
+               if CommonPasswordValidator().validate(a):
+                   raise ValidationError("Please choose another password")
         if all(checks.values()):
             return password
         else:

--- a/vms/registration/forms.py
+++ b/vms/registration/forms.py
@@ -26,9 +26,10 @@ class UserForm(forms.ModelForm):
         checks['special'] = set(y).intersection(password)
         #check for common passwords
         pas = re.split(r"[^\w]", password)
-        for a in pas:
-            if not a.isdigit():
-               if CommonPasswordValidator().validate(a):
+        for pwd in pas:
+            pwd = pwd.lower()
+            if not pwd.isdigit():
+               if CommonPasswordValidator().validate(pwd):
                    raise ValidationError("Please choose another password")
         if all(checks.values()):
             return password

--- a/vms/vms/settings.py
+++ b/vms/vms/settings.py
@@ -86,6 +86,15 @@ TEMPLATES = [
     },
 ]
 
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+]
+
 
 # Internationalization
 LANGUAGE_CODE = 'en-us'


### PR DESCRIPTION
# Description
1. Method to check certain password constraints like Users often choose poor passwords. For example: the password used is  `password` which clearly violates the constraints. Basically, Django comes pre-packaged with the ability to validate user passwords against the top 1,000 most commonly used passwords, vastly improving account security and resistance to password dictionary attacks.
2. Method to check that User doesn't add whitespace between their passwords.




Fixes #750 

# Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



# How Has This Been Tested?
When I used the password as `Password@123`

![screenshot from 2018-12-13 16-44-04](https://user-images.githubusercontent.com/30694592/49935203-6d106100-fef6-11e8-8a47-ea0c309ae12f.png)



# Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] I have added tests that prove my fix is effective or that my feature works

