### PR TITLE
Add more command to view list of tables for the vms database if existing one fails 

### DIFF
--- a/aut_docs/Installation_Setup.md
+++ b/aut_docs/Installation_Setup.md
@@ -128,8 +128,8 @@
     ```
         \dt[S+]
     ```
- 
- We can now manipulate the database by running the appropriate sql commands under this postgres client.
+   We can now manipulate the database by running the appropriate sql commands under this postgres client.
+
 
 
 - Exit the postgres client using

--- a/aut_docs/Installation_Setup.md
+++ b/aut_docs/Installation_Setup.md
@@ -123,8 +123,14 @@
 - To view a list of tables for the `vms` database, run this command under the postgres client
     ```
         \dt
-    ```        
-    We can now manipulate the database by running the appropriate sql commands under this postgres client.
+   ```        
+    Note: In case you get an error `Did not find any relations`, then run the following command 
+    ```
+        \dt[S+]
+    ```
+ 
+ We can now manipulate the database by running the appropriate sql commands under this postgres client.
+
 
 - Exit the postgres client using
     ```


### PR DESCRIPTION
# Description
Adding \dt[S+] command in installation guide if existing one fails
Fixes #1040 

# Type of Change:

- Documentation




# Checklist:


- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

