### PR TITLE
Add python manage.py cities_light command to the installation guide

### DIFF
--- a/aut_docs/Installation_Setup.md
+++ b/aut_docs/Installation_Setup.md
@@ -50,6 +50,11 @@ Following points are needed to start a testing session:
       python manage.py migrate --noinput --traceback --settings=vms.settings
     ```
 
+- Populate the database for django-cities-light
+    ```bash
+      python manage.py cities_light
+    ```
+
 - Check that the project is running correctly by browsing to
     ```
       http://127.0.0.1:8000


### PR DESCRIPTION
# Description
Adds `python manage.py cities_light` command to the installation guide for installation of django cities_light so that we can get a list of countries,state and cities while signing up.

Fixes #888 

# Type of Change:
- Documentation

# How Has This Been Tested?
No tests required.

# Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
